### PR TITLE
VET-1221: demo response extraction

### DIFF
--- a/src/app/api/ai/symptom-chat/route.ts
+++ b/src/app/api/ai/symptom-chat/route.ts
@@ -151,6 +151,7 @@ import {
   gateQuestionBeforePhrasing,
   phraseQuestion,
 } from "@/lib/symptom-chat/question-phrasing";
+import { demoResponse } from "@/lib/symptom-chat/demo-response";
 import { generateReport } from "@/lib/symptom-chat/report-pipeline";
 import type { SubscriptionRow } from "@/types";
 
@@ -1630,45 +1631,3 @@ Return ONLY the summary text.`;
 // =============================================================================
 // STEP 6: Diagnosis Report — Nemotron Ultra 253B (reasoning) + GLM-5 (safety)
 // =============================================================================
-
-function demoResponse(action: string, pet: PetProfile) {
-  if (action === "generate_report") {
-    return NextResponse.json({
-      type: "report",
-      report: {
-        severity: "high",
-        recommendation: "vet_48h",
-        title: "Demo Mode — Configure API Keys",
-        explanation: `This is demo mode. Add your NVIDIA NIM API key to enable the 4-model clinical diagnosis engine for ${pet.name}.`,
-        differential_diagnoses: [
-          {
-            condition: "Demo Mode",
-            likelihood: "high",
-            description:
-              "Configure API keys to unlock: Qwen 3.5 (extraction) → Llama 3.3 (phrasing) → Nemotron Ultra / DeepSeek V3.2 (diagnosis) → GLM-5 (safety verification).",
-          },
-        ],
-        clinical_notes: "Demo mode active.",
-        recommended_tests: [
-          { test: "CBC", reason: "Baseline", urgency: "routine" },
-        ],
-        home_care: [
-          {
-            instruction: "Monitor",
-            duration: "24h",
-            details: "Track symptoms",
-          },
-        ],
-        actions: ["Configure API keys"],
-        warning_signs: ["Any worsening"],
-        vet_questions: ["Ask about breed risks"],
-      },
-    });
-  }
-  return NextResponse.json({
-    type: "question",
-    message: `Demo mode. Add API keys for full triage. What's going on with ${pet.name}?`,
-    session: createSession(),
-    ready_for_report: false,
-  });
-}

--- a/src/lib/symptom-chat/demo-response.ts
+++ b/src/lib/symptom-chat/demo-response.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { createSession, type PetProfile } from "@/lib/triage-engine";
+
+export function demoResponse(action: "chat" | "generate_report", pet: PetProfile) {
+  if (action === "generate_report") {
+    return NextResponse.json({
+      type: "report",
+      report: {
+        severity: "high",
+        recommendation: "vet_48h",
+        title: "Demo Mode — Configure API Keys",
+        explanation: `This is demo mode. Add your NVIDIA NIM API key to enable the 4-model clinical diagnosis engine for ${pet.name}.`,
+        differential_diagnoses: [
+          {
+            condition: "Demo Mode",
+            likelihood: "high",
+            description:
+              "Configure API keys to unlock: Qwen 3.5 (extraction) → Llama 3.3 (phrasing) → Nemotron Ultra / DeepSeek V3.2 (diagnosis) → GLM-5 (safety verification).",
+          },
+        ],
+        clinical_notes: "Demo mode active.",
+        recommended_tests: [
+          { test: "CBC", reason: "Baseline", urgency: "routine" },
+        ],
+        home_care: [
+          {
+            instruction: "Monitor",
+            duration: "24h",
+            details: "Track symptoms",
+          },
+        ],
+        actions: ["Configure API keys"],
+        warning_signs: ["Any worsening"],
+        vet_questions: ["Ask about breed risks"],
+      },
+    });
+  }
+
+  return NextResponse.json({
+    type: "question",
+    message: `Demo mode. Add API keys for full triage. What's going on with ${pet.name}?`,
+    session: createSession(),
+    ready_for_report: false,
+  });
+}

--- a/tests/demo-response.test.ts
+++ b/tests/demo-response.test.ts
@@ -1,0 +1,42 @@
+import { createSession, type PetProfile } from "@/lib/triage-engine";
+import { demoResponse } from "@/lib/symptom-chat/demo-response";
+
+const PET: PetProfile = {
+  name: "Mochi",
+  breed: "Beagle",
+  age_years: 6,
+  weight: 28,
+};
+
+describe("demoResponse", () => {
+  it("returns the existing demo report payload unchanged", async () => {
+    const response = demoResponse("generate_report", PET);
+    const payload = await response.json();
+
+    expect(payload.type).toBe("report");
+    expect(payload.report).toEqual(
+      expect.objectContaining({
+        severity: "high",
+        recommendation: "vet_48h",
+        title: "Demo Mode — Configure API Keys",
+        clinical_notes: "Demo mode active.",
+        actions: ["Configure API keys"],
+        warning_signs: ["Any worsening"],
+        vet_questions: ["Ask about breed risks"],
+      })
+    );
+    expect(payload.report.explanation).toContain(PET.name);
+  });
+
+  it("returns the existing demo chat question payload with a fresh session", async () => {
+    const response = demoResponse("chat", PET);
+    const payload = await response.json();
+
+    expect(payload.type).toBe("question");
+    expect(payload.message).toBe(
+      "Demo mode. Add API keys for full triage. What's going on with Mochi?"
+    );
+    expect(payload.ready_for_report).toBe(false);
+    expect(payload.session).toEqual(createSession());
+  });
+});


### PR DESCRIPTION
## Summary
- extract the demo-mode response helper out of `src/app/api/ai/symptom-chat/route.ts`
- add focused unit coverage for demo chat and demo report payloads
- keep route orchestration and behavior unchanged

## Verification
- `npx tsc --noEmit`
- `npx eslint src/app/api/ai/symptom-chat/route.ts src/lib/symptom-chat/demo-response.ts tests/demo-response.test.ts`
- `npx jest --runInBand --runTestsByPath tests/demo-response.test.ts`
- `npx jest --runInBand --runTestsByPath tests/symptom-chat.route.test.ts`

Closes #204