### PR TITLE
VET-1223: server identity extraction

### DIFF
--- a/src/app/api/ai/symptom-chat/route.ts
+++ b/src/app/api/ai/symptom-chat/route.ts
@@ -82,7 +82,6 @@ import {
   describeShadowModeDecision,
   getShadowModeDecision,
 } from "@/lib/sidecar-observability";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
 import {
   buildContradictionRecord,
   detectTextContradictions,
@@ -143,6 +142,7 @@ import {
   extractDataFromMessage,
   extractSymptomsFromKeywords,
 } from "@/lib/symptom-chat/extraction-helpers";
+import { resolveVerifiedUserId } from "@/lib/symptom-chat/server-identity";
 import { maybeBuildUsageLimitResponse } from "@/lib/symptom-chat/usage-limit-gate";
 import {
   gateQuestionBeforePhrasing,
@@ -253,16 +253,7 @@ export async function POST(request: Request) {
     // Resolve the authenticated user server-side so REPORT_READY / URGENCY_HIGH
     // can be emitted with a trusted userId. Falls back to null in demo mode or
     // when the session cookie is absent — emissions are skipped in that case.
-    let verifiedUserId: string | null = null;
-    try {
-      const supabase = await createServerSupabaseClient();
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      verifiedUserId = user?.id ?? null;
-    } catch {
-      // Demo mode or misconfigured Supabase — safe to continue without auth
-    }
+    const verifiedUserId = await resolveVerifiedUserId();
 
     if (action === "generate_report") {
       const reportBlockingCriticalInfo = findReportBlockingCriticalInfo(session);

--- a/src/lib/symptom-chat/server-identity.ts
+++ b/src/lib/symptom-chat/server-identity.ts
@@ -1,0 +1,13 @@
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+
+export async function resolveVerifiedUserId() {
+  try {
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    return user?.id ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/tests/server-identity.test.ts
+++ b/tests/server-identity.test.ts
@@ -1,0 +1,55 @@
+const mockCreateServerSupabaseClient = jest.fn();
+
+jest.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: (...args: unknown[]) =>
+    mockCreateServerSupabaseClient(...args),
+}));
+
+describe("server-identity", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockCreateServerSupabaseClient.mockReset();
+  });
+
+  it("returns the authenticated user id", async () => {
+    mockCreateServerSupabaseClient.mockResolvedValue({
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: { id: "user-123" } },
+        }),
+      },
+    });
+
+    const { resolveVerifiedUserId } = await import(
+      "@/lib/symptom-chat/server-identity"
+    );
+
+    await expect(resolveVerifiedUserId()).resolves.toBe("user-123");
+  });
+
+  it("returns null when no authenticated user exists", async () => {
+    mockCreateServerSupabaseClient.mockResolvedValue({
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: null },
+        }),
+      },
+    });
+
+    const { resolveVerifiedUserId } = await import(
+      "@/lib/symptom-chat/server-identity"
+    );
+
+    await expect(resolveVerifiedUserId()).resolves.toBeNull();
+  });
+
+  it("fails open to null when auth lookup throws", async () => {
+    mockCreateServerSupabaseClient.mockRejectedValue(new Error("DEMO_MODE"));
+
+    const { resolveVerifiedUserId } = await import(
+      "@/lib/symptom-chat/server-identity"
+    );
+
+    await expect(resolveVerifiedUserId()).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- extract the fail-open verified-user lookup from symptom-chat route into a dedicated helper
- keep the REPORT_READY / URGENCY_HIGH auth behavior unchanged
- add focused server-identity unit coverage alongside the existing VET-825 route regressions

## Verification
- npx tsc --noEmit
- npx eslint src/app/api/ai/symptom-chat/route.ts src/lib/symptom-chat/server-identity.ts tests/server-identity.test.ts tests/symptom-chat.route.test.ts
- npx jest --runInBand --runTestsByPath tests/server-identity.test.ts tests/symptom-chat.route.test.ts