### PR TITLE
fix(VET-1337): tighten triage-engine emergency flooring guardrails

### DIFF
--- a/src/lib/triage-engine.ts
+++ b/src/lib/triage-engine.ts
@@ -605,6 +605,14 @@ function getCompositeEmergencyRedFlags(session: TriageSession): string[] {
     }
   }
 
+  if (
+    session.known_symptoms.includes("vomiting") &&
+    answers.appetite_status === "none" &&
+    answers.water_intake === "not_drinking"
+  ) {
+    flags.add("vomiting_not_drinking");
+  }
+
   return [...flags];
 }
 
@@ -947,6 +955,9 @@ export function buildDiagnosisContext(
 } {
   const probs = calculateProbabilities(session, pet);
   const top5 = probs.slice(0, 5);
+  const compositeRedFlags = getCompositeEmergencyRedFlags(session);
+  const hasEmergencyFlooringEvidence =
+    session.red_flags_triggered.length > 0 || compositeRedFlags.length > 0;
 
   // Build breed risk summary
   const breedMods = getBreedModifiers(pet.breed);
@@ -988,13 +999,12 @@ export function buildDiagnosisContext(
     }
   }
 
-  // Red flags override urgency
-  if (session.red_flags_triggered.length > 0) {
+  if (hasEmergencyFlooringEvidence) {
     highestUrgency = "emergency";
-  }
-
-  if (getCompositeEmergencyRedFlags(session).length > 0) {
-    highestUrgency = "emergency";
+  } else if (highestUrgency === "emergency") {
+    // Prevent mild lookalikes from auto-upgrading when they only inherit an
+    // emergency candidate disease without matching emergency evidence.
+    highestUrgency = "high";
   }
 
   return {

--- a/tests/triage-engine.emergency-flooring.test.ts
+++ b/tests/triage-engine.emergency-flooring.test.ts
@@ -1,0 +1,153 @@
+import {
+  addSymptoms,
+  buildDiagnosisContext,
+  createSession,
+  recordAnswer,
+  type PetProfile,
+  type TriageSession,
+} from "@/lib/triage-engine";
+
+const mixedBreedAdult: PetProfile = {
+  name: "Scout",
+  breed: "Mixed Breed",
+  age_years: 4,
+  weight: 42,
+};
+
+function buildSession(
+  symptoms: string[],
+  answers: Record<string, string | boolean | number>
+): TriageSession {
+  let session = createSession();
+  session = addSymptoms(session, symptoms);
+
+  for (const [questionId, value] of Object.entries(answers)) {
+    session = recordAnswer(session, questionId, value);
+  }
+
+  return session;
+}
+
+describe("VET-1337 engine emergency flooring sentinels", () => {
+  it.each([
+    {
+      label: "postpartum eclampsia",
+      symptoms: ["pregnancy_birth", "trembling"],
+      answers: { eclampsia_signs: true },
+      expectedFlags: ["eclampsia_signs"],
+    },
+    {
+      label: "protozoal/Babesia-style weakness",
+      symptoms: ["lethargy"],
+      answers: { gum_color: "pale_white", blood_in_urine: true },
+      expectedFlags: ["pale_gums"],
+    },
+    {
+      label: "urinary blockage",
+      symptoms: ["urination_problem"],
+      answers: { urinary_blockage: true },
+      expectedFlags: ["urinary_blockage"],
+    },
+    {
+      label: "vomiting blood with collapse",
+      symptoms: ["vomiting"],
+      answers: {
+        vomit_blood: true,
+        gum_color: "pale_white",
+        consciousness_level: "unresponsive",
+      },
+      expectedFlags: ["vomit_blood"],
+    },
+    {
+      label: "repeated green vomiting with dehydration signals",
+      symptoms: ["vomiting"],
+      answers: {
+        vomit_frequency: "repeated",
+        appetite_status: "none",
+        water_intake: "not_drinking",
+      },
+      expectedFlags: ["vomiting_not_drinking"],
+    },
+    {
+      label: "deep avulsion wound",
+      symptoms: ["wound_skin_issue"],
+      answers: { wound_deep_bleeding: true },
+      expectedFlags: ["wound_deep_bleeding"],
+    },
+  ])("keeps $label at emergency", ({ symptoms, answers, expectedFlags }) => {
+    const session = buildSession(symptoms, answers);
+    const context = buildDiagnosisContext(session, mixedBreedAdult);
+
+    expect(session.red_flags_triggered).toEqual(
+      expect.arrayContaining(expectedFlags)
+    );
+    expect(context.highest_urgency).toBe("emergency");
+  });
+});
+
+describe("VET-1337 engine false-positive guardrails", () => {
+  it.each([
+    {
+      label: "nursing dog acting normal",
+      symptoms: ["pregnancy_birth"],
+      answers: {
+        puppies_delivered: 4,
+        time_since_last_puppy: "2 days ago",
+        appetite_status: "normal",
+        restlessness: false,
+      },
+    },
+    {
+      label: "tick found but dog normal",
+      symptoms: ["lethargy"],
+      answers: {
+        gum_color: "pink_normal",
+        appetite_status: "normal",
+        water_intake: "normal",
+      },
+    },
+    {
+      label: "increased urination without straining or no-urine signs",
+      symptoms: ["urination_problem"],
+      answers: {
+        urination_frequency: true,
+        straining_present: false,
+        blood_in_urine: false,
+        water_intake: "normal",
+      },
+    },
+    {
+      label: "one mild vomit with the dog bright and alert",
+      symptoms: ["vomiting"],
+      answers: {
+        vomit_frequency: "once",
+        appetite_status: "normal",
+        water_intake: "normal",
+      },
+    },
+    {
+      label: "ate grass and vomited once, then acted normal",
+      symptoms: ["vomiting"],
+      answers: {
+        vomit_frequency: "once",
+        appetite_status: "normal",
+        water_intake: "normal",
+      },
+    },
+    {
+      label: "small scrape without deep tissue exposure",
+      symptoms: ["wound_skin_issue"],
+      answers: {
+        wound_size: "small scratch",
+        wound_discharge: "none",
+        wound_color: "pink",
+      },
+    },
+  ])("does not emergency-floor $label", ({ symptoms, answers }) => {
+    const session = buildSession(symptoms, answers);
+    const context = buildDiagnosisContext(session, mixedBreedAdult);
+
+    expect(session.red_flags_triggered).toEqual([]);
+    expect(context.highest_urgency).not.toBe("emergency");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #262.

Adds engine-only emergency-flooring sentinels for the six remaining critical blocker families and patches `triage-engine.ts` only where the new tests proved a real flooring bug.

## What changed

- Added `tests/triage-engine.emergency-flooring.test.ts` with six positive sentinels:
  - postpartum eclampsia
  - protozoal/Babesia-style weakness
  - urinary blockage
  - vomiting blood with collapse
  - repeated green vomiting with dehydration signals
  - deep avulsion wound
- Added engine-layer mild-lookalike guardrails so these families do not auto-upgrade from bare emergency candidate diseases alone.
- Added a vomiting dehydration composite floor in `src/lib/triage-engine.ts` for repeated vomiting plus `appetite_status=none` and `water_intake=not_drinking`.
- Tightened `buildDiagnosisContext()` so emergency flooring requires actual red-flag/composite evidence instead of inheriting `emergency` solely from the top-five disease list.

## Scope

Engine-only lane per VET-1337:
- `src/lib/triage-engine.ts`
- `tests/triage-engine.emergency-flooring.test.ts`

No route, extraction, clinical-matrix, release-gate, Wave 4, Wave 5, or species-scope changes are included.

## Validation

- `npx jest tests/triage-engine.emergency-flooring.test.ts --runInBand --verbose` — PASS
- `npm test` — PASS
- `$env:APP_BASE_URL='http://localhost:3005'; npm run eval:benchmark:dangerous -- --skip-preflight` — FAIL (metrics stable at `92.1% / 7.89% / 6`)
- `$env:APP_BASE_URL='http://localhost:3005'; npm run eval:benchmark -- --skip-preflight` — FAIL (metrics stable at `92.1% / 2.65% / 6`)

## Engine sentinel summary

- postpartum eclampsia -> passed
- protozoal/Babesia-style weakness -> passed
- urinary blockage -> passed
- vomiting blood/collapse -> passed
- green vomiting -> patched
- deep avulsion wound -> passed

## Runtime changes

- Added `vomiting_not_drinking` as a composite engine-flooring signal.
- Prevented mild lookalikes from auto-upgrading to `emergency` when they only inherited an emergency candidate disease without matching emergency evidence.

## Benchmark note

This lane does not resolve the remaining six critical live benchmark misses on its own. After the rebased validation on stack head `da9f049`, the live benchmark still reports the same six normalization-owned blockers:

- `emergency-postpartum-eclampsia`
- `emergency-protozoal-acute-babesia`
- `emergency-urinary-blockage`
- `emergency-vomit-blood-collapse`
- `emergency-vomiting-green`
- `emergency-wound-deep-avulsion`
