### PR TITLE
VET-1007: repair auto-fix workflow gating

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -10,12 +10,29 @@ permissions:
   pull-requests: write
 
 jobs:
+  evaluate-trigger:
+    name: Evaluate Auto-Fix Trigger
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.guard.outputs.should_run }}
+    steps:
+      - name: Check workflow_run eligibility
+        id: guard
+        run: |
+          if [ "${{ github.event.workflow_run.conclusion }}" = "failure" ] && \
+             [ "${{ github.event.workflow_run.event }}" = "pull_request" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "should_run=false" >> "$GITHUB_OUTPUT"
+          echo "Auto-fix only runs for failed pull_request CI workflow completions."
+
   auto-fix:
     name: Auto-Fix
     runs-on: ubuntu-latest
-    if: >
-      github.event.workflow_run.conclusion == 'failure' &&
-      github.event.workflow_run.event == 'pull_request'
+    needs: evaluate-trigger
+    if: needs.evaluate-trigger.outputs.should_run == 'true'
     steps:
       - name: Get PR number
         id: pr

--- a/docs/tickets/VET-1007-auto-fix-workflow-repair.md
+++ b/docs/tickets/VET-1007-auto-fix-workflow-repair.md
@@ -1,0 +1,30 @@
+# VET-1007 — Auto-Fix Workflow Repair
+
+Owner: `copilot`
+Branch: `copilot/vet-1007-auto-fix-workflow-repair-v1`
+Status: in progress
+
+## Goal
+
+Repair the auto-fix GitHub Actions workflow so merge pushes to master do not surface zero-job workflow failures, while preserving auto-fix behavior for failed PR CI runs.
+
+## Root Cause
+
+- `.github/workflows/auto-fix.yml` registered on every completed `CI Pipeline` workflow run.
+- The workflow relied on a job-level `if` using `github.event.workflow_run.conclusion` and `github.event.workflow_run.event` to skip non-PR or successful runs.
+- GitHub created repeated zero-second failed runs with no jobs for push-triggered completions, including failed run `24366113337` on `master`, and reported them as likely workflow-file issues.
+
+## Fix
+
+- add an unconditional `evaluate-trigger` job that computes whether auto-fix should run
+- keep the existing `auto-fix` job behavior, but gate it on the `evaluate-trigger` job output instead of the original job-level `if`
+- preserve the existing auto-fix steps so only failed PR CI runs can mutate PR branches or comment on the PR
+
+## Verification
+
+- `gh run view 24366113337 --repo kandamukeshkumar4-cmyk/pawvital-ai`
+- `gh run view 24366113337 --repo kandamukeshkumar4-cmyk/pawvital-ai --json conclusion,event,headBranch,headSha,jobs,name,number,status,url,workflowDatabaseId,workflowName,displayTitle`
+- `gh api repos/kandamukeshkumar4-cmyk/pawvital-ai/actions/runs/24366113337`
+- `gh api repos/kandamukeshkumar4-cmyk/pawvital-ai/actions/runs/24366113337/attempts/1/jobs`
+- `gh run list --workflow auto-fix.yml --repo kandamukeshkumar4-cmyk/pawvital-ai --limit 20`
+- `gh workflow list --repo kandamukeshkumar4-cmyk/pawvital-ai`

--- a/docs/tickets/VET-1007-auto-fix-workflow-repair.md
+++ b/docs/tickets/VET-1007-auto-fix-workflow-repair.md
@@ -2,7 +2,7 @@
 
 Owner: `copilot`
 Branch: `copilot/vet-1007-auto-fix-workflow-repair-v1`
-Status: in progress
+Status: ready for review
 
 ## Goal
 
@@ -28,3 +28,8 @@ Repair the auto-fix GitHub Actions workflow so merge pushes to master do not sur
 - `gh api repos/kandamukeshkumar4-cmyk/pawvital-ai/actions/runs/24366113337/attempts/1/jobs`
 - `gh run list --workflow auto-fix.yml --repo kandamukeshkumar4-cmyk/pawvital-ai --limit 20`
 - `gh workflow list --repo kandamukeshkumar4-cmyk/pawvital-ai`
+
+## Validation Notes
+
+- no local `actionlint` installation was available, so no standalone workflow linter was run
+- GitHub documents that `workflow_run` only triggers when the workflow file exists on the default branch, so branch-push auto-fix runs continue to use the current `master` workflow definition until this PR merges


### PR DESCRIPTION
## Summary
- add an always-run trigger evaluation job to the auto-fix workflow
- gate the existing auto-fix job on the evaluation output instead of a job-level workflow_run condition
- document the zero-job push-run failure pattern and repair in the VET-1007 ticket note

## Root cause
The auto-fix workflow subscribed to every completed CI Pipeline run and relied on a job-level if against workflow_run metadata to skip non-PR and successful runs. GitHub was creating zero-job failed runs for push-triggered CI completions, including run 24366113337 on master, and surfacing them as workflow file issues before any steps executed.

## Verification
- gh run view 24366113337 --repo kandamukeshkumar4-cmyk/pawvital-ai
- gh run view 24366113337 --repo kandamukeshkumar4-cmyk/pawvital-ai --json conclusion,event,headBranch,headSha,jobs,name,number,status,url,workflowDatabaseId,workflowName,displayTitle
- gh api repos/kandamukeshkumar4-cmyk/pawvital-ai/actions/runs/24366113337
- gh api repos/kandamukeshkumar4-cmyk/pawvital-ai/actions/runs/24366113337/attempts/1/jobs
- gh run list --workflow auto-fix.yml --repo kandamukeshkumar4-cmyk/pawvital-ai --limit 20
- gh workflow list --repo kandamukeshkumar4-cmyk/pawvital-ai
- git diff --name-only origin/master...HEAD