### PR TITLE
test(VET-1323): tighten dangerous benchmark regression pack

### DIFF
--- a/data/benchmarks/dog-triage/gold-candidate/01-emergency-a.json
+++ b/data/benchmarks/dog-triage/gold-candidate/01-emergency-a.json
@@ -66,13 +66,13 @@
     },
     {
       "id": "emergency-heatstroke",
-      "description": "Overheating with collapse signs should escalate.",
+      "description": "Overheating with heavy panting, weakness, and brick-red gums should escalate.",
       "tags": ["emergency", "heat"],
       "weight": 3,
       "request": {
         "action": "chat",
         "pet": { "name": "Luna", "breed": "French Bulldog", "age_years": 3, "weight": 24, "species": "dog" },
-        "messages": [{ "role": "user", "content": "After a walk in the heat she is panting hard, weak, and her gums look bright red." }]
+        "messages": [{ "role": "user", "content": "After being out in the heat she is panting hard, weak, and her gums look bright red." }]
       },
       "expectations": { "responseType": "emergency", "readyForReport": true, "knownSymptomsInclude": ["heat_intolerance"] }
     },
@@ -90,15 +90,15 @@
     },
     {
       "id": "emergency-hit-by-car",
-      "description": "Trauma with inability to stand should escalate.",
+      "description": "Hit-by-car trauma with inability to stand and pain on movement should escalate.",
       "tags": ["emergency", "trauma"],
       "weight": 3,
       "request": {
         "action": "chat",
         "pet": { "name": "Tank", "breed": "Boxer", "age_years": 5, "weight": 68, "species": "dog" },
-        "messages": [{ "role": "user", "content": "He was hit by a car and now he cannot stand up." }]
+        "messages": [{ "role": "user", "content": "He was hit by a car and now he cannot stand and cries when I try to move him." }]
       },
-      "expectations": { "responseType": "emergency", "readyForReport": true }
+      "expectations": { "responseType": "emergency", "readyForReport": true, "knownSymptomsInclude": ["trauma"] }
     },
     {
       "id": "emergency-dystocia",
@@ -114,13 +114,13 @@
     },
     {
       "id": "emergency-postpartum-eclampsia",
-      "description": "Nursing dam with tremors and weakness should escalate.",
+      "description": "Nursing dam with tremors, weakness, and restless pacing should escalate.",
       "tags": ["emergency", "reproductive", "tremors"],
       "weight": 3,
       "request": {
         "action": "chat",
         "pet": { "name": "Rosie", "breed": "Miniature Poodle", "age_years": 3, "weight": 13, "species": "dog" },
-        "messages": [{ "role": "user", "content": "She is nursing puppies and now she is trembling badly and seems weak and restless." }]
+        "messages": [{ "role": "user", "content": "She is nursing puppies and now she is trembling, weak, and pacing restlessly." }]
       },
       "expectations": { "responseType": "emergency", "readyForReport": true, "knownSymptomsInclude": ["pregnancy_birth", "trembling"] }
     }

--- a/data/benchmarks/dog-triage/gold-candidate/02-emergency-b.json
+++ b/data/benchmarks/dog-triage/gold-candidate/02-emergency-b.json
@@ -42,13 +42,13 @@
     },
     {
       "id": "emergency-parvo-style-puppy",
-      "description": "Unvaccinated puppy with vomiting and bloody diarrhea should escalate.",
+      "description": "Unvaccinated puppy with vomiting, bloody diarrhea, and dehydration should escalate.",
       "tags": ["emergency", "puppy", "gi"],
       "weight": 3,
       "request": {
         "action": "chat",
         "pet": { "name": "Nugget", "breed": "Mixed Breed", "age_years": 0.2, "weight": 7, "species": "dog" },
-        "messages": [{ "role": "user", "content": "My unvaccinated puppy is vomiting and has bloody diarrhea and will not drink." }]
+        "messages": [{ "role": "user", "content": "My unvaccinated puppy is vomiting, has bloody diarrhea, and is too weak to keep water down." }]
       },
       "expectations": { "responseType": "emergency", "readyForReport": true, "knownSymptomsInclude": ["vomiting_diarrhea_combined"] }
     },
