### PR TITLE
docs(VET-727): canonical unknown-option policy decision record

### DIFF
--- a/docs/tickets/VET-727-unknown-policy-decision-record.md
+++ b/docs/tickets/VET-727-unknown-policy-decision-record.md
@@ -1,0 +1,28 @@
+# VET-727: Canonical unknown-option policy (decision record)
+
+**Date:** 2026-04-03  
+**Agent:** RCA  
+**Type:** documentation / decision hygiene  
+**Related:** VET-722 (`docs/tickets/VET-722-unknown-option-proposal.md`)
+
+## Canonical policy
+
+The **VET-722** proposal merged on the mainline is the single canonical source for explicit-`unknown` policy: per-question **SAFE / UNSAFE / NEEDS DECISION** labels, the summary table, and the **UNSAFE** and **NEEDS DECISION** rules (clarification vs emergency-redirect, policy gates). In this repo that content is **`docs/tickets/VET-722-unknown-option-proposal.md`** (landed with VET-722).
+
+**Verify the file is present on your baseline:** `git fetch` then `git show origin/master:docs/tickets/VET-722-unknown-option-proposal.md` (use your remote’s default branch name if not `master`).
+
+Matrix-usage corrections that do **not** change those buckets may still land as factual fixes; changing buckets is a **policy revision**, not a typo fix.
+
+## Revision path
+
+To change classifications or disposition rules:
+
+1. Open a **new ticket** explicitly scoped as a **revision to VET-722** (not a silent edit to the landed doc).
+2. State clinical or product justification and expected impact on coercion/schema/tests.
+3. Review and land through the normal branch workflow; update the VET-722 doc in that ticket with a dated revision note if the table changes.
+
+## Why silent classification flips are unsafe
+
+Several agents may implement coercion, schema work, and tests against the **landed** table at once. Rewriting SAFE/UNSAFE/NEEDS without a ticket and review removes a shared source of truth: implementations and tests diverge, and risk is hidden because the repo still “has a VET-722 doc.”
+
+This record exists to prevent **policy drift** of the kind that motivated VET-727; it does not open new clinical decisions beyond “follow VET-722 until a revision ticket lands.”


### PR DESCRIPTION
## Summary
- add an in-repo decision record stating that landed VET-722 remains the canonical unknown-option policy baseline
- require future classification changes to go through an explicit revision ticket instead of silent doc rewrites
- document why silent SAFE / UNSAFE / NEEDS DECISION flips are unsafe in a multi-agent workflow

## Verification
- git diff --stat origin/master...HEAD
- manual check against `origin/master:docs/tickets/VET-722-unknown-option-proposal.md`
- shared memory completion update recorded from the clean VET-727 worktree

## Notes
- docs-only change
- no runtime code or `clinical-matrix.ts` changes
- Obsidian vault decision note was updated separately outside the repo branch
