### PR TITLE
VET-832: Conversation state on API responses and symptom-checker badge

### DIFF
--- a/src/app/(dashboard)/symptom-checker/page.tsx
+++ b/src/app/(dashboard)/symptom-checker/page.tsx
@@ -54,6 +54,56 @@ interface SendMessageOptions {
   appendUserMessage?: boolean;
 }
 
+type ConversationPhase =
+  | "idle"
+  | "asking"
+  | "answered_unconfirmed"
+  | "confirmed"
+  | "needs_clarification"
+  | "escalation";
+
+function isConversationPhase(value: unknown): value is ConversationPhase {
+  return (
+    value === "idle" ||
+    value === "asking" ||
+    value === "answered_unconfirmed" ||
+    value === "confirmed" ||
+    value === "needs_clarification" ||
+    value === "escalation"
+  );
+}
+
+function conversationPhaseLabel(phase: ConversationPhase): string {
+  const labels: Record<ConversationPhase, string> = {
+    idle: "Idle",
+    asking: "Asking",
+    answered_unconfirmed: "Answered",
+    confirmed: "Confirmed",
+    needs_clarification: "Clarifying",
+    escalation: "Escalation",
+  };
+  return labels[phase];
+}
+
+function conversationPhaseBadgeVariant(
+  phase: ConversationPhase
+): "default" | "success" | "warning" | "danger" | "info" {
+  switch (phase) {
+    case "confirmed":
+      return "success";
+    case "asking":
+      return "info";
+    case "answered_unconfirmed":
+      return "warning";
+    case "needs_clarification":
+      return "warning";
+    case "escalation":
+    case "idle":
+    default:
+      return "default";
+  }
+}
+
 // --- Config ---
 
 const quickSymptoms = [
@@ -157,6 +207,8 @@ export default function SymptomCheckerPage() {
   const [readyForReport, setReadyForReport] = useState(false);
   const [generatingReport, setGeneratingReport] = useState(false);
   const [sessionStarted, setSessionStarted] = useState(false);
+  const [conversationPhase, setConversationPhase] =
+    useState<ConversationPhase | null>(null);
   const chatEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -371,6 +423,10 @@ export default function SymptomCheckerPage() {
         triageSessionRef.current = data.session;
       }
 
+      if (isConversationPhase(data.conversationState)) {
+        setConversationPhase(data.conversationState);
+      }
+
       if (data.type === "emergency") {
         setMessages((prev) => [
           ...prev,
@@ -484,6 +540,7 @@ export default function SymptomCheckerPage() {
     setReadyForReport(false);
     setGeneratingReport(false);
     setSessionStarted(false);
+    setConversationPhase(null);
     setTriageSession(null);
     triageSessionRef.current = null;
     setInput("");
@@ -622,7 +679,12 @@ export default function SymptomCheckerPage() {
               </p>
             </div>
             {!report && (
-              <div className="ml-auto">
+              <div className="ml-auto flex items-center gap-2">
+                {conversationPhase && (
+                  <Badge variant={conversationPhaseBadgeVariant(conversationPhase)}>
+                    {conversationPhaseLabel(conversationPhase)}
+                  </Badge>
+                )}
                 <span className="text-xs text-gray-400">
                   {messages.filter((m) => m.role === "assistant").length}/5
                   questions

--- a/src/app/api/ai/symptom-chat/route.ts
+++ b/src/app/api/ai/symptom-chat/route.ts
@@ -110,6 +110,7 @@ import {
 import {
   getStateSnapshot,
   inferConversationState,
+  type ConversationState,
   transitionToAnswered,
   transitionToAsked,
   transitionToConfirmed,
@@ -248,6 +249,7 @@ export async function POST(request: Request) {
         message: "Tell me what's going on with your pet.",
         session,
         ready_for_report: false,
+        conversationState: conversationStateFromSession(session),
       });
     }
 
@@ -407,6 +409,7 @@ export async function POST(request: Request) {
           session,
           gate: gateWarning,
           ready_for_report: false,
+          conversationState: conversationStateFromSession(session),
         });
       }
     }
@@ -552,6 +555,7 @@ export async function POST(request: Request) {
                 message: `Based on my analysis of ${pet.name}'s photo, I've detected signs that require IMMEDIATE veterinary attention:\n\n${guardrail.flags.map(f => `• ${f}`).join("\n")}\n\nPlease take ${pet.name} to the nearest emergency veterinary hospital NOW. Do not wait. Call ahead so they can prepare. I can generate a full report for the vet while you're on the way.`,
                 session,
                 ready_for_report: true,
+                conversationState: conversationStateFromSession(session),
               });
             }
           }
@@ -899,6 +903,7 @@ export async function POST(request: Request) {
         message: `I've detected potential emergency signs (${flags}). This could be life-threatening. Please take ${pet.name} to the nearest emergency veterinary hospital IMMEDIATELY. Do not wait. Call ahead so they can prepare. I can still generate a full analysis while you're on the way.`,
         session: sanitizeSessionForClient(session),
         ready_for_report: true,
+        conversationState: conversationStateFromSession(session),
       });
     }
 
@@ -991,15 +996,21 @@ export async function POST(request: Request) {
 
     if (!nextQuestionId) {
       if (session.known_symptoms.length === 0) {
-        return NextResponse.json({
-          type: "question",
-          message: image
-            ? `I can see the photo, but I still need a little more context to triage ${pet.name} safely. What worries you most about this area, and when did you first notice it?`
-            : `I need a little more detail before I can triage ${pet.name} safely. What symptom or change worries you most right now, and when did it start?`,
-          session: sanitizeSessionForClient(session),
-          ready_for_report: false,
-        });
+      return NextResponse.json({
+        type: "question",
+        message: image
+          ? `I can see the photo, but I still need a little more context to triage ${pet.name} safely. What worries you most about this area, and when did you first notice it?`
+          : `I need a little more detail before I can triage ${pet.name} safely. What symptom or change worries you most right now, and when did it start?`,
+        session: sanitizeSessionForClient(session),
+        ready_for_report: false,
+        conversationState: conversationStateFromSession(session),
+      });
       }
+
+      session = transitionToConfirmed({
+        session,
+        reason: "report_ready",
+      });
 
       return NextResponse.json({
         type: "ready",
@@ -1007,6 +1018,7 @@ export async function POST(request: Request) {
           "I have enough information. Let me generate your full veterinary report.",
         session: sanitizeSessionForClient(session),
         ready_for_report: true,
+        conversationState: inferConversationState(getStateSnapshot(session)),
       });
     }
 
@@ -1074,6 +1086,7 @@ export async function POST(request: Request) {
       message: phrasedQuestion,
       session: sanitizeSessionForClient(session),
       ready_for_report: isReadyForDiagnosis(session),
+      conversationState: conversationStateFromSession(session),
     });
   } catch (error) {
     console.error("Symptom chat error:", error);
@@ -1082,6 +1095,7 @@ export async function POST(request: Request) {
         type: "error",
         message:
           "I encountered an issue. Please try again, or contact your veterinarian directly if this is urgent.",
+        conversationState: "idle",
       },
       { status: 200 }
     );
@@ -4607,11 +4621,13 @@ function demoResponse(action: string, pet: PetProfile) {
       },
     });
   }
