### PR TITLE
chore(tsconfig): exclude test files from tsc compilation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,11 @@
     "Roo-Code",
     "stress-test.ts",
     "test-clinical.ts",
-    "test-apis.mjs"
+    "test-apis.mjs",
+    "tests",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx"
   ]
 }


### PR DESCRIPTION
## Summary
Test files are compiled by ts-jest, not tsc. Including them in the main tsconfig caused:
- **TS2393** duplicate `makeRequest` function (each test file defines it locally, all visible in one compilation)
- **TS18048** `possibly undefined` on test-only assertions
- **TS2739** missing properties on stub fixtures in shadow-rollout tests

Adding `tests/`, `**/*.test.ts`, `**/*.spec.ts` to tsconfig `exclude` is the standard pattern for Next.js projects using ts-jest.

## Test plan
- [x] `npx tsc --noEmit` — exits clean, 0 errors
- [x] `npm test` — 268 tests pass, nothing changed
- [x] `npm run build` — builds clean
- No runtime code changed

🤖 Fixed by Claude Code