### PR TITLE
feat(VET-833): conversation-state guidance UX

### DIFF
--- a/src/app/(dashboard)/symptom-checker/conversation-state-ui.ts
+++ b/src/app/(dashboard)/symptom-checker/conversation-state-ui.ts
@@ -1,0 +1,158 @@
+/**
+ * VET-833: Pure presentational mapping from API conversationState → owner-facing UI copy.
+ * No React imports — safe for unit tests and deterministic rendering.
+ */
+
+export type ConversationStateApi =
+  | "idle"
+  | "asking"
+  | "answered_unconfirmed"
+  | "confirmed"
+  | "needs_clarification"
+  | "escalation";
+
+export type GuidanceTone = "muted" | "neutral" | "warning" | "success" | "attention";
+
+const CLARIFICATION_COMPOSER_HINT =
+  'Try answering the last question directly, even if the answer is "not sure."';
+
+export interface SymptomCheckerConversationUiConfig {
+  /** Short label for compact badges */
+  badgeLabel: string;
+  tone: GuidanceTone;
+  /** Optional second line under the “Clinical progress” label (e.g. clarification headline) */
+  railHeadline: string;
+  /** Clinical progress rail — main owner-facing message */
+  railBody: string;
+  showClarificationComposerHelper: boolean;
+  clarificationComposerHelperText: string;
+  /** Stronger visual treatment for the manual report CTA */
+  elevateReportCta: boolean;
+  reportCtaHeading: string;
+  reportCtaSubcopy: string;
+}
+
+export function isConversationStateApi(
+  value: unknown
+): value is ConversationStateApi {
+  return (
+    value === "idle" ||
+    value === "asking" ||
+    value === "answered_unconfirmed" ||
+    value === "confirmed" ||
+    value === "needs_clarification" ||
+    value === "escalation"
+  );
+}
+
+export function parseConversationStateApi(
+  value: unknown
+): ConversationStateApi | null {
+  return isConversationStateApi(value) ? value : null;
+}
+
+/**
+ * Maps API `conversationState` and `readyForReport` to UI copy and flags.
+ * When `conversationState` is null (e.g. before first server response), treats as idle.
+ */
+export function getSymptomCheckerConversationUiConfig(
+  conversationState: ConversationStateApi | null | unknown,
+  readyForReport: boolean
+): SymptomCheckerConversationUiConfig {
+  const state: ConversationStateApi =
+    parseConversationStateApi(conversationState) ?? "idle";
+
+  const elevateReportCta = readyForReport && state === "confirmed";
+
+  const reportCtaHeading = elevateReportCta
+    ? "Ready for your full veterinary report"
+    : "Generate your clinical report";
+
+  const reportCtaSubcopy = elevateReportCta
+    ? "Enough detail is in place to produce differentials, tests, and home-care guidance tailored to this conversation."
+    : "When you’re ready, we’ll compile everything from this chat into a structured summary.";
+
+  switch (state) {
+    case "needs_clarification":
+      return {
+        badgeLabel: "Clarify",
+        tone: "warning",
+        railHeadline: "We need a clearer answer",
+        railBody:
+          "Your last reply may not have been specific enough to use safely. Please answer the latest question as directly as you can.",
+        showClarificationComposerHelper: true,
+        clarificationComposerHelperText: CLARIFICATION_COMPOSER_HINT,
+        elevateReportCta,
+        reportCtaHeading,
+        reportCtaSubcopy,
+      };
+
+    case "confirmed":
+      return {
+        badgeLabel: "Confirmed",
+        tone: "success",
+        railHeadline: "",
+        railBody:
+          "Enough information has been confirmed to move toward a report.",
+        showClarificationComposerHelper: false,
+        clarificationComposerHelperText: "",
+        elevateReportCta,
+        reportCtaHeading,
+        reportCtaSubcopy,
+      };
+
+    case "asking":
+      return {
+        badgeLabel: "In progress",
+        tone: "neutral",
+        railHeadline: "",
+        railBody: "We’re still gathering key clinical details.",
+        showClarificationComposerHelper: false,
+        clarificationComposerHelperText: "",
+        elevateReportCta,
+        reportCtaHeading,
+        reportCtaSubcopy,
+      };
+
+    case "answered_unconfirmed":
+      return {
+        badgeLabel: "In progress",
+        tone: "neutral",
+        railHeadline: "",
+        railBody:
+          "Your latest answer is in. We may ask another short question before wrapping up.",
+        showClarificationComposerHelper: false,
+        clarificationComposerHelperText: "",
+        elevateReportCta,
+        reportCtaHeading,
+        reportCtaSubcopy,
+      };
+
+    case "escalation":
+      return {
+        badgeLabel: "Priority",
+        tone: "attention",
+        railHeadline: "",
+        railBody:
+          "This conversation may need urgent or in-person care. Follow any emergency guidance you’ve been given and contact a veterinarian if you’re unsure.",
+        showClarificationComposerHelper: false,
+        clarificationComposerHelperText: "",
+        elevateReportCta,
+        reportCtaHeading,
+        reportCtaSubcopy,
+      };
+
+    case "idle":
+      return {
+        badgeLabel: "Not started",
+        tone: "muted",
+        railHeadline: "",
+        railBody: "Waiting to start a triage conversation.",
+        showClarificationComposerHelper: false,
+        clarificationComposerHelperText: "",
+        elevateReportCta,
+        reportCtaHeading,
+        reportCtaSubcopy,
+      };
+  }
+}

--- a/src/app/(dashboard)/symptom-checker/conversation-state-ui.ts
+++ b/src/app/(dashboard)/symptom-checker/conversation-state-ui.ts
@@ -1,158 +1,162 @@
-/**
- * VET-833: Pure presentational mapping from API conversationState → owner-facing UI copy.
- * No React imports — safe for unit tests and deterministic rendering.
- */
+import {
+  CONVERSATION_STATE_VALUES,
+  type ConversationState,
+} from "@/lib/conversation-state/types";
+import { inferConversationState } from "@/lib/conversation-state/transitions";
+import type { ConversationControlStateSnapshot } from "@/lib/conversation-state/types";
 
-export type ConversationStateApi =
-  | "idle"
-  | "asking"
-  | "answered_unconfirmed"
-  | "confirmed"
-  | "needs_clarification"
-  | "escalation";
+export type ConversationUiTone = "neutral" | "info" | "warning" | "success";
 
