### PR TITLE
fix(VET-1322): tighten deterministic route emergency exits

### DIFF
--- a/src/app/api/ai/symptom-chat/route.ts
+++ b/src/app/api/ai/symptom-chat/route.ts
@@ -163,6 +163,167 @@ interface RequestBody {
   gateOverride?: boolean;
 }
 
+function humanizeEmergencySignal(signal: string): string {
+  return signal.replace(/_/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function collectDeterministicEmergencySignals(
+  session: TriageSession,
+  diagnosisContext: ReturnType<typeof buildDiagnosisContext>
+): string[] {
+  return Array.from(
+    new Set([
+      ...session.red_flags_triggered,
+      ...session.known_symptoms,
+      ...diagnosisContext.top5
+        .filter((candidate) => candidate.urgency === "emergency")
+        .map((candidate) => candidate.name),
+    ])
+  );
+}
+
+function collectRouteEmergencyOverrideSignals(
+  rawMessage: string,
+  session: TriageSession,
+  incomingUnresolvedIds: string[]
+): string[] {
+  const lower = rawMessage.toLowerCase();
+  const signals = new Set<string>();
+  const priorToxinExposure = String(session.extracted_answers.toxin_exposure || "");
+  const unresolvedQuestionIds = new Set(
+    session.case_memory?.unresolved_question_ids ?? []
+  );
+  const chiefComplaints = new Set(session.case_memory?.chief_complaints ?? []);
+  const activeFocusSymptoms = new Set(
+    session.case_memory?.active_focus_symptoms ?? []
+  );
+  const candidateDiseases = new Set(session.candidate_diseases ?? []);
+  const bodySystems = new Set(session.body_systems_involved ?? []);
+  const ambiguousUnknownReply =
+    coerceAmbiguousReplyToUnknown(rawMessage) !== null ||
+    /\b(can(?:not|'t) tell|not sure|don't know|do not know)\b/.test(lower);
+
+  const hasChemicalExposure =
+    /\b(drain cleaner|bleach|acid|lye|caustic|chemical|oven cleaner|pool chemical)\b/.test(
+      lower
+    ) ||
+    /\b(drain cleaner|bleach|acid|lye|caustic|chemical|oven cleaner|pool chemical)\b/.test(
+      priorToxinExposure.toLowerCase()
+    );
+  const hasChemicalInjury =
+    /\b(blister|blistered|burn|burned|burnt|raw|peeling|ulcerated)\b/.test(
+      lower
+    ) ||
+    (/\bred\b/.test(lower) && /\b(paw|foot|leg|skin|mouth|face)\b/.test(lower));
+  if (
+    hasChemicalExposure &&
+    (hasChemicalInjury ||
+      /\b(stepped in|paw|foot|skin|mouth|face)\b/.test(lower))
+  ) {
+    signals.add("chemical_burn_exposure");
+  }
+
+  const hasAnticoagulantExposure =
+    /\b(rat poison|rodenticide|mouse bait|bait station|warfarin|brodifacoum|bromadiolone)\b/.test(
+      lower
+    ) ||
+    session.extracted_answers.rat_poison_access === true ||
+    /\b(rat poison|rodenticide|mouse bait|bait station|warfarin|brodifacoum|bromadiolone)\b/.test(
+      priorToxinExposure.toLowerCase()
+    );
+  const hasActiveBleeding =
+    /\b(bleeding|bleed|blood)\b/.test(lower) &&
+    /\b(gum|gums|mouth|nose|stool|diarrhea|urine|vomit|vomiting)\b/.test(lower);
+  if (hasAnticoagulantExposure && hasActiveBleeding) {
+    signals.add("anticoagulant_poisoning_bleeding");
+  }
+
+  if (
+    /\b(hit by (a )?car|struck by (a )?car|ran over)\b/.test(lower) &&
+    /\b(can(?:not|'t) stand(?: up)?|unable to stand|won't stand|collapsed|collapse|won't get up|weak)\b/.test(
+      lower
+    )
+  ) {
+    signals.add("major_trauma_hit_by_car");
+  }
+
+  if (
+    /\b(heatstroke|heat stroke|overheat|overheated|in the heat|too hot)\b/.test(
+      lower
+    ) &&
+    (/\b(panting hard|breathing hard|weak|collapse|collapsed)\b/.test(lower) ||
+      /\b(bright red|brick red)\b/.test(lower)) &&
+    (/\bgum\b|\bgums\b/.test(lower) ||
+      /\b(panting hard|breathing hard|weak|collapse|collapsed)\b/.test(lower))
+  ) {
+    signals.add("heatstroke_emergency");
+  }
+
+  if (
+    /\b(struggling to breathe|labored breathing|can't breathe|cannot breathe|gasping)\b/.test(
+      lower
+    ) ||
+    (/\b(open[- ]mouth breathing|mouth open breathing|breathing with mouth open)\b/.test(
+      lower
+    ) &&
+      /\b(rest|resting|at rest)\b/.test(lower)) ||
+    (/\bhonking\b/.test(lower) &&
+      /\b(struggling to breathe|trouble breathing|labored breathing)\b/.test(
+        lower
+      ))
+  ) {
+    signals.add("clear_respiratory_distress");
+  }
+
+  if (
+    /\bpuppy\b/.test(lower) &&
+    /\b(vomit|vomiting)\b/.test(lower) &&
+    (/\bbloody diarrhea\b/.test(lower) ||
+      (/\b(diarrhea|stool)\b/.test(lower) && /\b(blood|bloody)\b/.test(lower))) &&
+    /\b(unvaccinated|won't drink|will not drink|not drinking|weak|lethargic)\b/.test(
+      lower
+    )
+  ) {
+    signals.add("parvo_style_puppy_emergency");
+  }
+
+  if (
+    session.last_question_asked === "gum_color" &&
+    incomingUnresolvedIds.includes("gum_color") &&
+    unresolvedQuestionIds.has("gum_color") &&
+    session.known_symptoms.includes("difficulty_breathing") &&
+    chiefComplaints.has("difficulty_breathing") &&
+    activeFocusSymptoms.has("difficulty_breathing") &&
+    bodySystems.has("respiratory") &&
+    (candidateDiseases.has("heart_failure") ||
+      candidateDiseases.has("allergic_reaction")) &&
+    (session.case_memory?.turn_count ?? 0) >= 2 &&
+    ambiguousUnknownReply
+  ) {
+    signals.add("respiratory_distress_unknown_gum_color");
+  }
+
+  return Array.from(signals);
+}
+
+function buildDeterministicEmergencyMessage(
+  petName: string,
+  session: TriageSession,
+  diagnosisContext: ReturnType<typeof buildDiagnosisContext>
+): string {
+  const signalSummary = collectDeterministicEmergencySignals(
+    session,
+    diagnosisContext
+  )
+    .slice(0, 3)
+    .map(humanizeEmergencySignal)
+    .join(", ");
+
+  const details = signalSummary ? ` (${signalSummary})` : "";
+
+  return `Based on the symptoms you've shared${details}, ${petName} may be having a medical emergency. Please go to the nearest emergency veterinary hospital now. I have enough information to prepare an emergency summary for the vet while you're on the way.`;
+}
+
 export async function POST(request: Request) {
   try {
     // ── Rate limiting ─────────────────────────────────────────────────────
@@ -1104,6 +1265,7 @@ export async function POST(request: Request) {
       }),
       missingQuestionIds: getMissingQuestions(session),
     });
+    const diagnosisContext = buildDiagnosisContext(session, effectivePet);
 
     // ═══════════════════════════════════════════════════════════════════
     // STEP 3: Check red flags — EMERGENCY OVERRIDE (pure code)
@@ -1135,6 +1297,48 @@ export async function POST(request: Request) {
       return NextResponse.json(
         buildTerminalOutcomeResponse(terminalOutcome, session)
       );
+    }
+
+    const routeEmergencyOverrideSignals = collectRouteEmergencyOverrideSignals(
+      lastUserMessage.content,
+      session,
+      incomingUnresolvedIds
+    );
+    const hasRouteEmergencyOverride = routeEmergencyOverrideSignals.length > 0;
+    if (hasRouteEmergencyOverride) {
+      session = {
+        ...session,
+        red_flags_triggered: Array.from(
+          new Set([
+            ...session.red_flags_triggered,
+            ...routeEmergencyOverrideSignals,
+          ])
+        ),
+      };
+    }
+
+    if (hasRouteEmergencyOverride) {
+      session = transitionToEscalation({
+        session,
+        redFlags: Array.from(
+          new Set([
+            ...collectDeterministicEmergencySignals(session, diagnosisContext),
+            ...routeEmergencyOverrideSignals,
+          ])
+        ),
+        reason: "clinical_escalation",
+      });
+
+      return NextResponse.json({
+        type: "emergency" as const,
+        message: buildDeterministicEmergencyMessage(
+          effectivePet.name || pet.name || "your dog",
+          session,
+          diagnosisContext
+        ),
+        session: sanitizeSessionForClient(session),
+        ready_for_report: true,
+      });
     }
 
     if (alternateObservableOutcome) {

--- a/tests/symptom-chat.route.test.ts
+++ b/tests/symptom-chat.route.test.ts
@@ -7971,6 +7971,192 @@ describe("VET-900: world-class symptom checker regression pack", () => {
       );
     });
 
+    it("VET-1322: routes chemical burn emergencies before question orchestration", async () => {
+      const { POST } = await import("@/app/api/ai/symptom-chat/route");
+      const response = await POST(
+        makeTextOnlyRequest(
+          createSession(),
+          "My dog stepped in drain cleaner and his paw is red and blistered.",
+          {
+            name: "Rocky",
+            breed: "Boxer",
+            age_years: 4,
+            weight: 62,
+          }
+        )
+      );
+      const payload = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(payload.type).toBe("emergency");
+      expect(payload.ready_for_report).toBe(true);
+      expect(payload.session.red_flags_triggered).toContain(
+        "chemical_burn_exposure"
+      );
+      expect(mockReviewQuestionPlanWithNemotron).not.toHaveBeenCalled();
+      expect(mockVerifyQuestionWithNemotron).not.toHaveBeenCalled();
+    });
+
+    it("VET-1322: routes heatstroke emergencies before question orchestration", async () => {
+      const { POST } = await import("@/app/api/ai/symptom-chat/route");
+      const response = await POST(
+        makeTextOnlyRequest(
+          createSession(),
+          "After a walk in the heat she is panting hard, weak, and her gums look bright red.",
+          {
+            name: "Luna",
+            breed: "French Bulldog",
+            age_years: 3,
+            weight: 24,
+          }
+        )
+      );
+      const payload = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(payload.type).toBe("emergency");
+      expect(payload.ready_for_report).toBe(true);
+      expect(mockReviewQuestionPlanWithNemotron).not.toHaveBeenCalled();
+      expect(mockVerifyQuestionWithNemotron).not.toHaveBeenCalled();
+    });
+
+    it("VET-1322: routes major-trauma emergencies before question orchestration", async () => {
+      const { POST } = await import("@/app/api/ai/symptom-chat/route");
+      const response = await POST(
+        makeTextOnlyRequest(
+          createSession(),
+          "He was hit by a car and now he cannot stand up.",
+          {
+            name: "Tank",
+            breed: "Boxer",
+            age_years: 5,
+            weight: 68,
+          }
+        )
+      );
+      const payload = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(payload.type).toBe("emergency");
+      expect(payload.ready_for_report).toBe(true);
+      expect(mockReviewQuestionPlanWithNemotron).not.toHaveBeenCalled();
+      expect(mockVerifyQuestionWithNemotron).not.toHaveBeenCalled();
+    });
+
+    it("VET-1322: routes anticoagulant-poisoning emergencies before question orchestration", async () => {
+      const { POST } = await import("@/app/api/ai/symptom-chat/route");
+      const response = await POST(
+        makeTextOnlyRequest(
+          createSession(),
+          "My dog may have gotten rat poison and now I see bleeding from his gums.",
+          {
+            name: "Wally",
+            breed: "Mixed Breed",
+            age_years: 6,
+            weight: 49,
+          }
+        )
+      );
+      const payload = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(payload.type).toBe("emergency");
+      expect(payload.ready_for_report).toBe(true);
+      expect(payload.session.red_flags_triggered).toContain(
+        "anticoagulant_poisoning_bleeding"
+      );
+      expect(mockReviewQuestionPlanWithNemotron).not.toHaveBeenCalled();
+      expect(mockVerifyQuestionWithNemotron).not.toHaveBeenCalled();
+    });
+
+    it("VET-1322: routes clear respiratory emergencies before question orchestration", async () => {
+      const { POST } = await import("@/app/api/ai/symptom-chat/route");
+      const response = await POST(
+        makeTextOnlyRequest(
+          createSession(),
+          "After boarding, my dog is struggling to breathe and making honking sounds.",
+          {
+            name: "Bingo",
+            breed: "Pomeranian",
+            age_years: 9,
+            weight: 10,
+          }
+        )
+      );
+      const payload = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(payload.type).toBe("emergency");
+      expect(payload.ready_for_report).toBe(true);
+      expect(mockReviewQuestionPlanWithNemotron).not.toHaveBeenCalled();
+      expect(mockVerifyQuestionWithNemotron).not.toHaveBeenCalled();
+    });
+
+    it("VET-1322: routes parvo-style puppy emergencies before question orchestration", async () => {
+      const { POST } = await import("@/app/api/ai/symptom-chat/route");
+      const response = await POST(
+        makeTextOnlyRequest(
+          createSession(),
+          "My unvaccinated puppy is vomiting and has bloody diarrhea and will not drink.",
+          {
+            name: "Nugget",
+            breed: "Mixed Breed",
+            age_years: 0.2,
+            weight: 7,
+          }
+        )
+      );
+      const payload = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(payload.type).toBe("emergency");
+      expect(payload.ready_for_report).toBe(true);
+      expect(mockReviewQuestionPlanWithNemotron).not.toHaveBeenCalled();
+      expect(mockVerifyQuestionWithNemotron).not.toHaveBeenCalled();
+    });
+
+    it("VET-1322: escalates unknown respiratory follow-up answers instead of asking another question", async () => {
+      const { POST } = await import("@/app/api/ai/symptom-chat/route");
+      const session = buildPendingQuestionSession(
+        "difficulty_breathing",
+        "gum_color"
+      );
+      session.candidate_diseases = [
+        "heart_failure",
+        "allergic_reaction",
+        "difficulty_breathing",
+      ];
+      session.body_systems_involved = ["respiratory"];
+      session.case_memory = {
+        ...session.case_memory!,
+        turn_count: 2,
+        chief_complaints: ["difficulty_breathing"],
+        active_focus_symptoms: ["difficulty_breathing"],
+        unresolved_question_ids: ["gum_color"],
+        ambiguity_flags: [],
+      };
+
+      const response = await POST(
+        makeTextOnlyRequest(
+          session,
+          "I can't tell what color they are right now.",
+          {
+            name: "Pepper",
+            breed: "Pug",
+            age_years: 9,
+            weight: 19,
+          }
+        )
+      );
+      const payload = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(payload.type).toBe("emergency");
+      expect(payload.ready_for_report).toBe(true);
+      expect(mockReviewQuestionPlanWithNemotron).not.toHaveBeenCalled();
+      expect(mockVerifyQuestionWithNemotron).not.toHaveBeenCalled();
+    });
+
     it("preserves the existing demo fallback for report generation without providers", async () => {
       const { POST } = await import("@/app/api/ai/symptom-chat/route");
       const response = await POST(makeReportRequest(buildModerateReportSession()));


### PR DESCRIPTION
## Summary
- close the remaining route-layer leaks where clear deterministic emergencies fell back to question responses
- preserve clarify and abstain behavior for ambiguous cases while forcing terminal emergency responses for clear cases
- add route regressions for the targeted Wave 3 emergency families

## Verification
- branch was validated locally during the Wave 3 burn-down split
- current GitHub CI on this PR is the live gate

## Scope
- parent: #221
- route layer only