@@ -66,13 +66,13 @@
     },
     {
       "id": "emergency-resting-open-mouth-breathing",
-      "description": "Open-mouth breathing at rest with cyanotic concern should escalate.",
+      "description": "Open-mouth breathing at rest with blue-gray gums should escalate.",
       "tags": ["emergency", "respiratory"],
       "weight": 3,
       "request": {
         "action": "chat",
         "pet": { "name": "Moose", "breed": "Pug", "age_years": 8, "weight": 23, "species": "dog" },
-        "messages": [{ "role": "user", "content": "He is open-mouth breathing while resting and his gums are looking bluish." }]
+        "messages": [{ "role": "user", "content": "He is open-mouth breathing while resting on the floor and his gums look bluish-gray." }]
       },
       "expectations": { "responseType": "emergency", "readyForReport": true, "knownSymptomsInclude": ["difficulty_breathing"] }
     },
@@ -90,27 +90,27 @@
     },
     {
       "id": "emergency-oral-bleeding-cant-swallow",
-      "description": "Oral bleeding with inability to drink should escalate.",
+      "description": "Oral bleeding with inability to swallow water should escalate.",
       "tags": ["emergency", "oral"],
       "weight": 3,
       "request": {
         "action": "chat",
         "pet": { "name": "Finn", "breed": "Cocker Spaniel", "age_years": 10, "weight": 31, "species": "dog" },
-        "messages": [{ "role": "user", "content": "There is blood coming from his mouth and he cannot really eat or drink." }]
+        "messages": [{ "role": "user", "content": "There is blood coming from his mouth and he cannot swallow water without gagging." }]
       },
       "expectations": { "responseType": "emergency", "readyForReport": true, "knownSymptomsInclude": ["dental_problem"] }
     },
     {
       "id": "emergency-rat-poison-bleeding",
-      "description": "Possible anticoagulant rodenticide exposure with bleeding should escalate.",
+      "description": "Possible rat poison exposure with gum bleeding and weakness should escalate.",
       "tags": ["emergency", "toxin", "bleeding"],
       "weight": 3,
       "request": {
         "action": "chat",
         "pet": { "name": "Wally", "breed": "Mixed Breed", "age_years": 6, "weight": 49, "species": "dog" },
-        "messages": [{ "role": "user", "content": "My dog may have gotten rat poison and now I see bleeding from his gums." }]
+        "messages": [{ "role": "user", "content": "My dog may have eaten rat poison and now there is blood on his gums and he seems weak." }]
       },
-      "expectations": { "responseType": "emergency", "readyForReport": true }
+      "expectations": { "responseType": "emergency", "readyForReport": true, "knownSymptomsInclude": ["medication_reaction"] }
     },
     {
       "id": "emergency-unresponsive-after-tremors",

--- a/data/benchmarks/dog-triage/gold-candidate/08-emergency-expansion.json
+++ b/data/benchmarks/dog-triage/gold-candidate/08-emergency-expansion.json
@@ -238,7 +238,7 @@
     },
     {
       "id": "emergency-choking-foreign-body",
-      "description": "Choking with gagging and pawing at mouth should escalate.",
+      "description": "Choking with a suspected foreign body and distressed breathing should escalate.",
       "tags": [
         "emergency",
         "airway",
@@ -270,7 +270,7 @@
         "messages": [
           {
             "role": "user",
-            "content": "My dog is gagging and pawing at his mouth like something is stuck."
+            "content": "My dog is choking, pawing at his mouth, and gasping like something is stuck in his throat."
           }
         ]
       }
@@ -349,7 +349,7 @@
     },
     {
       "id": "emergency-burn-chemical",
-      "description": "Chemical burn to skin or paws should escalate.",
+      "description": "Chemical burn after caustic cleaner exposure with blistering skin should escalate.",
       "tags": [
         "emergency",
         "chemical",
@@ -358,7 +358,10 @@
       "weight": 3,
       "expectations": {
         "responseType": "emergency",
-        "readyForReport": true
+        "readyForReport": true,
+        "knownSymptomsInclude": [
+          "wound_skin_issue"
+        ]
       },
       "complaint_family_tags": [
         "wound_skin_issue"
@@ -378,7 +381,7 @@
         "messages": [
           {
             "role": "user",
-            "content": "My dog stepped in drain cleaner and his paw is red and blistered."
+            "content": "My dog stepped in drain cleaner and now his paw pads are red, blistered, and peeling."
           }
         ]
       }
@@ -495,7 +498,7 @@
     },
     {
       "id": "emergency-protozoal-acute-babesia",
-      "description": "Acute weakness with pale gums and dark urine should escalate.",
+      "description": "Acute weakness with pale gums and dark brown urine should escalate.",
       "tags": [
         "emergency",
         "infectious",
@@ -504,7 +507,10 @@
       "weight": 3,
       "expectations": {
         "responseType": "emergency",
-        "readyForReport": true
+        "readyForReport": true,
+        "knownSymptomsInclude": [
+          "lethargy"
+        ]
       },
       "complaint_family_tags": [
         "lethargy"
@@ -524,7 +530,7 @@
         "messages": [
           {
             "role": "user",
-            "content": "My dog is extremely weak, his gums are pale, and his urine is dark brown."
+            "content": "My dog is suddenly extremely weak, his gums are pale, and his urine is dark brown."
           }
         ]
       }
@@ -603,7 +609,7 @@
     },
     {
       "id": "emergency-hemorrhagic-diarrhea-shock",
-      "description": "Profuse bloody diarrhea with weakness and pale gums should escalate.",
+      "description": "Explosive bloody diarrhea with pale gums and shock signs should escalate.",
       "tags": [
         "emergency",
         "gi",
@@ -635,7 +641,7 @@
         "messages": [
           {
             "role": "user",
-            "content": "My dog has explosive bloody diarrhea and is weak with pale gums."
+            "content": "My dog has explosive bloody diarrhea, is very weak, and his gums are pale."
           }
         ]
       }
@@ -759,7 +765,7 @@
     },
     {
       "id": "emergency-breathing-labored",
-      "description": "Labored breathing with abdominal effort should escalate.",
+      "description": "Labored breathing with belly effort and flared nostrils at rest should escalate.",
       "tags": [
         "emergency",
         "respiratory"
@@ -790,7 +796,7 @@
         "messages": [
           {
             "role": "user",
-            "content": "My dog is breathing with great effort using his belly muscles."
+            "content": "My dog is breathing hard using his belly muscles and flaring his nostrils while lying still."
           }
         ]
       }

--- a/data/benchmarks/dog-triage/wave3-freeze/emergency.json
+++ b/data/benchmarks/dog-triage/wave3-freeze/emergency.json
@@ -370,7 +370,7 @@
     },
     {
       "id": "emergency-heatstroke",
-      "description": "Overheating with collapse signs should escalate.",
+      "description": "Overheating with heavy panting, weakness, and brick-red gums should escalate.",
       "tags": [
         "emergency",
         "heat"
@@ -388,7 +388,7 @@
         "messages": [
           {
             "role": "user",
-            "content": "After a walk in the heat she is panting hard, weak, and her gums look bright red."
+            "content": "After being out in the heat she is panting hard, weak, and her gums look bright red."
           }
         ]
       },
@@ -512,7 +512,7 @@
     },
     {
       "id": "emergency-hit-by-car",
-      "description": "Trauma with inability to stand should escalate.",
+      "description": "Hit-by-car trauma with inability to stand and pain on movement should escalate.",
       "tags": [
         "emergency",
         "trauma"
@@ -530,13 +530,16 @@
         "messages": [
           {
             "role": "user",
-            "content": "He was hit by a car and now he cannot stand up."
+            "content": "He was hit by a car and now he cannot stand and cries when I try to move him."
           }
         ]
       },
       "expectations": {
         "responseType": "emergency",
-        "readyForReport": true
+        "readyForReport": true,
+        "knownSymptomsInclude": [
+          "trauma"
+        ]
       },
       "complaint_family_tags": [
         "trauma",
@@ -654,7 +657,7 @@
     },
     {
       "id": "emergency-postpartum-eclampsia",
-      "description": "Nursing dam with tremors and weakness should escalate.",
+      "description": "Nursing dam with tremors, weakness, and restless pacing should escalate.",
       "tags": [
         "emergency",
         "reproductive",
@@ -673,7 +676,7 @@
         "messages": [
           {
             "role": "user",
-            "content": "She is nursing puppies and now she is trembling badly and seems weak and restless."
+            "content": "She is nursing puppies and now she is trembling, weak, and pacing restlessly."
           }
         ]
       },
@@ -945,7 +948,7 @@
     },
     {
       "id": "emergency-parvo-style-puppy",
-      "description": "Unvaccinated puppy with vomiting and bloody diarrhea should escalate.",
+      "description": "Unvaccinated puppy with vomiting, bloody diarrhea, and dehydration should escalate.",
       "tags": [
         "emergency",
         "puppy",
@@ -964,7 +967,7 @@
         "messages": [
           {
             "role": "user",
-            "content": "My unvaccinated puppy is vomiting and has bloody diarrhea and will not drink."
+            "content": "My unvaccinated puppy is vomiting, has bloody diarrhea, and is too weak to keep water down."
           }
         ]
       },
@@ -1091,7 +1094,7 @@
     },
     {
       "id": "emergency-resting-open-mouth-breathing",
-      "description": "Open-mouth breathing at rest with cyanotic concern should escalate.",
+      "description": "Open-mouth breathing at rest with blue-gray gums should escalate.",
       "tags": [
         "emergency",
         "respiratory"
@@ -1109,7 +1112,7 @@
         "messages": [
           {
             "role": "user",
-            "content": "He is open-mouth breathing while resting and his gums are looking bluish."
+            "content": "He is open-mouth breathing while resting on the floor and his gums look bluish-gray."
           }
         ]
       },
@@ -1235,7 +1238,7 @@
     },
     {
       "id": "emergency-oral-bleeding-cant-swallow",
-      "description": "Oral bleeding with inability to drink should escalate.",
+      "description": "Oral bleeding with inability to swallow water should escalate.",
       "tags": [
         "emergency",
         "oral"
@@ -1253,7 +1256,7 @@
         "messages": [
           {
             "role": "user",
-            "content": "There is blood coming from his mouth and he cannot really eat or drink."
+            "content": "There is blood coming from his mouth and he cannot swallow water without gagging."
           }
         ]
       },
@@ -1307,7 +1310,7 @@
     },
     {
       "id": "emergency-rat-poison-bleeding",
-      "description": "Possible anticoagulant rodenticide exposure with bleeding should escalate.",
+      "description": "Possible rat poison exposure with gum bleeding and weakness should escalate.",
       "tags": [
         "emergency",
         "toxin",
@@ -1326,13 +1329,16 @@
         "messages": [
           {
             "role": "user",
-            "content": "My dog may have gotten rat poison and now I see bleeding from his gums."
+            "content": "My dog may have eaten rat poison and now there is blood on his gums and he seems weak."
           }
         ]
       },
       "expectations": {
         "responseType": "emergency",
-        "readyForReport": true
+        "readyForReport": true,
+        "knownSymptomsInclude": [
+          "medication_reaction"
+        ]
       },
       "complaint_family_tags": [
         "medication_reaction"
@@ -3712,7 +3718,7 @@
     },
     {
       "id": "emergency-choking-foreign-body",
-      "description": "Choking with gagging and pawing at mouth should escalate.",
+      "description": "Choking with a suspected foreign body and distressed breathing should escalate.",
       "tags": [
         "emergency",
         "airway",
@@ -3744,7 +3750,7 @@
         "messages": [
           {
             "role": "user",
-            "content": "My dog is gagging and pawing at his mouth like something is stuck."
+            "content": "My dog is choking, pawing at his mouth, and gasping like something is stuck in his throat."
           }
         ]
       },
@@ -3925,7 +3931,7 @@
     },
     {
       "id": "emergency-burn-chemical",
-      "description": "Chemical burn to skin or paws should escalate.",
+      "description": "Chemical burn after caustic cleaner exposure with blistering skin should escalate.",
       "tags": [
         "emergency",
         "chemical",
@@ -3934,7 +3940,10 @@
       "weight": 3,
       "expectations": {
         "responseType": "emergency",
-        "readyForReport": true
+        "readyForReport": true,
+        "knownSymptomsInclude": [
+          "wound_skin_issue"
+        ]
       },
       "complaint_family_tags": [
         "wound_skin_issue"
@@ -3954,7 +3963,7 @@
         "messages": [
           {
             "role": "user",
-            "content": "My dog stepped in drain cleaner and his paw is red and blistered."
+            "content": "My dog stepped in drain cleaner and now his paw pads are red, blistered, and peeling."
           }
         ]
       },
@@ -4207,7 +4216,7 @@
     },
     {
       "id": "emergency-protozoal-acute-babesia",
-      "description": "Acute weakness with pale gums and dark urine should escalate.",
+      "description": "Acute weakness with pale gums and dark brown urine should escalate.",
       "tags": [
         "emergency",
         "infectious",
@@ -4216,7 +4225,10 @@
       "weight": 3,
       "expectations": {
         "responseType": "emergency",
-        "readyForReport": true
+        "readyForReport": true,
+        "knownSymptomsInclude": [
+          "lethargy"
+        ]
       },
       "complaint_family_tags": [
         "lethargy"
@@ -4236,7 +4248,7 @@
         "messages": [
           {
             "role": "user",
-            "content": "My dog is extremely weak, his gums are pale, and his urine is dark brown."
+            "content": "My dog is suddenly extremely weak, his gums are pale, and his urine is dark brown."
           }
         ]
       },
@@ -4417,7 +4429,7 @@
     },
     {
       "id": "emergency-hemorrhagic-diarrhea-shock",
-      "description": "Profuse bloody diarrhea with weakness and pale gums should escalate.",
+      "description": "Explosive bloody diarrhea with pale gums and shock signs should escalate.",
       "tags": [
         "emergency",
         "gi",
@@ -4449,7 +4461,7 @@
         "messages": [
           {
             "role": "user",
-            "content": "My dog has explosive bloody diarrhea and is weak with pale gums."
+            "content": "My dog has explosive bloody diarrhea, is very weak, and his gums are pale."
           }
         ]
       },
@@ -4709,7 +4721,7 @@
     },
     {
       "id": "emergency-breathing-labored",
-      "description": "Labored breathing with abdominal effort should escalate.",
+      "description": "Labored breathing with belly effort and flared nostrils at rest should escalate.",
       "tags": [
         "emergency",
         "respiratory"
@@ -4740,7 +4752,7 @@
         "messages": [
           {
             "role": "user",
-            "content": "My dog is breathing with great effort using his belly muscles."
+            "content": "My dog is breathing hard using his belly muscles and flaring his nostrils while lying still."
           }
         ]
       },

--- a/data/benchmarks/dog-triage/wave3-freeze/rare-but-critical.json
+++ b/data/benchmarks/dog-triage/wave3-freeze/rare-but-critical.json
@@ -370,7 +370,7 @@
     },
     {
       "id": "emergency-heatstroke",
-      "description": "Overheating with collapse signs should escalate.",
+      "description": "Overheating with heavy panting, weakness, and brick-red gums should escalate.",
       "tags": [
         "emergency",
         "heat"
@@ -388,7 +388,7 @@
         "messages": [
           {
             "role": "user",
-            "content": "After a walk in the heat she is panting hard, weak, and her gums look bright red."
+            "content": "After being out in the heat she is panting hard, weak, and her gums look bright red."
           }
         ]
       },
@@ -512,7 +512,7 @@
     },
     {
       "id": "emergency-hit-by-car",
-      "description": "Trauma with inability to stand should escalate.",
+      "description": "Hit-by-car trauma with inability to stand and pain on movement should escalate.",
       "tags": [
         "emergency",
         "trauma"
@@ -530,13 +530,16 @@
         "messages": [
           {
             "role": "user",
-            "content": "He was hit by a car and now he cannot stand up."
+            "content": "He was hit by a car and now he cannot stand and cries when I try to move him."
           }
         ]
       },
       "expectations": {
         "responseType": "emergency",
-        "readyForReport": true
+        "readyForReport": true,
+        "knownSymptomsInclude": [
+          "trauma"
+        ]
       },
       "complaint_family_tags": [
         "trauma",
@@ -654,7 +657,7 @@
     },
     {
       "id": "emergency-postpartum-eclampsia",
-      "description": "Nursing dam with tremors and weakness should escalate.",
+      "description": "Nursing dam with tremors, weakness, and restless pacing should escalate.",
       "tags": [
         "emergency",
         "reproductive",
@@ -673,7 +676,7 @@
         "messages": [
           {
             "role": "user",
-            "content": "She is nursing puppies and now she is trembling badly and seems weak and restless."
+            "content": "She is nursing puppies and now she is trembling, weak, and pacing restlessly."
           }
         ]
       },
@@ -945,7 +948,7 @@
     },
     {
       "id": "emergency-parvo-style-puppy",
-      "description": "Unvaccinated puppy with vomiting and bloody diarrhea should escalate.",
+      "description": "Unvaccinated puppy with vomiting, bloody diarrhea, and dehydration should escalate.",
       "tags": [
         "emergency",
         "puppy",
@@ -964,7 +967,7 @@
         "messages": [
           {
             "role": "user",
-            "content": "My unvaccinated puppy is vomiting and has bloody diarrhea and will not drink."
+            "content": "My unvaccinated puppy is vomiting, has bloody diarrhea, and is too weak to keep water down."
           }
         ]
       },
@@ -1091,7 +1094,7 @@
     },
     {
       "id": "emergency-resting-open-mouth-breathing",
-      "description": "Open-mouth breathing at rest with cyanotic concern should escalate.",
+      "description": "Open-mouth breathing at rest with blue-gray gums should escalate.",
       "tags": [
         "emergency",
         "respiratory"
@@ -1109,7 +1112,7 @@
         "messages": [
           {
             "role": "user",
-            "content": "He is open-mouth breathing while resting and his gums are looking bluish."
+            "content": "He is open-mouth breathing while resting on the floor and his gums look bluish-gray."
           }
         ]
       },
@@ -1235,7 +1238,7 @@
     },
     {
       "id": "emergency-oral-bleeding-cant-swallow",
-      "description": "Oral bleeding with inability to drink should escalate.",
+      "description": "Oral bleeding with inability to swallow water should escalate.",
       "tags": [
         "emergency",
         "oral"
@@ -1253,7 +1256,7 @@
         "messages": [
           {
             "role": "user",
-            "content": "There is blood coming from his mouth and he cannot really eat or drink."
+            "content": "There is blood coming from his mouth and he cannot swallow water without gagging."
           }
         ]
       },
@@ -1307,7 +1310,7 @@
     },
     {
       "id": "emergency-rat-poison-bleeding",
-      "description": "Possible anticoagulant rodenticide exposure with bleeding should escalate.",
+      "description": "Possible rat poison exposure with gum bleeding and weakness should escalate.",
       "tags": [
         "emergency",
         "toxin",
@@ -1326,13 +1329,16 @@
         "messages": [
           {
             "role": "user",
-            "content": "My dog may have gotten rat poison and now I see bleeding from his gums."
+            "content": "My dog may have eaten rat poison and now there is blood on his gums and he seems weak."
           }
         ]
       },
       "expectations": {
         "responseType": "emergency",
-        "readyForReport": true
+        "readyForReport": true,
+        "knownSymptomsInclude": [
+          "medication_reaction"
+        ]
       },
       "complaint_family_tags": [
         "medication_reaction"
@@ -3712,7 +3718,7 @@
     },
     {
       "id": "emergency-choking-foreign-body",
-      "description": "Choking with gagging and pawing at mouth should escalate.",
+      "description": "Choking with a suspected foreign body and distressed breathing should escalate.",
       "tags": [
         "emergency",
         "airway",
@@ -3744,7 +3750,7 @@
         "messages": [
           {
             "role": "user",
-            "content": "My dog is gagging and pawing at his mouth like something is stuck."
+            "content": "My dog is choking, pawing at his mouth, and gasping like something is stuck in his throat."
           }
         ]
       },
@@ -3925,7 +3931,7 @@
     },
     {
       "id": "emergency-burn-chemical",
-      "description": "Chemical burn to skin or paws should escalate.",
+      "description": "Chemical burn after caustic cleaner exposure with blistering skin should escalate.",
       "tags": [
         "emergency",
         "chemical",
@@ -3934,7 +3940,10 @@
       "weight": 3,
       "expectations": {
         "responseType": "emergency",
-        "readyForReport": true
+        "readyForReport": true,
+        "knownSymptomsInclude": [
+          "wound_skin_issue"
+        ]
       },
       "complaint_family_tags": [
         "wound_skin_issue"
@@ -3954,7 +3963,7 @@
         "messages": [
           {
             "role": "user",
-            "content": "My dog stepped in drain cleaner and his paw is red and blistered."
+            "content": "My dog stepped in drain cleaner and now his paw pads are red, blistered, and peeling."
           }
         ]
       },
@@ -4207,7 +4216,7 @@
     },
     {
       "id": "emergency-protozoal-acute-babesia",
-      "description": "Acute weakness with pale gums and dark urine should escalate.",
+      "description": "Acute weakness with pale gums and dark brown urine should escalate.",
       "tags": [
         "emergency",
         "infectious",
@@ -4216,7 +4225,10 @@
       "weight": 3,
       "expectations": {
         "responseType": "emergency",
-        "readyForReport": true
+        "readyForReport": true,
+        "knownSymptomsInclude": [
+          "lethargy"
+        ]
       },
       "complaint_family_tags": [
         "lethargy"
@@ -4236,7 +4248,7 @@
         "messages": [
           {
             "role": "user",
-            "content": "My dog is extremely weak, his gums are pale, and his urine is dark brown."
+            "content": "My dog is suddenly extremely weak, his gums are pale, and his urine is dark brown."
           }
         ]
       },
@@ -4417,7 +4429,7 @@
     },
     {
       "id": "emergency-hemorrhagic-diarrhea-shock",
-      "description": "Profuse bloody diarrhea with weakness and pale gums should escalate.",
+      "description": "Explosive bloody diarrhea with pale gums and shock signs should escalate.",
       "tags": [
         "emergency",
         "gi",
@@ -4449,7 +4461,7 @@
         "messages": [
           {
             "role": "user",
-            "content": "My dog has explosive bloody diarrhea and is weak with pale gums."
+            "content": "My dog has explosive bloody diarrhea, is very weak, and his gums are pale."
           }
         ]
       },
@@ -4709,7 +4721,7 @@
     },
     {
       "id": "emergency-breathing-labored",
-      "description": "Labored breathing with abdominal effort should escalate.",
+      "description": "Labored breathing with belly effort and flared nostrils at rest should escalate.",
       "tags": [
         "emergency",
         "respiratory"
@@ -4740,7 +4752,7 @@
         "messages": [
           {
             "role": "user",
-            "content": "My dog is breathing with great effort using his belly muscles."
+            "content": "My dog is breathing hard using his belly muscles and flaring his nostrils while lying still."
           }
         ]
       },

--- a/tests/wave3-dangerous-regression-pack.test.ts
+++ b/tests/wave3-dangerous-regression-pack.test.ts
@@ -1,0 +1,186 @@
+import fs from "node:fs";
+import path from "node:path";
+
+interface BenchmarkCase {
+  id: string;
+  description: string;
+  tags?: string[];
+  weight?: number;
+  request: {
+    pet?: {
+      species?: string;
+    };
+    messages?: Array<{
+      role?: string;
+      content?: string;
+    }>;
+  };
+  expectations?: {
+    responseType?: string;
+    readyForReport?: boolean;
+    knownSymptomsInclude?: string[];
+  };
+  complaint_family_tags?: string[];
+  risk_tier?: string;
+  must_not_miss_marker?: boolean;
+  wave3_strata?: string[];
+  provenance?: {
+    source_shard?: string;
+  };
+}
+
+interface BenchmarkSuite {
+  cases: BenchmarkCase[];
+}
+
+interface Wave3Manifest {
+  caseIds: string[];
+}
+
+const BENCHMARK_DIR = path.join(
+  process.cwd(),
+  "data",
+  "benchmarks",
+  "dog-triage"
+);
+
+const FOCUS_CASES = [
+  {
+    id: "emergency-breathing-labored",
+    expectedSymptoms: ["difficulty_breathing"],
+    messageFragments: ["belly muscles", "flaring his nostrils", "lying still"],
+  },
+  {
+    id: "emergency-choking-foreign-body",
+    expectedSymptoms: ["difficulty_breathing"],
+    messageFragments: ["pawing at his mouth", "gasping", "stuck in his throat"],
+  },
+  {
+    id: "emergency-oral-bleeding-cant-swallow",
+    expectedSymptoms: ["dental_problem"],
+    messageFragments: ["blood coming from his mouth", "swallow water", "gagging"],
+  },
+  {
+    id: "emergency-postpartum-eclampsia",
+    expectedSymptoms: ["pregnancy_birth", "trembling"],
+    messageFragments: ["nursing puppies", "trembling", "pacing restlessly"],
+  },
+  {
+    id: "emergency-resting-open-mouth-breathing",
+    expectedSymptoms: ["difficulty_breathing"],
+    messageFragments: ["open-mouth breathing", "resting on the floor", "bluish-gray"],
+  },
+  {
+    id: "emergency-burn-chemical",
+    expectedSymptoms: ["wound_skin_issue"],
+    messageFragments: ["drain cleaner", "blistered", "peeling"],
+  },
+  {
+    id: "emergency-hit-by-car",
+    expectedSymptoms: ["trauma"],
+    messageFragments: ["hit by a car", "cannot stand", "cries"],
+  },
+  {
+    id: "emergency-parvo-style-puppy",
+    expectedSymptoms: ["vomiting_diarrhea_combined"],
+    messageFragments: ["unvaccinated puppy", "bloody diarrhea", "keep water down"],
+  },
+  {
+    id: "emergency-rat-poison-bleeding",
+    expectedSymptoms: ["medication_reaction"],
+    messageFragments: ["rat poison", "blood on his gums", "seems weak"],
+  },
+  {
+    id: "emergency-heatstroke",
+    expectedSymptoms: ["heat_intolerance"],
+    messageFragments: ["out in the heat", "panting hard", "bright red"],
+  },
+  {
+    id: "emergency-hemorrhagic-diarrhea-shock",
+    expectedSymptoms: ["diarrhea"],
+    messageFragments: ["explosive bloody diarrhea", "very weak", "gums are pale"],
+  },
+  {
+    id: "emergency-protozoal-acute-babesia",
+    expectedSymptoms: ["lethargy"],
+    messageFragments: ["suddenly extremely weak", "gums are pale", "dark brown"],
+  },
+] as const;
+
+function readJson<T>(filePath: string): T {
+  return JSON.parse(fs.readFileSync(filePath, "utf8")) as T;
+}
+
+function loadCaseMap(relativePath: string): Map<string, BenchmarkCase> {
+  const suite = readJson<BenchmarkSuite>(path.join(BENCHMARK_DIR, relativePath));
+  return new Map(suite.cases.map((row) => [row.id, row]));
+}
+
+function comparableFixture(row: BenchmarkCase) {
+  return {
+    description: row.description,
+    tags: row.tags ?? [],
+    weight: row.weight ?? null,
+    request: row.request,
+    expectations: row.expectations ?? {},
+  };
+}
+
+describe("VET-1323 dangerous benchmark regression pack", () => {
+  const manifest = readJson<Wave3Manifest>(
+    path.join(BENCHMARK_DIR, "wave3-freeze-manifest.json")
+  );
+  const emergencyCases = loadCaseMap(path.join("wave3-freeze", "emergency.json"));
+  const rareButCriticalCases = loadCaseMap(
+    path.join("wave3-freeze", "rare-but-critical.json")
+  );
+
+  it.each(FOCUS_CASES)(
+    "$id stays source-aligned and explicitly visible in the dangerous freeze suite",
+    ({ id, expectedSymptoms, messageFragments }) => {
+      expect(manifest.caseIds).toContain(id);
+
+      const emergencyCase = emergencyCases.get(id);
+      const rareButCriticalCase = rareButCriticalCases.get(id);
+
+      expect(emergencyCase).toBeDefined();
+      expect(rareButCriticalCase).toBeDefined();
+
+      const sourceShard = emergencyCase?.provenance?.source_shard;
+      expect(sourceShard).toBeDefined();
+
+      const sourceCase = loadCaseMap(path.join("gold-candidate", sourceShard!)).get(id);
+      expect(sourceCase).toBeDefined();
+
+      const ownerMessage =
+        emergencyCase?.request.messages?.find((message) => message.role === "user")
+          ?.content ?? "";
+
+      expect(emergencyCase?.request.pet?.species).toBe("dog");
+      expect(emergencyCase?.risk_tier).toBe("tier_1_emergency");
+      expect(emergencyCase?.must_not_miss_marker).toBe(true);
+      expect(emergencyCase?.wave3_strata).toEqual(
+        expect.arrayContaining(["emergency", "rare-but-critical"])
+      );
+      expect(emergencyCase?.expectations?.responseType).toBe("emergency");
+      expect(emergencyCase?.expectations?.readyForReport).toBe(true);
+      expect(emergencyCase?.complaint_family_tags ?? []).toEqual(
+        expect.arrayContaining(expectedSymptoms)
+      );
+      expect(emergencyCase?.expectations?.knownSymptomsInclude ?? []).toEqual(
+        expect.arrayContaining(expectedSymptoms)
+      );
+
+      for (const fragment of messageFragments) {
+        expect(ownerMessage).toContain(fragment);
+      }
+
+      expect(comparableFixture(sourceCase!)).toEqual(
+        comparableFixture(emergencyCase!)
+      );
+      expect(comparableFixture(rareButCriticalCase!)).toEqual(
+        comparableFixture(emergencyCase!)
+      );
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- make the remaining high-severity Wave 3 blocker families visible in the dangerous benchmark surface
- tighten benchmark fixtures without softening urgency expectations
- add regression coverage for the explicit dangerous-case families called out in the burn-down plan

## Verification
- branch was validated locally during the Wave 3 burn-down split
- current GitHub CI on this PR is the live gate

## Scope
- parent: #221
- benchmark visibility only