-export type GuidanceTone = "muted" | "neutral" | "warning" | "success" | "attention";
-
-const CLARIFICATION_COMPOSER_HINT =
-  'Try answering the last question directly, even if the answer is "not sure."';
-
-export interface SymptomCheckerConversationUiConfig {
-  /** Short label for compact badges */
-  badgeLabel: string;
-  tone: GuidanceTone;
-  /** Optional second line under the “Clinical progress” label (e.g. clarification headline) */
-  railHeadline: string;
-  /** Clinical progress rail — main owner-facing message */
-  railBody: string;
-  showClarificationComposerHelper: boolean;
-  clarificationComposerHelperText: string;
-  /** Stronger visual treatment for the manual report CTA */
+export interface ConversationStateUi {
+  /** Short status label (e.g. for badges); not raw enum values */
+  label: string;
+  tone: ConversationUiTone;
+  /** Primary heading for the guidance panel */
+  title: string;
+  /** Supporting line; may be empty when a single sentence is enough */
+  body: string;
+  showClarificationHelper: boolean;
   elevateReportCta: boolean;
-  reportCtaHeading: string;
-  reportCtaSubcopy: string;
 }
 
-export function isConversationStateApi(
-  value: unknown
-): value is ConversationStateApi {
-  return (
-    value === "idle" ||
-    value === "asking" ||
-    value === "answered_unconfirmed" ||
-    value === "confirmed" ||
-    value === "needs_clarification" ||
-    value === "escalation"
-  );
-}
-
-export function parseConversationStateApi(
-  value: unknown
-): ConversationStateApi | null {
-  return isConversationStateApi(value) ? value : null;
+function isConversationState(value: string): value is ConversationState {
+  return (CONVERSATION_STATE_VALUES as readonly string[]).includes(value);
 }
 
 /**
- * Maps API `conversationState` and `readyForReport` to UI copy and flags.
- * When `conversationState` is null (e.g. before first server response), treats as idle.
+ * Builds the same control snapshot as server-side getStateSnapshot from a
+ * client-held session object (API JSON). Pure; safe for the browser bundle.
  */
-export function getSymptomCheckerConversationUiConfig(
-  conversationState: ConversationStateApi | null | unknown,
+export function clientSessionToControlSnapshot(
+  session: unknown
+): ConversationControlStateSnapshot | null {
+  if (!session || typeof session !== "object") return null;
+  const s = session as Record<string, unknown>;
+  const memory = s.case_memory as Record<string, unknown> | undefined;
+  const answered = s.answered_questions;
+  const extracted = s.extracted_answers;
+  const unresolved = memory?.unresolved_question_ids;
+  const lastAsked = s.last_question_asked;
+
+  return {
+    answeredQuestionIds: Array.isArray(answered)
+      ? answered.filter((id): id is string => typeof id === "string")
+      : [],
+    extractedAnswers:
+      extracted && typeof extracted === "object" && !Array.isArray(extracted)
+        ? { ...(extracted as Record<string, string | boolean | number>) }
+        : {},
+    unresolvedQuestionIds: Array.isArray(unresolved)
+      ? unresolved.filter((id): id is string => typeof id === "string")
+      : [],
+    lastQuestionAsked:
+      typeof lastAsked === "string" && lastAsked.length > 0
+        ? lastAsked
+        : undefined,
+  };
+}
+
+/**
+ * Prefer API `conversationState` when present; otherwise infer from session
+ * so the UI stays aligned with backend state-machine rules.
+ */
+export function resolveConversationStateFromSession(
+  session: unknown,
+  apiConversationState: string | undefined | null
+): ConversationState {
+  if (
+    apiConversationState != null &&
+    typeof apiConversationState === "string" &&
+    isConversationState(apiConversationState)
+  ) {
+    return apiConversationState;
+  }
+  const snap = clientSessionToControlSnapshot(session);
+  if (!snap) return "idle";
+  return inferConversationState(snap);
+}
+
+/** Shown above the composer when clarification is needed */
+export const CLARIFICATION_COMPOSER_HINT =
+  "Try answering the last question directly, even if the answer is 'not sure.'";
+
+/**
+ * Maps triage conversationState + report readiness to owner-facing UI copy.
+ * Never interpolates raw enum identifiers into user-visible strings.
+ */
+export function getConversationStateUi(
+  conversationState: ConversationState,
   readyForReport: boolean
-): SymptomCheckerConversationUiConfig {
-  const state: ConversationStateApi =
-    parseConversationStateApi(conversationState) ?? "idle";
+): ConversationStateUi {
+  const elevateReportCta =
+    readyForReport && conversationState === "confirmed";
 
-  const elevateReportCta = readyForReport && state === "confirmed";
-
-  const reportCtaHeading = elevateReportCta
-    ? "Ready for your full veterinary report"
-    : "Generate your clinical report";
-
-  const reportCtaSubcopy = elevateReportCta
-    ? "Enough detail is in place to produce differentials, tests, and home-care guidance tailored to this conversation."
-    : "When you’re ready, we’ll compile everything from this chat into a structured summary.";
-
-  switch (state) {
-    case "needs_clarification":
-      return {
-        badgeLabel: "Clarify",
-        tone: "warning",
-        railHeadline: "We need a clearer answer",
-        railBody:
-          "Your last reply may not have been specific enough to use safely. Please answer the latest question as directly as you can.",
-        showClarificationComposerHelper: true,
-        clarificationComposerHelperText: CLARIFICATION_COMPOSER_HINT,
-        elevateReportCta,
-        reportCtaHeading,
-        reportCtaSubcopy,
-      };
-
-    case "confirmed":
-      return {
-        badgeLabel: "Confirmed",
-        tone: "success",
-        railHeadline: "",
-        railBody:
-          "Enough information has been confirmed to move toward a report.",
-        showClarificationComposerHelper: false,
-        clarificationComposerHelperText: "",
-        elevateReportCta,
-        reportCtaHeading,
-        reportCtaSubcopy,
-      };
-
-    case "asking":
-      return {
-        badgeLabel: "In progress",
-        tone: "neutral",
-        railHeadline: "",
-        railBody: "We’re still gathering key clinical details.",
-        showClarificationComposerHelper: false,
-        clarificationComposerHelperText: "",
-        elevateReportCta,
-        reportCtaHeading,
-        reportCtaSubcopy,
-      };
-
-    case "answered_unconfirmed":
-      return {
-        badgeLabel: "In progress",
-        tone: "neutral",
-        railHeadline: "",
-        railBody:
-          "Your latest answer is in. We may ask another short question before wrapping up.",
-        showClarificationComposerHelper: false,
-        clarificationComposerHelperText: "",
-        elevateReportCta,
-        reportCtaHeading,
-        reportCtaSubcopy,
-      };
-
-    case "escalation":
-      return {
-        badgeLabel: "Priority",
-        tone: "attention",
-        railHeadline: "",
-        railBody:
-          "This conversation may need urgent or in-person care. Follow any emergency guidance you’ve been given and contact a veterinarian if you’re unsure.",
-        showClarificationComposerHelper: false,
-        clarificationComposerHelperText: "",
-        elevateReportCta,
-        reportCtaHeading,
-        reportCtaSubcopy,
-      };
-
+  switch (conversationState) {
     case "idle":
       return {
-        badgeLabel: "Not started",
-        tone: "muted",
-        railHeadline: "",
-        railBody: "Waiting to start a triage conversation.",
-        showClarificationComposerHelper: false,
-        clarificationComposerHelperText: "",
+        label: "Not started",
+        tone: "neutral",
+        title: "Clinical progress",
+        body: "Waiting to start a triage conversation.",
+        showClarificationHelper: false,
         elevateReportCta,
-        reportCtaHeading,
-        reportCtaSubcopy,
       };
+    case "asking":
+      return {
+        label: "Gathering details",
+        tone: "info",
+        title: "Clinical progress",
+        body: "We're still gathering key clinical details.",
+        showClarificationHelper: false,
+        elevateReportCta,
+      };
+    case "answered_unconfirmed":
+      return {
+        label: "Reviewing your answer",
+        tone: "info",
+        title: "Clinical progress",
+        body: "We're still gathering key clinical details.",
+        showClarificationHelper: false,
+        elevateReportCta,
+      };
+    case "needs_clarification":
+      return {
+        label: "Needs a clearer answer",
+        tone: "warning",
+        title: "Please be more specific",
+        body: "Your last reply may not have been specific enough to use safely. Please answer the latest question as directly as you can.",
+        showClarificationHelper: true,
+        elevateReportCta,
+      };
+    case "confirmed":
+      return {
+        label: "Ready to continue",
+        tone: "success",
+        title: "Clinical progress",
+        body: "Enough information has been confirmed to move toward a report.",
+        showClarificationHelper: false,
+        elevateReportCta,
+      };
+    case "escalation":
+      return {
+        label: "Clinical review",
+        tone: "warning",
+        title: "Clinical progress",
+        body: "We're still gathering key clinical details.",
+        showClarificationHelper: false,
+        elevateReportCta,
+      };
+    default: {
+      const _exhaustive: never = conversationState;
+      void _exhaustive;
+      return {
+        label: "In progress",
+        tone: "info",
+        title: "Clinical progress",
+        body: "We're still gathering key clinical details.",
+        showClarificationHelper: false,
+        elevateReportCta: false,
+      };
+    }
   }
 }

--- a/src/app/(dashboard)/symptom-checker/page.tsx
+++ b/src/app/(dashboard)/symptom-checker/page.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
 import {
   Stethoscope,
   AlertTriangle,
   AlertCircle,
-  CheckCircle,
   Send,
   Loader2,
   Activity,
@@ -22,6 +21,12 @@ import Badge from "@/components/ui/badge";
 import PlanGate from "@/components/subscription/plan-gate";
 import { useAppStore } from "@/store/app-store";
 import { FullReport, type SymptomReport } from "@/components/symptom-report";
+import {
+  getSymptomCheckerConversationUiConfig,
+  parseConversationStateApi,
+  type ConversationStateApi,
+  type GuidanceTone,
+} from "@/app/(dashboard)/symptom-checker/conversation-state-ui";
 
 // --- Types ---
 
@@ -52,6 +57,41 @@ interface SendMessageOptions {
   imageMetaOverride?: ImageMeta | null;
   gateOverride?: boolean;
   appendUserMessage?: boolean;
+}
+
+function guidanceToneToBadgeVariant(
+  tone: GuidanceTone
+): "default" | "success" | "warning" | "danger" | "info" {
+  switch (tone) {
+    case "success":
+      return "success";
+    case "neutral":
+      return "info";
+    case "warning":
+      return "warning";
+    case "attention":
+      return "danger";
+    case "muted":
+    default:
+      return "default";
+  }
+}
+
+function clinicalProgressRailClass(tone: GuidanceTone): string {
+  switch (tone) {
+    case "muted":
+      return "border-gray-200 bg-gray-50/80 text-gray-600";
+    case "neutral":
+      return "border-blue-200 bg-blue-50/90 text-blue-950";
+    case "warning":
+      return "border-amber-300 bg-amber-50/95 text-amber-950";
+    case "success":
+      return "border-emerald-200 bg-emerald-50/90 text-emerald-950";
+    case "attention":
+      return "border-rose-200 bg-rose-50/90 text-rose-950";
+    default:
+      return "border-gray-200 bg-gray-50";
+  }
 }
 
 // --- Config ---
@@ -157,6 +197,8 @@ export default function SymptomCheckerPage() {
   const [readyForReport, setReadyForReport] = useState(false);
   const [generatingReport, setGeneratingReport] = useState(false);
   const [sessionStarted, setSessionStarted] = useState(false);
+  const [conversationState, setConversationState] =
+    useState<ConversationStateApi | null>(null);
   const chatEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -167,6 +209,11 @@ export default function SymptomCheckerPage() {
   const [, setTriageSession] = useState<any>(null);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const triageSessionRef = useRef<any>(null);
+
+  const conversationUi = useMemo(
+    () => getSymptomCheckerConversationUiConfig(conversationState, readyForReport),
+    [conversationState, readyForReport]
+  );
 
   const pet = activePet || {
     name: "your dog",
@@ -371,6 +418,8 @@ export default function SymptomCheckerPage() {
         triageSessionRef.current = data.session;
       }
 
+      setConversationState(parseConversationStateApi(data.conversationState));
+
       if (data.type === "emergency") {
         setMessages((prev) => [
           ...prev,
@@ -484,6 +533,7 @@ export default function SymptomCheckerPage() {
     setReadyForReport(false);
     setGeneratingReport(false);
     setSessionStarted(false);
+    setConversationState(null);
     setTriageSession(null);
     triageSessionRef.current = null;
     setInput("");
@@ -546,6 +596,31 @@ export default function SymptomCheckerPage() {
             </Button>
           )}
         </div>
+      </div>
+
+      {/* VET-833: Clinical progress guidance (owner-facing copy from API state) */}
+      <div
+        className={`rounded-xl border px-4 py-3 ${clinicalProgressRailClass(conversationUi.tone)}`}
+        role="status"
+        aria-live="polite"
+      >
+        <p className="text-xs font-semibold uppercase tracking-wide opacity-80">
+          Clinical progress
+        </p>
+        {conversationUi.railHeadline ? (
+          <>
+            <p className="text-sm font-semibold text-gray-900 mt-1">
+              {conversationUi.railHeadline}
+            </p>
+            <p className="text-sm text-gray-700 mt-1 leading-relaxed">
+              {conversationUi.railBody}
+            </p>
+          </>
+        ) : (
+          <p className="text-sm text-gray-800 mt-1 leading-relaxed">
+            {conversationUi.railBody}
+          </p>
+        )}
       </div>
 
       {/* Pre-session: Welcome + Quick Start */}
@@ -622,7 +697,10 @@ export default function SymptomCheckerPage() {
               </p>
             </div>
             {!report && (
-              <div className="ml-auto">
+              <div className="ml-auto flex items-center gap-2">
+                <Badge variant={guidanceToneToBadgeVariant(conversationUi.tone)}>
+                  {conversationUi.badgeLabel}
+                </Badge>
                 <span className="text-xs text-gray-400">
                   {messages.filter((m) => m.role === "assistant").length}/5
                   questions
@@ -675,6 +753,11 @@ export default function SymptomCheckerPage() {
           {/* Input area — hide when report is generated */}
           {!report && (
             <div className="border-t border-gray-100 p-3">
+              {conversationUi.showClarificationComposerHelper && (
+                <p className="text-xs text-amber-800 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 mb-3">
+                  {conversationUi.clarificationComposerHelperText}
+                </p>
+              )}
               {selectedImage && (
                 <div className="mb-3 relative inline-block">
                   <img
@@ -732,14 +815,34 @@ export default function SymptomCheckerPage() {
 
               {/* Generate Report button */}
               {readyForReport && !generatingReport && (
-                <div className="mt-3 flex justify-center">
-                  <button
-                    onClick={() => generateReport()}
-                    className="flex items-center gap-2 px-6 py-2.5 bg-gradient-to-r from-purple-600 to-blue-600 text-white text-sm font-semibold rounded-full hover:from-purple-700 hover:to-blue-700 transition-all shadow-lg shadow-purple-200"
-                  >
-                    <Zap className="w-4 h-4" />
-                    Generate Full Veterinary Report
-                  </button>
+                <div
+                  className={`mt-4 rounded-xl border p-4 ${
+                    conversationUi.elevateReportCta
+                      ? "border-emerald-200 bg-gradient-to-b from-emerald-50/90 to-white shadow-md"
+                      : "border-gray-100 bg-gray-50/50"
+                  }`}
+                >
+                  <div className="text-center space-y-1 mb-3">
+                    <p className="text-sm font-semibold text-gray-900">
+                      {conversationUi.reportCtaHeading}
+                    </p>
+                    <p className="text-xs text-gray-600 max-w-md mx-auto leading-relaxed">
+                      {conversationUi.reportCtaSubcopy}
+                    </p>
+                  </div>
+                  <div className="flex justify-center">
+                    <button
+                      onClick={() => generateReport()}
+                      className={`flex items-center gap-2 px-6 py-2.5 text-white text-sm font-semibold rounded-full transition-all ${
+                        conversationUi.elevateReportCta
+                          ? "bg-gradient-to-r from-emerald-600 to-teal-600 hover:from-emerald-700 hover:to-teal-700 shadow-lg shadow-emerald-200/80"
+                          : "bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 shadow-lg shadow-purple-200"
+                      }`}
+                    >
+                      <Zap className="w-4 h-4" />
+                      Generate full veterinary report
+                    </button>
+                  </div>
                 </div>
               )}
             </div>
@@ -749,6 +852,11 @@ export default function SymptomCheckerPage() {
 
       {(!sessionStarted && !report) && (
         <div className="p-3 bg-white border border-gray-200 rounded-xl">
+          {conversationUi.showClarificationComposerHelper && (
+            <p className="text-xs text-amber-800 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 mb-3">
+              {conversationUi.clarificationComposerHelperText}
+            </p>
+          )}
            <div className="flex gap-2">
               <Button
                   variant="outline"

--- a/src/app/(dashboard)/symptom-checker/page.tsx
+++ b/src/app/(dashboard)/symptom-checker/page.tsx
@@ -5,6 +5,7 @@ import {
   Stethoscope,
   AlertTriangle,
   AlertCircle,
+  CheckCircle,
   Send,
   Loader2,
   Activity,
@@ -21,12 +22,13 @@ import Badge from "@/components/ui/badge";
 import PlanGate from "@/components/subscription/plan-gate";
 import { useAppStore } from "@/store/app-store";
 import { FullReport, type SymptomReport } from "@/components/symptom-report";
+import type { ConversationState } from "@/lib/conversation-state/types";
 import {
-  getSymptomCheckerConversationUiConfig,
-  parseConversationStateApi,
-  type ConversationStateApi,
-  type GuidanceTone,
-} from "@/app/(dashboard)/symptom-checker/conversation-state-ui";
+  CLARIFICATION_COMPOSER_HINT,
+  getConversationStateUi,
+  resolveConversationStateFromSession,
+  type ConversationStateUi,
+} from "./conversation-state-ui";
 
 // --- Types ---
 
@@ -60,37 +62,18 @@ interface SendMessageOptions {
 }
 
 function guidanceToneToBadgeVariant(
-  tone: GuidanceTone
+  tone: ConversationStateUi["tone"]
 ): "default" | "success" | "warning" | "danger" | "info" {
   switch (tone) {
     case "success":
       return "success";
-    case "neutral":
+    case "info":
       return "info";
     case "warning":
       return "warning";
-    case "attention":
-      return "danger";
-    case "muted":
+    case "neutral":
     default:
       return "default";
-  }
-}
-
-function clinicalProgressRailClass(tone: GuidanceTone): string {
-  switch (tone) {
-    case "muted":
-      return "border-gray-200 bg-gray-50/80 text-gray-600";
-    case "neutral":
-      return "border-blue-200 bg-blue-50/90 text-blue-950";
-    case "warning":
-      return "border-amber-300 bg-amber-50/95 text-amber-950";
-    case "success":
-      return "border-emerald-200 bg-emerald-50/90 text-emerald-950";
-    case "attention":
-      return "border-rose-200 bg-rose-50/90 text-rose-950";
-    default:
-      return "border-gray-200 bg-gray-50";
   }
 }
 
@@ -198,7 +181,7 @@ export default function SymptomCheckerPage() {
   const [generatingReport, setGeneratingReport] = useState(false);
   const [sessionStarted, setSessionStarted] = useState(false);
   const [conversationState, setConversationState] =
-    useState<ConversationStateApi | null>(null);
+    useState<ConversationState>("idle");
   const chatEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -210,10 +193,17 @@ export default function SymptomCheckerPage() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const triageSessionRef = useRef<any>(null);
 
-  const conversationUi = useMemo(
-    () => getSymptomCheckerConversationUiConfig(conversationState, readyForReport),
-    [conversationState, readyForReport]
-  );
+  const syncConversationFromApiPayload = (data: {
+    session?: unknown;
+    conversationState?: string | null;
+  }) => {
+    setConversationState(
+      resolveConversationStateFromSession(
+        data.session,
+        data.conversationState ?? null
+      )
+    );
+  };
 
   const pet = activePet || {
     name: "your dog",
@@ -417,8 +407,7 @@ export default function SymptomCheckerPage() {
         setTriageSession(data.session);
         triageSessionRef.current = data.session;
       }
-
-      setConversationState(parseConversationStateApi(data.conversationState));
+      syncConversationFromApiPayload(data);
 
       if (data.type === "emergency") {
         setMessages((prev) => [
@@ -533,9 +522,9 @@ export default function SymptomCheckerPage() {
     setReadyForReport(false);
     setGeneratingReport(false);
     setSessionStarted(false);
-    setConversationState(null);
     setTriageSession(null);
     triageSessionRef.current = null;
+    setConversationState("idle");
     setInput("");
     clearComposerImage();
     clearPendingGateImage();
@@ -564,6 +553,31 @@ export default function SymptomCheckerPage() {
       sendMessage();
     }
   };
+
+  const progressUi = useMemo(() => {
+    const effectiveState: ConversationState = sessionStarted
+      ? conversationState
+      : "idle";
+    return getConversationStateUi(effectiveState, readyForReport);
+  }, [sessionStarted, conversationState, readyForReport]);
+
+  const progressPanelClass =
+    progressUi.tone === "warning"
+      ? "border-amber-200 bg-amber-50/90"
+      : progressUi.tone === "success"
+        ? "border-emerald-200 bg-emerald-50/80"
+        : progressUi.tone === "info"
+          ? "border-blue-100 bg-blue-50/70"
+          : "border-gray-200 bg-gray-50/80";
+
+  const ProgressIcon =
+    progressUi.tone === "warning"
+      ? AlertTriangle
+      : progressUi.tone === "success"
+        ? CheckCircle
+        : progressUi.tone === "info"
+          ? Activity
+          : Stethoscope;
 
   return (
     <PlanGate requiredPlan="pro">
@@ -598,30 +612,39 @@ export default function SymptomCheckerPage() {
         </div>
       </div>
 
-      {/* VET-833: Clinical progress guidance (owner-facing copy from API state) */}
-      <div
-        className={`rounded-xl border px-4 py-3 ${clinicalProgressRailClass(conversationUi.tone)}`}
-        role="status"
-        aria-live="polite"
-      >
-        <p className="text-xs font-semibold uppercase tracking-wide opacity-80">
-          Clinical progress
-        </p>
-        {conversationUi.railHeadline ? (
-          <>
-            <p className="text-sm font-semibold text-gray-900 mt-1">
-              {conversationUi.railHeadline}
+      {/* Clinical progress — owner guidance from conversation state */}
+      {!report && (
+        <div
+          className={`rounded-xl border px-4 py-3 flex gap-3 items-start ${progressPanelClass}`}
+          role="status"
+          aria-live="polite"
+        >
+          <div
+            className={`mt-0.5 flex-shrink-0 ${
+              progressUi.tone === "warning"
+                ? "text-amber-700"
+                : progressUi.tone === "success"
+                  ? "text-emerald-700"
+                  : progressUi.tone === "info"
+                    ? "text-blue-700"
+                    : "text-gray-600"
+            }`}
+          >
+            <ProgressIcon className="w-5 h-5" aria-hidden />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">
+              Clinical progress · {progressUi.label}
             </p>
-            <p className="text-sm text-gray-700 mt-1 leading-relaxed">
-              {conversationUi.railBody}
+            <h2 className="text-sm font-semibold text-gray-900 mt-0.5">
+              {progressUi.title}
+            </h2>
+            <p className="text-sm text-gray-700 mt-1 leading-snug">
+              {progressUi.body}
             </p>
-          </>
-        ) : (
-          <p className="text-sm text-gray-800 mt-1 leading-relaxed">
-            {conversationUi.railBody}
-          </p>
-        )}
-      </div>
+          </div>
+        </div>
+      )}
 
       {/* Pre-session: Welcome + Quick Start */}
       {!sessionStarted && (
@@ -698,8 +721,8 @@ export default function SymptomCheckerPage() {
             </div>
             {!report && (
               <div className="ml-auto flex items-center gap-2">
-                <Badge variant={guidanceToneToBadgeVariant(conversationUi.tone)}>
-                  {conversationUi.badgeLabel}
+                <Badge variant={guidanceToneToBadgeVariant(progressUi.tone)}>
+                  {progressUi.label}
                 </Badge>
                 <span className="text-xs text-gray-400">
                   {messages.filter((m) => m.role === "assistant").length}/5
@@ -753,9 +776,9 @@ export default function SymptomCheckerPage() {
           {/* Input area — hide when report is generated */}
           {!report && (
             <div className="border-t border-gray-100 p-3">
-              {conversationUi.showClarificationComposerHelper && (
-                <p className="text-xs text-amber-800 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 mb-3">
-                  {conversationUi.clarificationComposerHelperText}
+              {progressUi.showClarificationHelper && (
+                <p className="text-xs text-amber-900/90 bg-amber-50 border border-amber-200/80 rounded-lg px-3 py-2 mb-3 leading-relaxed">
+                  {CLARIFICATION_COMPOSER_HINT}
                 </p>
               )}
               {selectedImage && (
@@ -816,32 +839,49 @@ export default function SymptomCheckerPage() {
               {/* Generate Report button */}
               {readyForReport && !generatingReport && (
                 <div
-                  className={`mt-4 rounded-xl border p-4 ${
-                    conversationUi.elevateReportCta
-                      ? "border-emerald-200 bg-gradient-to-b from-emerald-50/90 to-white shadow-md"
-                      : "border-gray-100 bg-gray-50/50"
-                  }`}
+                  className={
+                    progressUi.elevateReportCta
+                      ? "mt-6 pt-5 border-t border-purple-100"
+                      : "mt-3 flex justify-center"
+                  }
                 >
-                  <div className="text-center space-y-1 mb-3">
-                    <p className="text-sm font-semibold text-gray-900">
-                      {conversationUi.reportCtaHeading}
-                    </p>
-                    <p className="text-xs text-gray-600 max-w-md mx-auto leading-relaxed">
-                      {conversationUi.reportCtaSubcopy}
-                    </p>
-                  </div>
-                  <div className="flex justify-center">
-                    <button
-                      onClick={() => generateReport()}
-                      className={`flex items-center gap-2 px-6 py-2.5 text-white text-sm font-semibold rounded-full transition-all ${
-                        conversationUi.elevateReportCta
-                          ? "bg-gradient-to-r from-emerald-600 to-teal-600 hover:from-emerald-700 hover:to-teal-700 shadow-lg shadow-emerald-200/80"
-                          : "bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 shadow-lg shadow-purple-200"
-                      }`}
+                  <div
+                    className={
+                      progressUi.elevateReportCta
+                        ? "rounded-2xl border border-purple-200/80 bg-gradient-to-b from-purple-50/90 to-white px-5 py-5 text-center shadow-sm w-full max-w-lg mx-auto"
+                        : ""
+                    }
+                  >
+                    {progressUi.elevateReportCta && (
+                      <>
+                        <h3 className="text-base font-semibold text-gray-900">
+                          Ready for your full report
+                        </h3>
+                        <p className="text-sm text-gray-600 mt-2 max-w-md mx-auto leading-relaxed">
+                          We have enough confirmed detail to compile differentials,
+                          next steps, and questions for your veterinarian.
+                        </p>
+                      </>
+                    )}
+                    <div
+                      className={
+                        progressUi.elevateReportCta
+                          ? "mt-5 flex justify-center"
+                          : ""
+                      }
                     >
-                      <Zap className="w-4 h-4" />
-                      Generate full veterinary report
-                    </button>
+                      <button
+                        onClick={() => generateReport()}
+                        className={
+                          progressUi.elevateReportCta
+                            ? "flex items-center gap-2 px-8 py-3 bg-gradient-to-r from-purple-600 to-blue-600 text-white text-sm font-semibold rounded-full hover:from-purple-700 hover:to-blue-700 transition-all shadow-lg shadow-purple-300/60"
+                            : "flex items-center gap-2 px-6 py-2.5 bg-gradient-to-r from-purple-600 to-blue-600 text-white text-sm font-semibold rounded-full hover:from-purple-700 hover:to-blue-700 transition-all shadow-lg shadow-purple-200"
+                        }
+                      >
+                        <Zap className="w-4 h-4" />
+                        Generate Full Veterinary Report
+                      </button>
+                    </div>
                   </div>
                 </div>
               )}
@@ -852,9 +892,9 @@ export default function SymptomCheckerPage() {
 
       {(!sessionStarted && !report) && (
         <div className="p-3 bg-white border border-gray-200 rounded-xl">
-          {conversationUi.showClarificationComposerHelper && (
-            <p className="text-xs text-amber-800 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 mb-3">
-              {conversationUi.clarificationComposerHelperText}
+          {progressUi.showClarificationHelper && (
+            <p className="text-xs text-amber-900/90 bg-amber-50 border border-amber-200/80 rounded-lg px-3 py-2 mb-3 leading-relaxed">
+              {CLARIFICATION_COMPOSER_HINT}
             </p>
           )}
            <div className="flex gap-2">

--- a/src/app/api/ai/symptom-chat/route.ts
+++ b/src/app/api/ai/symptom-chat/route.ts
@@ -62,6 +62,7 @@ import {
   capDiagnosticConfidence,
   inferSupportedImageDomain,
   type ConsultOpinion,
+  type SidecarObservation,
   type RetrievalBundle,
   type ServiceTimeoutRecord,
   type SupportedImageDomain,
@@ -4634,16 +4635,40 @@ function buildImageGateMessage(
   return `This looks more like a full-pet or unrelated photo than a close-up of the affected area.${labelDetail} Please upload a close, well-lit photo of the wound or skin issue, or use Analyze Anyway if this is the only image available.`;
 }
 
+const INTERNAL_TELEMETRY_NOTE_MARKERS = [
+  "question_state=",
+  "conversation_state=",
+];
+
+function isInternalTelemetryObservationForClient(item: SidecarObservation): boolean {
+  if (item.service === "async-review-service") {
+    return true;
+  }
+
+  if (INTERNAL_TELEMETRY_STAGES.has(item.stage)) {
+    return true;
+  }
+
+  const note = typeof item.note === "string" ? item.note : "";
+  return INTERNAL_TELEMETRY_NOTE_MARKERS.some((marker) => note.includes(marker));
+}
+
+function sanitizeServiceObservationsForClient(
+  observations: SidecarObservation[] | undefined
+): SidecarObservation[] {
+  return (observations ?? []).filter(
+    (item) => !isInternalTelemetryObservationForClient(item)
+  );
+}
+
 function sanitizeSessionForClient(session: TriageSession): TriageSession {
   if (!session || !session.case_memory) return session;
 
   const sanitizedMemory = {
     ...session.case_memory,
-    // Strictly filter out internal service observations
-    service_observations: (session.case_memory.service_observations || []).filter(
-      (item) =>
-        item.service !== "async-review-service" &&
-        !INTERNAL_TELEMETRY_STAGES.has(item.stage)
+    // Keep user-safe operational notes while stripping internal telemetry traces.
+    service_observations: sanitizeServiceObservationsForClient(
+      session.case_memory.service_observations
     ),
     // Hide developer-only comparison data from client responses
     shadow_comparisons: [],

--- a/tests/conversation-state-ui.test.ts
+++ b/tests/conversation-state-ui.test.ts
@@ -1,88 +1,144 @@
+import type { ConversationState } from "@/lib/conversation-state/types";
+import { CONVERSATION_STATE_VALUES } from "@/lib/conversation-state/types";
 import {
-  getSymptomCheckerConversationUiConfig,
-  parseConversationStateApi,
+  clientSessionToControlSnapshot,
+  getConversationStateUi,
+  resolveConversationStateFromSession,
 } from "@/app/(dashboard)/symptom-checker/conversation-state-ui";
 
-/** API-style snake_case and internal tokens must not appear in owner-facing strings. */
+/** Internal snake_case / telemetry tokens must not appear in owner-facing strings. */
 const FORBIDDEN_LEAKS = [
   "needs_clarification",
   "answered_unconfirmed",
+  "conversation_state",
+  "question_state",
   "state_transition",
-  "observer",
-  "protected control",
 ];
 
-function assertNoInternalTokenLeak(
-  config: ReturnType<typeof getSymptomCheckerConversationUiConfig>
-) {
-  const blob = [
-    config.badgeLabel,
-    config.railHeadline,
-    config.railBody,
-    config.clarificationComposerHelperText,
-    config.reportCtaHeading,
-    config.reportCtaSubcopy,
-  ].join(" ");
-  const lower = blob.toLowerCase();
-  for (const s of FORBIDDEN_LEAKS) {
-    expect(lower).not.toContain(s);
+function assertNoInternalTokenLeak(ui: ReturnType<typeof getConversationStateUi>) {
+  const blob = [ui.label, ui.title, ui.body].join(" ").toLowerCase();
+  for (const token of FORBIDDEN_LEAKS) {
+    expect(blob).not.toContain(token);
   }
 }
 
-describe("VET-833: getSymptomCheckerConversationUiConfig", () => {
-  it("idle: muted guidance and no clarification helper", () => {
-    const c = getSymptomCheckerConversationUiConfig("idle", false);
-    expect(c.tone).toBe("muted");
-    expect(c.railBody).toContain("Waiting to start");
-    expect(c.showClarificationComposerHelper).toBe(false);
-    expect(c.elevateReportCta).toBe(false);
-    assertNoInternalTokenLeak(c);
+describe("getConversationStateUi", () => {
+  it("idle: waiting copy and no helper", () => {
+    const ui = getConversationStateUi("idle", false);
+    expect(ui.body).toContain("Waiting to start a triage conversation");
+    expect(ui.showClarificationHelper).toBe(false);
+    expect(ui.elevateReportCta).toBe(false);
+    expect(ui.tone).toBe("neutral");
+    assertNoInternalTokenLeak(ui);
   });
 
-  it("asking: neutral copy", () => {
-    const c = getSymptomCheckerConversationUiConfig("asking", false);
-    expect(c.tone).toBe("neutral");
-    expect(c.railBody).toContain("gathering key clinical");
-    expect(c.showClarificationComposerHelper).toBe(false);
-    assertNoInternalTokenLeak(c);
+  it("asking: gathering copy", () => {
+    const ui = getConversationStateUi("asking", false);
+    expect(ui.body).toContain("still gathering key clinical details");
+    expect(ui.showClarificationHelper).toBe(false);
+    expect(ui.elevateReportCta).toBe(false);
+    expect(ui.tone).toBe("info");
+    assertNoInternalTokenLeak(ui);
   });
 
-  it("needs_clarification: warning + composer helper", () => {
-    const c = getSymptomCheckerConversationUiConfig("needs_clarification", false);
-    expect(c.tone).toBe("warning");
-    expect(c.railHeadline.length).toBeGreaterThan(0);
-    expect(c.showClarificationComposerHelper).toBe(true);
-    expect(c.clarificationComposerHelperText.length).toBeGreaterThan(10);
-    expect(c.railBody).toContain("specific enough");
-    assertNoInternalTokenLeak(c);
+  it("needs_clarification: warning copy and composer helper flag", () => {
+    const ui = getConversationStateUi("needs_clarification", false);
+    expect(ui.tone).toBe("warning");
+    expect(ui.body).toContain("specific enough");
+    expect(ui.showClarificationHelper).toBe(true);
+    expect(ui.elevateReportCta).toBe(false);
+    assertNoInternalTokenLeak(ui);
   });
 
-  it("confirmed: success rail", () => {
-    const c = getSymptomCheckerConversationUiConfig("confirmed", false);
-    expect(c.tone).toBe("success");
-    expect(c.railBody).toContain("confirmed");
-    expect(c.showClarificationComposerHelper).toBe(false);
-    assertNoInternalTokenLeak(c);
+  it("confirmed: success copy", () => {
+    const ui = getConversationStateUi("confirmed", false);
+    expect(ui.tone).toBe("success");
+    expect(ui.body).toContain("Enough information has been confirmed");
+    expect(ui.showClarificationHelper).toBe(false);
+    expect(ui.elevateReportCta).toBe(false);
+    assertNoInternalTokenLeak(ui);
   });
 
   it("confirmed + readyForReport elevates report CTA", () => {
-    const off = getSymptomCheckerConversationUiConfig("confirmed", false);
-    const on = getSymptomCheckerConversationUiConfig("confirmed", true);
+    const off = getConversationStateUi("confirmed", false);
+    const on = getConversationStateUi("confirmed", true);
     expect(off.elevateReportCta).toBe(false);
     expect(on.elevateReportCta).toBe(true);
-    expect(on.reportCtaHeading).not.toEqual(off.reportCtaHeading);
-    expect(on.reportCtaSubcopy.length).toBeGreaterThan(off.reportCtaSubcopy.length);
     assertNoInternalTokenLeak(on);
   });
 
-  it("null conversationState behaves as idle", () => {
-    const c = getSymptomCheckerConversationUiConfig(null, false);
-    expect(c.tone).toBe("muted");
-    expect(c.railBody).toContain("Waiting to start");
+  it("readyForReport alone does not elevate when not confirmed", () => {
+    const ui = getConversationStateUi("asking", true);
+    expect(ui.elevateReportCta).toBe(false);
   });
 
-  it("parseConversationStateApi rejects unknown strings", () => {
-    expect(parseConversationStateApi("needs_clarification")).toBe("needs_clarification");
-    expect(parseConversationStateApi("bogus")).toBeNull();
+  it("clarification state is the only state that shows helper", () => {
+    const states: ConversationState[] = [
+      "idle",
+      "asking",
+      "answered_unconfirmed",
+      "confirmed",
+      "escalation",
+    ];
+    for (const s of states) {
+      expect(getConversationStateUi(s, false).showClarificationHelper).toBe(
+        false
+      );
+    }
+    expect(
+      getConversationStateUi("needs_clarification", false).showClarificationHelper
+    ).toBe(true);
+  });
+
+  it("owner-facing strings do not include internal enum / telemetry tokens", () => {
+    for (const state of CONVERSATION_STATE_VALUES) {
+      for (const ready of [false, true]) {
+        assertNoInternalTokenLeak(getConversationStateUi(state, ready));
+      }
+    }
+  });
+});
+
+describe("resolveConversationStateFromSession", () => {
+  it("uses API conversationState when valid", () => {
+    const session = {
+      last_question_asked: "q1",
+      answered_questions: [],
+      case_memory: { unresolved_question_ids: [] },
+    };
+    expect(
+      resolveConversationStateFromSession(session, "needs_clarification")
+    ).toBe("needs_clarification");
+  });
+
+  it("infers asking when last question unanswered", () => {
+    const session = {
+      last_question_asked: "water_intake",
+      answered_questions: [] as string[],
+      extracted_answers: {},
+      case_memory: { unresolved_question_ids: [] },
+    };
+    expect(resolveConversationStateFromSession(session, null)).toBe("asking");
+  });
+
+  it("returns idle for null session without API state", () => {
+    expect(resolveConversationStateFromSession(null, undefined)).toBe("idle");
+  });
+});
+
+describe("clientSessionToControlSnapshot", () => {
+  it("maps triage session fields into control snapshot shape", () => {
+    const snap = clientSessionToControlSnapshot({
+      last_question_asked: "x",
+      answered_questions: ["a"],
+      extracted_answers: { a: "yes" },
+      case_memory: { unresolved_question_ids: ["u"] },
+    });
+    expect(snap).toEqual({
+      answeredQuestionIds: ["a"],
+      extractedAnswers: { a: "yes" },
+      unresolvedQuestionIds: ["u"],
+      lastQuestionAsked: "x",
+    });
   });
 });

--- a/tests/conversation-state-ui.test.ts
+++ b/tests/conversation-state-ui.test.ts
@@ -1,0 +1,88 @@
+import {
+  getSymptomCheckerConversationUiConfig,
+  parseConversationStateApi,
+} from "@/app/(dashboard)/symptom-checker/conversation-state-ui";
+
+/** API-style snake_case and internal tokens must not appear in owner-facing strings. */
+const FORBIDDEN_LEAKS = [
+  "needs_clarification",
+  "answered_unconfirmed",
+  "state_transition",
+  "observer",
+  "protected control",
+];
+
+function assertNoInternalTokenLeak(
+  config: ReturnType<typeof getSymptomCheckerConversationUiConfig>
+) {
+  const blob = [
+    config.badgeLabel,
+    config.railHeadline,
+    config.railBody,
+    config.clarificationComposerHelperText,
+    config.reportCtaHeading,
+    config.reportCtaSubcopy,
+  ].join(" ");
+  const lower = blob.toLowerCase();
+  for (const s of FORBIDDEN_LEAKS) {
+    expect(lower).not.toContain(s);
+  }
+}
+
+describe("VET-833: getSymptomCheckerConversationUiConfig", () => {
+  it("idle: muted guidance and no clarification helper", () => {
+    const c = getSymptomCheckerConversationUiConfig("idle", false);
+    expect(c.tone).toBe("muted");
+    expect(c.railBody).toContain("Waiting to start");
+    expect(c.showClarificationComposerHelper).toBe(false);
+    expect(c.elevateReportCta).toBe(false);
+    assertNoInternalTokenLeak(c);
+  });
+
+  it("asking: neutral copy", () => {
+    const c = getSymptomCheckerConversationUiConfig("asking", false);
+    expect(c.tone).toBe("neutral");
+    expect(c.railBody).toContain("gathering key clinical");
+    expect(c.showClarificationComposerHelper).toBe(false);
+    assertNoInternalTokenLeak(c);
+  });
+
+  it("needs_clarification: warning + composer helper", () => {
+    const c = getSymptomCheckerConversationUiConfig("needs_clarification", false);
+    expect(c.tone).toBe("warning");
+    expect(c.railHeadline.length).toBeGreaterThan(0);
+    expect(c.showClarificationComposerHelper).toBe(true);
+    expect(c.clarificationComposerHelperText.length).toBeGreaterThan(10);
+    expect(c.railBody).toContain("specific enough");
+    assertNoInternalTokenLeak(c);
+  });
+
+  it("confirmed: success rail", () => {
+    const c = getSymptomCheckerConversationUiConfig("confirmed", false);
+    expect(c.tone).toBe("success");
+    expect(c.railBody).toContain("confirmed");
+    expect(c.showClarificationComposerHelper).toBe(false);
+    assertNoInternalTokenLeak(c);
+  });
+
+  it("confirmed + readyForReport elevates report CTA", () => {
+    const off = getSymptomCheckerConversationUiConfig("confirmed", false);
+    const on = getSymptomCheckerConversationUiConfig("confirmed", true);
+    expect(off.elevateReportCta).toBe(false);
+    expect(on.elevateReportCta).toBe(true);
+    expect(on.reportCtaHeading).not.toEqual(off.reportCtaHeading);
+    expect(on.reportCtaSubcopy.length).toBeGreaterThan(off.reportCtaSubcopy.length);
+    assertNoInternalTokenLeak(on);
+  });
+
+  it("null conversationState behaves as idle", () => {
+    const c = getSymptomCheckerConversationUiConfig(null, false);
+    expect(c.tone).toBe("muted");
+    expect(c.railBody).toContain("Waiting to start");
+  });
+
+  it("parseConversationStateApi rejects unknown strings", () => {
+    expect(parseConversationStateApi("needs_clarification")).toBe("needs_clarification");
+    expect(parseConversationStateApi("bogus")).toBeNull();
+  });
+});

--- a/tests/symptom-chat.route.test.ts
+++ b/tests/symptom-chat.route.test.ts
@@ -3874,32 +3874,49 @@ describe("VET-725: asked-state regression pack", () => {
     expect(payload2.session.last_question_asked).toBe("limping_progression");
   });
 
-  it("VET-828: state_transition observations are stripped from client session payload", async () => {
+  it("VET-737: client payload strips internal telemetry observations but preserves user-safe observations", async () => {
     const { POST } = await import("@/app/api/ai/symptom-chat/route");
 
+    const recordedAt = new Date().toISOString();
+    const internalTransitionObservation: SidecarObservation = {
+      service: "async-review-service",
+      stage: "state_transition",
+      latencyMs: 0,
+      outcome: "success",
+      shadowMode: false,
+      fallbackUsed: false,
+      note:
+        "question_state=unanswered->answered | conversation_state=asking->confirmed",
+      recordedAt,
+    };
+    const misclassifiedInternalObservation: SidecarObservation = {
+      service: "vision-preprocess-service",
+      stage: "state_transition",
+      latencyMs: 12,
+      outcome: "success",
+      shadowMode: false,
+      fallbackUsed: false,
+      note:
+        "question_state=unanswered->answered | conversation_state=asking->confirmed",
+      recordedAt,
+    };
+    const safeObservation: SidecarObservation = {
+      service: "vision-preprocess-service",
+      stage: "preprocess",
+      latencyMs: 120,
+      outcome: "success",
+      shadowMode: false,
+      fallbackUsed: false,
+      note: "Owner-safe photo preprocessing completed.",
+      recordedAt,
+    };
     const session = createSession();
     session.case_memory = {
       ...(session.case_memory ?? {}),
       service_observations: [
-        {
-          service: "async-review-service",
-          stage: "state_transition",
-          latencyMs: 0,
-          outcome: "success",
-          shadowMode: false,
-          fallbackUsed: false,
-          note: "question_state=unanswered→answered for vomit_duration",
-          recordedAt: new Date().toISOString(),
-        },
-        {
-          service: "vision-preprocess-service",
-          stage: "preprocess",
-          latencyMs: 120,
-          outcome: "success",
-          shadowMode: false,
-          fallbackUsed: false,
-          recordedAt: new Date().toISOString(),
-        },
+        internalTransitionObservation,
+        misclassifiedInternalObservation,
+        safeObservation,
       ],
     };
 
@@ -3918,15 +3935,30 @@ describe("VET-725: asked-state regression pack", () => {
       (caseMemory.service_observations as Array<Record<string, unknown>> | undefined) ??
       [];
 
-    for (const obs of observations) {
-      expect(String(obs.service ?? "")).not.toBe("async-review-service");
-      expect(INTERNAL_STAGES).not.toContain(String(obs.stage ?? ""));
-    }
-
-    const survived = observations.some(
-      (obs) => String(obs.service ?? "") === "vision-preprocess-service"
+    expect(observations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          service: safeObservation.service,
+          stage: safeObservation.stage,
+          note: safeObservation.note,
+        }),
+      ])
     );
-    expect(survived).toBe(true);
+    expect(observations).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          service: internalTransitionObservation.service,
+        }),
+      ])
+    );
+    expect(observations).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          stage: misclassifiedInternalObservation.stage,
+          note: misclassifiedInternalObservation.note,
+        }),
+      ])
+    );
   });
 
   describe("VET-825 - server-auth REPORT_READY / URGENCY_HIGH emission", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds a compact **Clinical progress** panel below the page header (hidden when a full report is shown) with tone-aware styling and owner-facing copy driven by `conversationState`, with **session inference** when the API omits `conversationState`.
- Shows a **clarification hint** above the composer when `needs_clarification`; copy matches the ticket (`'not sure.'` apostrophe style).
- When `readyForReport` and `conversationState === confirmed`, the **Generate Full Veterinary Report** block gets stronger hierarchy (heading, subcopy, spacing) without changing `generateReport()` behavior.
- Pure helpers live in `conversation-state-ui.ts` (`getConversationStateUi`, `resolveConversationStateFromSession`, `clientSessionToControlSnapshot`); unit tests in `tests/conversation-state-ui.test.ts`.

## Test plan

- [x] `npm test`
- [x] `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9514c311-b9ee-420e-b9c4-125e34aee1b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9514c311-b9ee-420e-b9c4-125e34aee1b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

