### PR TITLE
fix(VET-1335): recover six critical emergency normalizations

### DIFF
--- a/src/lib/symptom-chat/answer-extraction.ts
+++ b/src/lib/symptom-chat/answer-extraction.ts
@@ -152,6 +152,8 @@ function deriveDeterministicAnswerForQuestion(
       return extractBloodColor(rawMessage);
     case "blood_amount":
       return extractBloodAmount(rawMessage);
+    case "vomit_blood":
+      return extractVomitBlood(rawMessage);
     case "rat_poison_access":
       return extractRatPoisonAccess(rawMessage);
     case "toxin_exposure":
@@ -270,6 +272,7 @@ function isRefreshableDeterministicQuestion(questionId: string): boolean {
     "consciousness_level",
     "blood_color",
     "blood_amount",
+    "vomit_blood",
     "rat_poison_access",
     "toxin_exposure",
     "trauma_mobility",
@@ -363,6 +366,7 @@ function shouldPreferDeterministicAnswer(questionId: string): boolean {
     "consciousness_level",
     "blood_color",
     "blood_amount",
+    "vomit_blood",
     "rat_poison_access",
     "toxin_exposure",
     "trauma_mobility",
@@ -591,6 +595,27 @@ function extractBloodAmount(rawMessage: string): string | null {
   }
   if (/\b(streaks|streaking|on the surface|small amount)\b/.test(lower)) {
     return "streaks";
+  }
+
+  return null;
+}
+
+function extractVomitBlood(rawMessage: string): boolean | null {
+  const lower = rawMessage.toLowerCase();
+
+  if (
+    /\b(no blood in (the )?vomit|no blood in what (he|she|they) threw up|not bloody vomit|not vomiting blood|wasn't blood|was not blood)\b/.test(
+      lower
+    )
+  ) {
+    return false;
+  }
+
+  if (
+    /\b(vomit|vomiting|throwing up|threw up|throw up)\b/.test(lower) &&
+    /\b(blood|bloody|coffee grounds?|coffee-ground)\b/.test(lower)
+  ) {
+    return true;
   }
 
   return null;

--- a/src/lib/symptom-chat/answer-extraction.ts
+++ b/src/lib/symptom-chat/answer-extraction.ts
@@ -154,6 +154,8 @@ function deriveDeterministicAnswerForQuestion(
       return extractBloodAmount(rawMessage);
     case "vomit_blood":
       return extractVomitBlood(rawMessage);
+    case "vomit_content":
+      return extractVomitContent(rawMessage);
     case "rat_poison_access":
       return extractRatPoisonAccess(rawMessage);
     case "toxin_exposure":
@@ -273,6 +275,7 @@ function isRefreshableDeterministicQuestion(questionId: string): boolean {
     "blood_color",
     "blood_amount",
     "vomit_blood",
+    "vomit_content",
     "rat_poison_access",
     "toxin_exposure",
     "trauma_mobility",
@@ -367,6 +370,7 @@ function shouldPreferDeterministicAnswer(questionId: string): boolean {
     "blood_color",
     "blood_amount",
     "vomit_blood",
+    "vomit_content",
     "rat_poison_access",
     "toxin_exposure",
     "trauma_mobility",
@@ -527,6 +531,16 @@ function extractGumColor(rawMessage: string): string | null {
 }
 
 function extractWaterIntake(rawMessage: string): string | null {
+  const lower = rawMessage.toLowerCase();
+
+  if (
+    /\b(won'?t eat or drink|will not eat or drink|not eating or drinking|won'?t drink|will not drink|not drinking|refusing water)\b/.test(
+      lower
+    )
+  ) {
+    return "not_drinking";
+  }
+
   return coerceChoiceAnswerFromIntent("water_intake", rawMessage);
 }
 
@@ -616,6 +630,19 @@ function extractVomitBlood(rawMessage: string): boolean | null {
     /\b(blood|bloody|coffee grounds?|coffee-ground)\b/.test(lower)
   ) {
     return true;
+  }
+
+  return null;
+}
+
+function extractVomitContent(rawMessage: string): string | null {
+  const lower = rawMessage.toLowerCase();
+
+  if (
+    /\b(vomit|vomiting|throwing up|threw up|throw up|heaving)\b/.test(lower) &&
+    /\b(green bile|bright green vomit|green vomit|green fluid)\b/.test(lower)
+  ) {
+    return "green bile";
   }
 
   return null;

--- a/src/lib/symptom-chat/extraction-helpers.ts
+++ b/src/lib/symptom-chat/extraction-helpers.ts
@@ -195,8 +195,6 @@ export function extractSymptomsFromKeywords(message: string): string[] {
     "chemical burn": "trauma",
     "can't pee": "urination_problem",
     "cannot pee": "urination_problem",
-    "trying to pee": "urination_problem",
-    "straining to pee": "urination_problem",
     "eye discharge": "eye_discharge",
     "goopy eye": "eye_discharge",
     "goopy eyes": "eye_discharge",
@@ -359,6 +357,23 @@ export function extractSymptomsFromKeywords(message: string): string[] {
     pushSymptom("lethargy");
   }
 
+  const hasUrinaryContext = /\b(pee|peeing|urinat|urine|squatt)\b/.test(lower);
+  const hasBlockageAttemptCue =
+    /\b(straining|trying to pee|trying to urinate|crying while trying to pee|crying when he tries to pee|repeated trips outside|keeps going outside)\b/.test(
+      lower
+    ) &&
+    !/\b(not|without|was not|wasn't)\b[^.?!]{0,24}\b(straining|crying|trying to pee|trying to urinate)\b/.test(
+      lower
+    );
+  const hasLowOutputCue =
+    /\b(almost no urine|nothing comes out|nothing has come out|no urine|only dribbles|only a few drops|few drops|barely anything)\b/.test(
+      lower
+    );
+
+  if (hasUrinaryContext && hasBlockageAttemptCue && hasLowOutputCue) {
+    pushSymptom("urination_problem");
+  }
+
   return symptoms;
 }
 
@@ -368,6 +383,17 @@ export function extractDeterministicEmergencyRedFlags(
 ): string[] {
   const lower = rawMessage.toLowerCase();
   const flags = new Set<string>();
+  const hasUrinaryBlockageAttemptCue =
+    /\b(straining|trying to pee|trying to urinate|crying while trying to pee|crying when he tries to pee|repeated trips outside|keeps going outside)\b/.test(
+      lower
+    ) &&
+    !/\b(not|without|was not|wasn't)\b[^.?!]{0,24}\b(straining|crying|trying to pee|trying to urinate)\b/.test(
+      lower
+    );
+  const hasUrinaryLowOutputCue =
+    /\b(almost no urine|nothing comes out|nothing has come out|no urine|only dribbles|only a few drops|few drops|barely anything)\b/.test(
+      lower
+    );
   const hasCyanoticGumLanguage =
     /\b(bluish?|gray|grey|purple) gums?\b/.test(lower) ||
     /\bgums? (?:look(?:ing|s|ed)?|are(?: looking)?|turned?) (bluish?|gray|grey|purple)\b/.test(
@@ -524,9 +550,17 @@ export function extractDeterministicEmergencyRedFlags(
 
   if (
     knownSymptoms.includes("urination_problem") &&
-    /\b(can'?t pee|cannot pee|trying to pee|straining to pee|nothing comes out|only dribbles|no urine)\b/.test(
-      lower
-    )
+    ((/\b(can'?t pee|cannot pee)\b/.test(lower) ||
+      ((/\b(trying to pee|straining to pee)\b/.test(lower) &&
+        !/\b(not|without|was not|wasn't)\b[^.?!]{0,24}\b(trying to pee|straining to pee)\b/.test(
+          lower
+        )) &&
+        hasUrinaryLowOutputCue) ||
+      /\b(only dribbles|no urine)\b/.test(lower)) ||
+      (hasUrinaryBlockageAttemptCue &&
+        /\b(almost no urine|nothing has come out|nothing comes out|no urine|only a few drops|few drops|barely anything)\b/.test(
+          lower
+        )))
   ) {
     flags.add("urinary_blockage");
   }

--- a/src/lib/symptom-chat/extraction-helpers.ts
+++ b/src/lib/symptom-chat/extraction-helpers.ts
@@ -339,6 +339,14 @@ export function extractSymptomsFromKeywords(message: string): string[] {
   }
 
   if (
+    /\b(flap of skin|skin hanging off|skin torn open|gaping wound|flesh visible|tissue exposed|avulsion)\b/.test(
+      lower
+    )
+  ) {
+    pushSymptom("wound_skin_issue");
+  }
+
+  if (
     /\b(heat|hot|overheat|overheated|heatstroke)\b/.test(lower) &&
     /\b(panting hard|panting heavily|bright red gums|collapse|collapsed|weak)\b/.test(
       lower
@@ -375,6 +383,14 @@ export function extractSymptomsFromKeywords(message: string): string[] {
 
   if (hasUrinaryContext && hasBlockageAttemptCue && hasLowOutputCue) {
     pushSymptom("urination_problem");
+  }
+
+  if (
+    /\b(flap of skin|skin hanging off|skin torn open|gaping wound|flesh visible|tissue exposed|avulsion)\b/.test(
+      lower
+    )
+  ) {
+    pushSymptom("wound_skin_issue");
   }
 
   return symptoms;
@@ -528,6 +544,14 @@ export function extractDeterministicEmergencyRedFlags(
 
     if (/\b(bone sticking out|bone visible)\b/.test(lower)) {
       flags.add("wound_bone_visible");
+    }
+
+    if (
+      /\b(flap of skin|skin hanging off|skin torn open|gaping wound|flesh visible|tissue exposed|avulsion)\b/.test(
+        lower
+      )
+    ) {
+      flags.add("wound_tissue_exposed");
     }
   }
 

--- a/src/lib/symptom-chat/extraction-helpers.ts
+++ b/src/lib/symptom-chat/extraction-helpers.ts
@@ -346,6 +346,19 @@ export function extractSymptomsFromKeywords(message: string): string[] {
     pushSymptom("heat_intolerance");
   }
 
+  if (
+    /\b(weak|weakness|wobbly|stumbling|lethargic)\b/.test(lower) &&
+    (/\b(pale|white) gums?\b/.test(lower) ||
+      /\bgums? (?:look(?:ing|s|ed)?|are(?: looking)?|turned?) (pale|white)\b/.test(
+        lower
+      )) &&
+    /\b(dark (?:brown|red|tea-colored) urine|urine is dark|dark urine|brown urine|red urine)\b/.test(
+      lower
+    )
+  ) {
+    pushSymptom("lethargy");
+  }
+
   return symptoms;
 }
 

--- a/src/lib/symptom-chat/extraction-helpers.ts
+++ b/src/lib/symptom-chat/extraction-helpers.ts
@@ -261,6 +261,9 @@ export function extractSymptomsFromKeywords(message: string): string[] {
 
   const mentionsVomiting =
     /\b(vomit|vomiting|throwing up|threw up|retching|heaving)\b/.test(lower);
+  if (mentionsVomiting) {
+    pushSymptom("vomiting");
+  }
   const mentionsDiarrhea =
     /\b(diarrhea|diarrhoea|bloody diarrhea|the runs)\b/.test(lower);
   if (mentionsVomiting && mentionsDiarrhea) {

--- a/src/lib/symptom-chat/extraction-helpers.ts
+++ b/src/lib/symptom-chat/extraction-helpers.ts
@@ -176,7 +176,13 @@ export function extractSymptomsFromKeywords(message: string): string[] {
     "in labor": "pregnancy_birth",
     "in labour": "pregnancy_birth",
     "giving birth": "pregnancy_birth",
+    "after giving birth": "pregnancy_birth",
+    "recently gave birth": "pregnancy_birth",
+    "after whelping": "pregnancy_birth",
     "having puppies": "pregnancy_birth",
+    "had puppies": "pregnancy_birth",
+    "nursing puppies": "pregnancy_birth",
+    postpartum: "pregnancy_birth",
     "green discharge": "pregnancy_birth",
     "stuck puppy": "pregnancy_birth",
     contractions: "pregnancy_birth",
@@ -431,7 +437,7 @@ export function extractDeterministicEmergencyRedFlags(
 
     if (
       /\b(postpartum|after giving birth|after whelping|nursing)\b/.test(lower) &&
-      /\b(tremors?|shaking|seizures?)\b/.test(lower)
+      /\b(trembling|tremors?|shaking|seizures?)\b/.test(lower)
     ) {
       flags.add("eclampsia_signs");
     }

--- a/tests/symptom-chat.extraction-critical-normalization.test.ts
+++ b/tests/symptom-chat.extraction-critical-normalization.test.ts
@@ -2,6 +2,8 @@ import {
   extractDeterministicEmergencyRedFlags,
   extractSymptomsFromKeywords,
 } from "@/lib/symptom-chat/extraction-helpers";
+import { extractDeterministicAnswersForTurn } from "@/lib/symptom-chat/answer-extraction";
+import { addSymptoms, createSession } from "@/lib/triage-engine";
 
 describe("VET-1335 critical emergency normalization", () => {
   describe("postpartum eclampsia", () => {
@@ -89,6 +91,48 @@ describe("VET-1335 critical emergency normalization", () => {
       const redFlags = extractDeterministicEmergencyRedFlags(message, symptoms);
 
       expect(redFlags).not.toContain("urinary_blockage");
+    });
+  });
+
+  describe("vomiting blood and collapse", () => {
+    it("maps 'threw up' phrasing to vomiting for the blood-collapse blocker", () => {
+      const message =
+        "My dog threw up a lot of blood and now he is weak and wobbly.";
+
+      const symptoms = extractSymptomsFromKeywords(message);
+
+      expect(symptoms).toContain("vomiting");
+    });
+
+    it("extracts vomit_blood from first-turn bleeding vomit phrasing", () => {
+      const session = addSymptoms(createSession(), ["vomiting"]);
+      const answers = extractDeterministicAnswersForTurn(
+        "My dog threw up a lot of blood and now he is weak and wobbly.",
+        session
+      );
+
+      expect(answers.vomit_blood).toBe(true);
+    });
+
+    it("does not add emergency red flags for a mild one-off red-treat lookalike", () => {
+      const message =
+        "He threw up once after eating a red treat, but now he is alert and acting normal.";
+
+      const symptoms = extractSymptomsFromKeywords(message);
+      const redFlags = extractDeterministicEmergencyRedFlags(message, symptoms);
+
+      expect(symptoms).toContain("vomiting");
+      expect(redFlags).toEqual([]);
+    });
+
+    it("does not mark red-food vomit as vomit_blood without bleeding language", () => {
+      const session = addSymptoms(createSession(), ["vomiting"]);
+      const answers = extractDeterministicAnswersForTurn(
+        "He threw up once after eating a red treat, but now he is alert and acting normal.",
+        session
+      );
+
+      expect(answers.vomit_blood).toBeUndefined();
     });
   });
 });

--- a/tests/symptom-chat.extraction-critical-normalization.test.ts
+++ b/tests/symptom-chat.extraction-critical-normalization.test.ts
@@ -1,0 +1,33 @@
+import {
+  extractDeterministicEmergencyRedFlags,
+  extractSymptomsFromKeywords,
+} from "@/lib/symptom-chat/extraction-helpers";
+
+describe("VET-1335 critical emergency normalization", () => {
+  describe("postpartum eclampsia", () => {
+    it("maps nursing postpartum tremors to pregnancy_birth with eclampsia signs", () => {
+      const message =
+        "She is nursing puppies and now she is trembling, weak, and pacing restlessly.";
+
+      const symptoms = extractSymptomsFromKeywords(message);
+      const redFlags = extractDeterministicEmergencyRedFlags(message, symptoms);
+
+      expect(symptoms).toEqual(
+        expect.arrayContaining(["pregnancy_birth", "trembling"])
+      );
+      expect(redFlags).toContain("eclampsia_signs");
+    });
+
+    it("does not turn normal postpartum recovery into eclampsia red flags", () => {
+      const message =
+        "She recently had puppies and is nursing normally, eating, and walking around fine.";
+
+      const symptoms = extractSymptomsFromKeywords(message);
+      const redFlags = extractDeterministicEmergencyRedFlags(message, symptoms);
+
+      expect(symptoms).toContain("pregnancy_birth");
+      expect(symptoms).not.toContain("trembling");
+      expect(redFlags).not.toContain("eclampsia_signs");
+    });
+  });
+});

--- a/tests/symptom-chat.extraction-critical-normalization.test.ts
+++ b/tests/symptom-chat.extraction-critical-normalization.test.ts
@@ -169,4 +169,29 @@ describe("VET-1335 critical emergency normalization", () => {
       expect(answers.vomit_content).toBeUndefined();
     });
   });
+
+  describe("deep avulsion wound", () => {
+    it("maps exposed tissue owner language to wound_skin_issue and wound_tissue_exposed", () => {
+      const message =
+        "My dog has a large flap of skin hanging off his shoulder from a fence incident.";
+
+      const symptoms = extractSymptomsFromKeywords(message);
+      const redFlags = extractDeterministicEmergencyRedFlags(message, symptoms);
+
+      expect(symptoms).toContain("wound_skin_issue");
+      expect(redFlags).toContain("wound_tissue_exposed");
+    });
+
+    it("does not mark a superficial scrape as tissue-exposed", () => {
+      const message =
+        "My dog has a small superficial scrape, the bleeding stopped quickly, and he is acting normal.";
+
+      const symptoms = extractSymptomsFromKeywords(message);
+      const redFlags = extractDeterministicEmergencyRedFlags(message, symptoms);
+
+      expect(redFlags).not.toContain("wound_tissue_exposed");
+      expect(redFlags).not.toContain("wound_deep_bleeding");
+      expect(symptoms).toContain("wound_skin_issue");
+    });
+  });
 });

--- a/tests/symptom-chat.extraction-critical-normalization.test.ts
+++ b/tests/symptom-chat.extraction-critical-normalization.test.ts
@@ -58,4 +58,37 @@ describe("VET-1335 critical emergency normalization", () => {
       expect(symptoms).not.toContain("lethargy");
     });
   });
+
+  describe("urinary blockage", () => {
+    it("maps straining with almost no urine to urination_problem and blockage red flags", () => {
+      const message =
+        "My male dog keeps squatting and straining but almost no urine is coming out.";
+
+      const symptoms = extractSymptomsFromKeywords(message);
+      const redFlags = extractDeterministicEmergencyRedFlags(message, symptoms);
+
+      expect(symptoms).toContain("urination_problem");
+      expect(redFlags).toContain("urinary_blockage");
+    });
+
+    it("does not turn normal increased urination into a blockage signal", () => {
+      const message =
+        "He peed normally each time, just more often than usual, and he does not seem painful.";
+
+      const symptoms = extractSymptomsFromKeywords(message);
+      const redFlags = extractDeterministicEmergencyRedFlags(message, symptoms);
+
+      expect(redFlags).not.toContain("urinary_blockage");
+    });
+
+    it("does not turn an indoor accident without straining into a blockage signal", () => {
+      const message =
+        "She had a small accident indoors but was not straining, crying, or trying to pee repeatedly.";
+
+      const symptoms = extractSymptomsFromKeywords(message);
+      const redFlags = extractDeterministicEmergencyRedFlags(message, symptoms);
+
+      expect(redFlags).not.toContain("urinary_blockage");
+    });
+  });
 });

--- a/tests/symptom-chat.extraction-critical-normalization.test.ts
+++ b/tests/symptom-chat.extraction-critical-normalization.test.ts
@@ -30,4 +30,32 @@ describe("VET-1335 critical emergency normalization", () => {
       expect(redFlags).not.toContain("eclampsia_signs");
     });
   });
+
+  describe("protozoal acute weakness", () => {
+    it("maps weakness with pale gums and dark urine to lethargy", () => {
+      const message =
+        "My dog is suddenly extremely weak, his gums are pale, and his urine is dark brown.";
+
+      const symptoms = extractSymptomsFromKeywords(message);
+
+      expect(symptoms).toContain("lethargy");
+    });
+
+    it("does not turn a normal tick exposure into lethargy", () => {
+      const message = "I found one tick on him, but he is acting normal and his gums look fine.";
+
+      const symptoms = extractSymptomsFromKeywords(message);
+
+      expect(symptoms).not.toContain("lethargy");
+    });
+
+    it("does not turn post-exercise tiredness with normal gums into lethargy", () => {
+      const message =
+        "He seemed tired after running, but his breathing is normal and his gums are pink.";
+
+      const symptoms = extractSymptomsFromKeywords(message);
+
+      expect(symptoms).not.toContain("lethargy");
+    });
+  });
 });

--- a/tests/symptom-chat.extraction-critical-normalization.test.ts
+++ b/tests/symptom-chat.extraction-critical-normalization.test.ts
@@ -135,4 +135,38 @@ describe("VET-1335 critical emergency normalization", () => {
       expect(answers.vomit_blood).toBeUndefined();
     });
   });
+
+  describe("green vomiting", () => {
+    it('extracts "green bile" vomit content from first-turn owner language', () => {
+      const session = addSymptoms(createSession(), ["vomiting"]);
+      const answers = extractDeterministicAnswersForTurn(
+        "My dog keeps throwing up green bile and won't eat or drink.",
+        session
+      );
+
+      expect(answers.vomit_content).toBe("green bile");
+    });
+
+    it('extracts "won\'t eat or drink" as not_drinking when water intake is the active follow-up', () => {
+      const session = addSymptoms(createSession(), ["vomiting"]);
+      session.last_question_asked = "water_intake";
+
+      const answers = extractDeterministicAnswersForTurn(
+        "My dog keeps throwing up green bile and won't eat or drink.",
+        session
+      );
+
+      expect(answers.water_intake).toBe("not_drinking");
+    });
+
+    it("does not set green bile content for a mild grass-once lookalike", () => {
+      const session = addSymptoms(createSession(), ["vomiting"]);
+      const answers = extractDeterministicAnswersForTurn(
+        "He ate grass and vomited once, but now he is acting normal and eating again.",
+        session
+      );
+
+      expect(answers.vomit_content).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the six remaining normalization-owned critical blockers on top of `codex/wave3-green-stack`.

This stays extraction-only and keeps the route, matrix, engine, benchmark expectations, release-gate tooling, Wave 4/Wave 5, and cat/species logic untouched.

## What changed

- recovers postpartum eclampsia owner language
- recovers protozoal or Babesia-style acute weakness owner language
- recovers urinary blockage owner language
- recovers vomiting blood or collapse owner language
- recovers green bile vomiting owner language
- recovers deep avulsion wound owner language
- adds positive and negative extraction regressions for every family

## Verification

- `npx jest tests/symptom-chat.extraction-critical-normalization.test.ts --runInBand --verbose` — PASS
- `npm test` — PASS
- `$env:APP_BASE_URL="http://localhost:3003"; npm run eval:benchmark:dangerous -- --skip-preflight` — PASS (`100.0% / 0.00% / 0`)
- `$env:APP_BASE_URL="http://localhost:3003"; npm run eval:benchmark -- --skip-preflight` — PASS (`100.0% / 0.00% / 0`)

## Family burn-down

- `emergency-postpartum-eclampsia` -> fixed
- `emergency-protozoal-acute-babesia` -> fixed
- `emergency-urinary-blockage` -> fixed
- `emergency-vomit-blood-collapse` -> fixed
- `emergency-vomiting-green` -> fixed
- `emergency-wound-deep-avulsion` -> fixed

## Benchmark delta

- before dangerous: `92.1% / 7.89% / 6`
- after dangerous: `100.0% / 0.00% / 0`
- after full: `100.0% / 0.00% / 0`

## Parents

- #246
- #248
- #260