+  const demoSession = createSession();
   return NextResponse.json({
     type: "question",
     message: `Demo mode. Add API keys for full triage. What's going on with ${pet.name}?`,
-    session: createSession(),
+    session: demoSession,
     ready_for_report: false,
+    conversationState: conversationStateFromSession(demoSession),
   });
 }
 
@@ -4654,4 +4670,9 @@ function sanitizeSessionForClient(session: TriageSession): TriageSession {
     ...session,
     case_memory: sanitizedMemory,
   };
+}
+
+/** VET-832: Root-level conversation phase for UI badge (not stored on session). */
+function conversationStateFromSession(session: TriageSession): ConversationState {
+  return inferConversationState(getStateSnapshot(session));
 }

--- a/tests/symptom-chat.route.test.ts
+++ b/tests/symptom-chat.route.test.ts
@@ -11,6 +11,7 @@ import type { SidecarObservation } from "@/lib/clinical-evidence";
 
 const mockCheckRateLimit = jest.fn();
 const mockGetRateLimitId = jest.fn();
+const mockIsNvidiaConfigured = jest.fn(() => true);
 const mockCreateServerSupabaseClient = jest.fn();
 const mockExtractWithQwen = jest.fn();
 const mockPhraseWithLlama = jest.fn();
@@ -57,7 +58,7 @@ jest.mock("@/lib/supabase-server", () => ({
 }));
 
 jest.mock("@/lib/nvidia-models", () => ({
-  isNvidiaConfigured: () => true,
+  isNvidiaConfigured: () => mockIsNvidiaConfigured(),
   extractWithQwen: (...args: unknown[]) => mockExtractWithQwen(...args),
   phraseWithLlama: (...args: unknown[]) => mockPhraseWithLlama(...args),
   reviewQuestionPlanWithNemotron: (...args: unknown[]) =>
@@ -4224,6 +4225,80 @@ describe("VET-736: transitionToConfirmed", () => {
     } finally {
       logSpy.mockRestore();
     }
+  });
+});
+
+describe("VET-832: conversationState in chat API", () => {
+  it("demo mode includes root-level conversationState", async () => {
+    jest.resetModules();
+    mockIsNvidiaConfigured.mockReturnValue(false);
+    try {
+      const { POST } = await import("@/app/api/ai/symptom-chat/route");
+      const res = await POST(
+        new Request("http://localhost/api/ai/symptom-chat", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            action: "chat",
+            pet: PET,
+            messages: [{ role: "user", content: "Hello" }],
+          }),
+        })
+      );
+      const payload = await res.json();
+      expect(res.status).toBe(200);
+      expect(payload.conversationState).toBe("idle");
+    } finally {
+      mockIsNvidiaConfigured.mockReturnValue(true);
+    }
+  });
+
+  it("question response includes root-level conversationState only", async () => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    mockCheckRateLimit.mockResolvedValue({
+      success: true,
+      reset: Date.now() + 60_000,
+    });
+    mockGetRateLimitId.mockReturnValue("test-user");
+    mockCompressCaseMemoryWithMiniMax.mockResolvedValue({
+      summary: "Case summary.",
+      model: "MiniMax-M2.7",
+    });
+    mockRunRoboflowSkinWorkflow.mockResolvedValue({
+      positive: false,
+      summary: "",
+      labels: [],
+    });
+    mockShouldAnalyzeWoundImage.mockReturnValue(false);
+    mockExtractWithQwen.mockResolvedValue(
+      JSON.stringify({ symptoms: ["limping"], answers: {} })
+    );
+    mockPhraseWithLlama.mockImplementation(async (prompt: string) => {
+      const questionId =
+        prompt.match(/\(Internal ID: ([^,)\n]+)/)?.[1] || "unknown";
+      return `QUESTION_ID:${questionId}`;
+    });
+    mockVerifyQuestionWithNemotron.mockImplementation(async (prompt: string) => {
+      const questionId =
+        prompt.match(/Internal ID: ([^\n]+)/)?.[1]?.trim() || "unknown";
+      return JSON.stringify({ message: `Next: ${questionId}?` });
+    });
+
+    let session = createSession();
+    session = addSymptoms(session, ["limping"]);
+    const { POST } = await import("@/app/api/ai/symptom-chat/route");
+    const response = await POST(
+      makeTextOnlyRequest(session, "My dog has been limping on the left back leg")
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.type).toBe("question");
+    expect(typeof payload.conversationState).toBe("string");
+    expect(payload.session).toBeDefined();
+    expect(payload.session).not.toHaveProperty("conversationState");
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Surfaces `conversationState` on every successful symptom-chat JSON response (root level only, not on `session`) so the UI can show a reliable phase badge. Wires the symptom-checker chat header to display that phase after each turn.

## API

- New helper `conversationStateFromSession()` mirrors `inferConversationState(getStateSnapshot(session))`.
- Added `conversationState` to: no-user-message, image_gate, both emergency paths, matrix-ready `ready`, alternate `ready` (with `transitionToConfirmed` + `report_ready` for observer parity), clarification question, main question return, error payload (`idle`), and demo mode (`idle`).

## UI

- `symptom-checker/page.tsx`: tracks `conversationPhase` from `data.conversationState`, shows a `Badge` next to the question counter, clears on new session.

## Tests

- Mock `isNvidiaConfigured` for a demo-mode assertion.
- Assert question responses include root `conversationState` and session body does not embed it.

## Verification

- `npm test`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9514c311-b9ee-420e-b9c4-125e34aee1b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9514c311-b9ee-420e-b9c4-125e34aee1b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

