### PR TITLE
VET-1222: usage limit gate extraction

### DIFF
--- a/src/app/api/ai/symptom-chat/route.ts
+++ b/src/app/api/ai/symptom-chat/route.ts
@@ -51,10 +51,6 @@ import {
   getRateLimitId,
 } from "@/lib/rate-limit";
 import {
-  evaluateSymptomCheckUsageGate,
-  getPlanFromSubscription,
-} from "@/lib/subscription-state";
-import {
   buildDeterministicCaseSummary,
   buildNarrativeSnapshot,
   ensureStructuredCaseMemory,
@@ -147,13 +143,13 @@ import {
   extractDataFromMessage,
   extractSymptomsFromKeywords,
 } from "@/lib/symptom-chat/extraction-helpers";
+import { maybeBuildUsageLimitResponse } from "@/lib/symptom-chat/usage-limit-gate";
 import {
   gateQuestionBeforePhrasing,
   phraseQuestion,
 } from "@/lib/symptom-chat/question-phrasing";
 import { demoResponse } from "@/lib/symptom-chat/demo-response";
 import { generateReport } from "@/lib/symptom-chat/report-pipeline";
-import type { SubscriptionRow } from "@/types";
 
 // =============================================================================
 // HYBRID STATE MACHINE API — 4-Model NVIDIA NIM Pipeline
@@ -174,13 +170,6 @@ import type { SubscriptionRow } from "@/types";
 // Detect which engine to use
 const useNvidia = isNvidiaConfigured();
 
-const USAGE_LIMIT_BYPASS_PATTERNS = [
-  /\b(can(?:not|'?t)\s+breathe|difficulty breathing|struggling to breathe|not breathing)\b/i,
-  /\b(vomit(?:ing|ed)? blood|blood in vomit|coughing blood|bloody diarrhea)\b/i,
-  /\b(seizure|collapsed?|collapse|unresponsive)\b/i,
-  /\b(hit by a car|car accident|distended abdomen|bloated abdomen|bloat)\b/i,
-];
-
 interface RequestBody {
   messages: { role: "user" | "assistant"; content: string }[];
   pet: PetProfile;
@@ -189,163 +178,6 @@ interface RequestBody {
   image?: string; // base64 image data (with or without data URL prefix)
   imageMeta?: ImageMeta;
   gateOverride?: boolean;
-}
-
-function hasConversationStarted(session: TriageSession | null | undefined) {
-  if (!session) {
-    return false;
-  }
-
-  return (
-    session.known_symptoms.length > 0 ||
-    session.answered_questions.length > 0 ||
-    Object.keys(session.extracted_answers ?? {}).length > 0 ||
-    Boolean(session.last_question_asked) ||
-    (session.case_memory?.turn_count ?? 0) > 0
-  );
-}
-
-function hasEmergencyUsageGateBypassSignal(
-  session: TriageSession,
-  messages: RequestBody["messages"]
-) {
-  if ((session.red_flags_triggered?.length ?? 0) > 0) {
-    return true;
-  }
-
-  const latestUserMessage =
-    [...messages].reverse().find((message) => message.role === "user")
-      ?.content ?? "";
-
-  return USAGE_LIMIT_BYPASS_PATTERNS.some((pattern) =>
-    pattern.test(latestUserMessage)
-  );
-}
-
-async function loadLatestSubscriptionForUser(
-  supabase: Awaited<ReturnType<typeof createServerSupabaseClient>>,
-  userId: string
-) {
-  const { data, error } = await supabase
-    .from("subscriptions")
-    .select("*")
-    .eq("user_id", userId)
-    .order("updated_at", { ascending: false })
-    .limit(1)
-    .maybeSingle();
-
-  if (error) {
-    throw new Error(`SUBSCRIPTION_LOOKUP_FAILED:${error.message}`);
-  }
-
-  return (data ?? null) as SubscriptionRow | null;
-}
-
-async function countMonthlySymptomChecksForUser(
-  supabase: Awaited<ReturnType<typeof createServerSupabaseClient>>,
-  userId: string
-) {
-  const { data: pets, error: petsError } = await supabase
-    .from("pets")
-    .select("id")
-    .eq("user_id", userId);
-
-  if (petsError) {
-    throw new Error(`PET_LOOKUP_FAILED:${petsError.message}`);
-  }
-
-  const petIds = (pets ?? [])
-    .map((pet) => String((pet as { id?: string }).id ?? "").trim())
-    .filter(Boolean);
-  if (petIds.length === 0) {
-    return 0;
-  }
-
-  const monthStart = new Date();
-  monthStart.setUTCDate(1);
-  monthStart.setUTCHours(0, 0, 0, 0);
-
-  const { count, error: checksError } = await supabase
-    .from("symptom_checks")
-    .select("*", { count: "exact", head: true })
-    .in("pet_id", petIds)
-    .gte("created_at", monthStart.toISOString());
-
-  if (checksError) {
-    throw new Error(`USAGE_COUNT_FAILED:${checksError.message}`);
-  }
-
-  return count ?? 0;
-}
-
-async function maybeBuildUsageLimitResponse(input: {
-  action: RequestBody["action"];
-  messages: RequestBody["messages"];
-  session: TriageSession;
-}) {
-  if (input.action !== "chat") {
-    return null;
-  }
-
-  const conversationStarted = hasConversationStarted(input.session);
-  const emergencyBypass = hasEmergencyUsageGateBypassSignal(
-    input.session,
-    input.messages
-  );
-
-  if (conversationStarted || emergencyBypass) {
-    return null;
-  }
-
-  try {
-    const supabase = await createServerSupabaseClient();
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-      return null;
-    }
-
-    const [latestSubscription, completedChecksThisMonth] = await Promise.all([
-      loadLatestSubscriptionForUser(supabase, user.id),
-      countMonthlySymptomChecksForUser(supabase, user.id),
-    ]);
-
-    const usageGate = evaluateSymptomCheckUsageGate({
-      completedChecksThisMonth,
-      conversationStarted: false,
-      isEmergency: false,
-      plan: getPlanFromSubscription(latestSubscription),
-    });
-
-    if (usageGate.allowed) {
-      return null;
-    }
-
-    return NextResponse.json(
-      {
-        type: "usage_limit",
-        code: "FREE_TIER_LIMIT_REACHED",
-        error: "Monthly free-tier limit reached",
-        message: `You've reached the free limit of ${usageGate.limit} new symptom checks this month. Upgrade to keep starting new checks, or continue any symptom conversation already in progress.`,
-        requires_upgrade: usageGate.requiresUpgrade,
-        usage_gate: {
-          limit: usageGate.limit,
-          reason: usageGate.reason,
-          remaining: usageGate.remaining,
-        },
-        ready_for_report: false,
-        conversationState: "idle",
-        session: sanitizeSessionForClient(input.session),
-      },
-      { status: 402 }
-    );
-  } catch (error) {
-    console.error("[Billing] Usage gate failed open:", error);
-    return null;
-  }
 }
 
 export async function POST(request: Request) {

--- a/src/lib/symptom-chat/usage-limit-gate.ts
+++ b/src/lib/symptom-chat/usage-limit-gate.ts
@@ -1,0 +1,187 @@
+import { NextResponse } from "next/server";
+import {
+  evaluateSymptomCheckUsageGate,
+  getPlanFromSubscription,
+  type SymptomCheckUsageGateResult,
+} from "@/lib/subscription-state";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { sanitizeSessionForClient } from "@/lib/symptom-chat/context-helpers";
+import type { TriageSession } from "@/lib/triage-engine";
+import type { SubscriptionRow } from "@/types";
+
+export type SymptomChatAction = "chat" | "generate_report";
+
+export interface SymptomChatMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+const USAGE_LIMIT_BYPASS_PATTERNS = [
+  /\b(can(?:not|'?t)\s+breathe|difficulty breathing|struggling to breathe|not breathing)\b/i,
+  /\b(vomit(?:ing|ed)? blood|blood in vomit|coughing blood|bloody diarrhea)\b/i,
+  /\b(seizure|collapsed?|collapse|unresponsive)\b/i,
+  /\b(hit by a car|car accident|distended abdomen|bloated abdomen|bloat)\b/i,
+];
+
+export function hasConversationStarted(
+  session: TriageSession | null | undefined
+) {
+  if (!session) {
+    return false;
+  }
+
+  return (
+    session.known_symptoms.length > 0 ||
+    session.answered_questions.length > 0 ||
+    Object.keys(session.extracted_answers ?? {}).length > 0 ||
+    Boolean(session.last_question_asked) ||
+    (session.case_memory?.turn_count ?? 0) > 0
+  );
+}
+
+export function hasEmergencyUsageGateBypassSignal(
+  session: TriageSession,
+  messages: SymptomChatMessage[]
+) {
+  if ((session.red_flags_triggered?.length ?? 0) > 0) {
+    return true;
+  }
+
+  const latestUserMessage =
+    [...messages].reverse().find((message) => message.role === "user")
+      ?.content ?? "";
+
+  return USAGE_LIMIT_BYPASS_PATTERNS.some((pattern) =>
+    pattern.test(latestUserMessage)
+  );
+}
+
+async function loadLatestSubscriptionForUser(
+  supabase: Awaited<ReturnType<typeof createServerSupabaseClient>>,
+  userId: string
+) {
+  const { data, error } = await supabase
+    .from("subscriptions")
+    .select("*")
+    .eq("user_id", userId)
+    .order("updated_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`SUBSCRIPTION_LOOKUP_FAILED:${error.message}`);
+  }
+
+  return (data ?? null) as SubscriptionRow | null;
+}
+
+async function countMonthlySymptomChecksForUser(
+  supabase: Awaited<ReturnType<typeof createServerSupabaseClient>>,
+  userId: string
+) {
+  const { data: pets, error: petsError } = await supabase
+    .from("pets")
+    .select("id")
+    .eq("user_id", userId);
+
+  if (petsError) {
+    throw new Error(`PET_LOOKUP_FAILED:${petsError.message}`);
+  }
+
+  const petIds = (pets ?? [])
+    .map((pet) => String((pet as { id?: string }).id ?? "").trim())
+    .filter(Boolean);
+  if (petIds.length === 0) {
+    return 0;
+  }
+
+  const monthStart = new Date();
+  monthStart.setUTCDate(1);
+  monthStart.setUTCHours(0, 0, 0, 0);
+
+  const { count, error: checksError } = await supabase
+    .from("symptom_checks")
+    .select("*", { count: "exact", head: true })
+    .in("pet_id", petIds)
+    .gte("created_at", monthStart.toISOString());
+
+  if (checksError) {
+    throw new Error(`USAGE_COUNT_FAILED:${checksError.message}`);
+  }
+
+  return count ?? 0;
+}
+
+function buildUsageLimitResponse(
+  session: TriageSession,
+  usageGate: Pick<
+    SymptomCheckUsageGateResult,
+    "limit" | "reason" | "remaining" | "requiresUpgrade"
+  >
+) {
+  return NextResponse.json(
+    {
+      type: "usage_limit",
+      code: "FREE_TIER_LIMIT_REACHED",
+      error: "Monthly free-tier limit reached",
+      message: `You've reached the free limit of ${usageGate.limit} new symptom checks this month. Upgrade to keep starting new checks, or continue any symptom conversation already in progress.`,
+      requires_upgrade: usageGate.requiresUpgrade,
+      usage_gate: {
+        limit: usageGate.limit,
+        reason: usageGate.reason,
+        remaining: usageGate.remaining,
+      },
+      ready_for_report: false,
+      conversationState: "idle",
+      session: sanitizeSessionForClient(session),
+    },
+    { status: 402 }
+  );
+}
+
+export async function maybeBuildUsageLimitResponse(input: {
+  action: SymptomChatAction;
+  messages: SymptomChatMessage[];
+  session: TriageSession;
+}) {
+  if (input.action !== "chat") {
+    return null;
+  }
+
+  if (
+    hasConversationStarted(input.session) ||
+    hasEmergencyUsageGateBypassSignal(input.session, input.messages)
+  ) {
+    return null;
+  }
+
+  try {
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return null;
+    }
+
+    const [latestSubscription, completedChecksThisMonth] = await Promise.all([
+      loadLatestSubscriptionForUser(supabase, user.id),
+      countMonthlySymptomChecksForUser(supabase, user.id),
+    ]);
+    const usageGate = evaluateSymptomCheckUsageGate({
+      completedChecksThisMonth,
+      conversationStarted: false,
+      isEmergency: false,
+      plan: getPlanFromSubscription(latestSubscription),
+    });
+
+    return usageGate.allowed
+      ? null
+      : buildUsageLimitResponse(input.session, usageGate);
+  } catch (error) {
+    console.error("[Billing] Usage gate failed open:", error);
+    return null;
+  }
+}

--- a/tests/symptom-chat.route.test.ts
+++ b/tests/symptom-chat.route.test.ts
@@ -6149,6 +6149,28 @@ describe("VET-900 comprehensive scenarios", () => {
       expect(payload.type).not.toBe("usage_limit");
       expect(mockExtractWithQwen).toHaveBeenCalled();
     });
+
+    it("bypasses the usage gate for conversations already in progress", async () => {
+      mockCreateServerSupabaseClient.mockResolvedValue(
+        buildBillingSupabase({
+          completedChecksThisMonth: 999,
+          userId: "user-1",
+        })
+      );
+
+      let activeSession = createSession();
+      activeSession = recordAnswer(activeSession, "appetite", false);
+
+      const { POST } = await import("@/app/api/ai/symptom-chat/route");
+      const response = await POST(
+        makeTextOnlyRequest(activeSession, "still not eating today")
+      );
+      const payload = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(payload.type).not.toBe("usage_limit");
+      expect(mockExtractWithQwen).toHaveBeenCalled();
+    });
   });
 
   // --- 10. Error handling ---

--- a/tests/usage-limit-gate.test.ts
+++ b/tests/usage-limit-gate.test.ts
@@ -1,0 +1,32 @@
+import { createSession, recordAnswer } from "@/lib/triage-engine";
+import {
+  hasConversationStarted,
+  hasEmergencyUsageGateBypassSignal,
+} from "@/lib/symptom-chat/usage-limit-gate";
+
+describe("usage-limit-gate helpers", () => {
+  it("detects when a conversation is already in progress", () => {
+    const untouchedSession = createSession();
+    let activeSession = createSession();
+    activeSession = recordAnswer(activeSession, "appetite", false);
+
+    expect(hasConversationStarted(undefined)).toBe(false);
+    expect(hasConversationStarted(untouchedSession)).toBe(false);
+    expect(hasConversationStarted(activeSession)).toBe(true);
+  });
+
+  it("bypasses the gate for emergency language even before extraction runs", () => {
+    const session = createSession();
+
+    expect(
+      hasEmergencyUsageGateBypassSignal(session, [
+        { role: "user", content: "My dog is struggling to breathe." },
+      ])
+    ).toBe(true);
+    expect(
+      hasEmergencyUsageGateBypassSignal(session, [
+        { role: "user", content: "My dog seems itchy today." },
+      ])
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- extract the non-clinical usage-limit preflight cluster from symptom-chat route into a dedicated helper module
- keep the billing fail-open and response contract unchanged while slimming route.ts further
- add focused regression coverage for usage-gate helpers and in-progress conversation bypasses

## Verification
- npx tsc --noEmit
- npx eslint src/app/api/ai/symptom-chat/route.ts src/lib/symptom-chat/usage-limit-gate.ts tests/usage-limit-gate.test.ts tests/symptom-chat.route.test.ts
- npx jest --runInBand --runTestsByPath tests/usage-limit-gate.test.ts tests/symptom-chat.route.test.ts