### PR TITLE
fix(VET-1340): revert route stack regression after green candidate

### DIFF
--- a/src/app/api/ai/symptom-chat/route.ts
+++ b/src/app/api/ai/symptom-chat/route.ts
@@ -185,11 +185,7 @@ function collectDeterministicEmergencySignals(
 function collectRouteEmergencyOverrideSignals(
   rawMessage: string,
   session: TriageSession,
-  incomingUnresolvedIds: string[],
-  context: {
-    answersBeforeTurn: TriageSession["extracted_answers"];
-    ambiguityFlagsBeforeTurn: string[];
-  }
+  incomingUnresolvedIds: string[]
 ): string[] {
   const lower = rawMessage.toLowerCase();
   const signals = new Set<string>();
@@ -204,14 +200,9 @@ function collectRouteEmergencyOverrideSignals(
   const candidateDiseases = new Set(session.candidate_diseases ?? []);
   const bodySystems = new Set(session.body_systems_involved ?? []);
   const turnCount = session.case_memory?.turn_count ?? 0;
-  const ambiguityFlagsBeforeTurn = new Set(context.ambiguityFlagsBeforeTurn);
   const ambiguousUnknownReply =
     coerceAmbiguousReplyToUnknown(rawMessage) !== null ||
     /\b(can(?:not|'t) tell|not sure|don't know|do not know)\b/.test(lower);
-  const hadPriorUnknownAnswer = (questionId: string) =>
-    String(context.answersBeforeTurn[questionId] ?? "")
-      .trim()
-      .toLowerCase() === "unknown";
   const hasCarriedOverRespiratoryUnknown =
     turnCount >= 2 &&
     session.known_symptoms.includes("difficulty_breathing") &&
@@ -609,7 +600,7 @@ function collectRouteEmergencyOverrideSignals(
   }
 
   if (
-    hadPriorUnknownAnswer("breathing_onset") &&
+    incomingUnresolvedIds.includes("breathing_onset") &&
     hasCarriedOverRespiratoryUnknown &&
     ambiguousUnknownReply
   ) {
@@ -617,7 +608,7 @@ function collectRouteEmergencyOverrideSignals(
   }
 
   if (
-    hadPriorUnknownAnswer("breathing_pattern") &&
+    incomingUnresolvedIds.includes("breathing_pattern") &&
     hasCarriedOverRespiratoryUnknown &&
     ambiguousUnknownReply
   ) {
@@ -625,7 +616,7 @@ function collectRouteEmergencyOverrideSignals(
   }
 
   if (
-    hadPriorUnknownAnswer("consciousness_level") &&
+    incomingUnresolvedIds.includes("consciousness_level") &&
     hasCarriedOverSeizureUnknown &&
     ambiguousUnknownReply
   ) {
@@ -633,7 +624,7 @@ function collectRouteEmergencyOverrideSignals(
   }
 
   if (
-    hadPriorUnknownAnswer("seizure_duration") &&
+    incomingUnresolvedIds.includes("seizure_duration") &&
     hasCarriedOverSeizureUnknown &&
     ambiguousUnknownReply
   ) {
@@ -642,7 +633,6 @@ function collectRouteEmergencyOverrideSignals(
 
   if (
     incomingUnresolvedIds.includes("gum_color") &&
-    ambiguityFlagsBeforeTurn.has("alternate_observable_prompted_gum_color") &&
     unresolvedQuestionIds.has("gum_color") &&
     session.known_symptoms.includes("difficulty_breathing") &&
     chiefComplaints.has("difficulty_breathing") &&
@@ -733,9 +723,6 @@ export async function POST(request: Request) {
     const knownSymptomsBeforeTurn = new Set(session.known_symptoms);
     const answersBeforeTurn = { ...session.extracted_answers };
     const answerKeysBeforeTurn = new Set(Object.keys(session.extracted_answers));
-    const ambiguityFlagsBeforeTurn = [
-      ...(session.case_memory?.ambiguity_flags ?? []),
-    ];
     let imagePreprocess: VisionPreprocessResult | null = null;
     let visualEvidence: VisionClinicalEvidence | null = null;
     let consultOpinion: ConsultOpinion | null = null;
@@ -1647,11 +1634,7 @@ export async function POST(request: Request) {
     const routeEmergencyOverrideSignals = collectRouteEmergencyOverrideSignals(
       lastUserMessage.content,
       session,
-      incomingUnresolvedIds,
-      {
-        answersBeforeTurn,
-        ambiguityFlagsBeforeTurn,
-      }
+      incomingUnresolvedIds
     );
     const hasRouteEmergencyOverride = routeEmergencyOverrideSignals.length > 0;
     if (hasRouteEmergencyOverride) {

--- a/tests/symptom-chat.route.test.ts
+++ b/tests/symptom-chat.route.test.ts
@@ -7198,7 +7198,7 @@ describe("VET-900: world-class symptom checker regression pack", () => {
       );
     });
 
-    it("keeps the first high-risk respiratory gum-color unknown on the alternate-observable retry", async () => {
+    it("routes high-risk respiratory gum-color unknown replies to emergency", async () => {
       const session = buildPendingQuestionSession(
         "difficulty_breathing",
         "gum_color"
@@ -7228,86 +7228,12 @@ describe("VET-900: world-class symptom checker regression pack", () => {
       const payload = await response.json();
 
       expect(response.status).toBe(200);
-      expect(payload.type).toBe("question");
-      expect(payload.question_id).toBe("gum_color");
-      expect(payload.reason_code).toBe("alternate_observable_gum_color");
-      expect(payload.ready_for_report).toBe(false);
+      expect(payload.type).toBe("emergency");
+      expect(payload.ready_for_report).toBe(true);
+      expect(payload.session.red_flags_triggered).toContain(
+        "respiratory_distress_unknown_gum_color"
+      );
     });
-
-    it.each([
-      {
-        symptom: "difficulty_breathing",
-        questionId: "breathing_onset",
-        ownerReply: "I don't know, I just found him like this.",
-        candidateDiseases: [
-          "heart_failure",
-          "allergic_reaction",
-          "difficulty_breathing",
-        ],
-        bodySystems: ["respiratory"],
-      },
-      {
-        symptom: "difficulty_breathing",
-        questionId: "breathing_pattern",
-        ownerReply: "I can't describe how he's breathing, he just seems off.",
-        candidateDiseases: [
-          "heart_failure",
-          "allergic_reaction",
-          "difficulty_breathing",
-        ],
-        bodySystems: ["respiratory"],
-      },
-      {
-        symptom: "seizure_collapse",
-        questionId: "consciousness_level",
-        ownerReply: "I don't know if he's fully aware right now.",
-        candidateDiseases: ["seizure_disorder", "toxin_exposure", "heatstroke"],
-        bodySystems: ["neurologic"],
-      },
-      {
-        symptom: "seizure_collapse",
-        questionId: "seizure_duration",
-        ownerReply: "I don't know how long it lasted, it felt like forever.",
-        candidateDiseases: ["seizure_disorder", "toxin_exposure", "brain_tumor"],
-        bodySystems: ["neurologic"],
-      },
-    ])(
-      "keeps direct tier-1 unknown follow-ups on cannot_assess for $questionId",
-      async ({
-        symptom,
-        questionId,
-        ownerReply,
-        candidateDiseases,
-        bodySystems,
-      }) => {
-        const session = buildPendingQuestionSession(symptom, questionId);
-        session.candidate_diseases = candidateDiseases;
-        session.body_systems_involved = bodySystems;
-        session.case_memory = {
-          ...session.case_memory!,
-          turn_count: 2,
-          chief_complaints: [symptom],
-          active_focus_symptoms: [symptom],
-          unresolved_question_ids: [questionId],
-        };
-
-        mockExtractWithQwen.mockResolvedValueOnce(
-          JSON.stringify({ symptoms: [symptom], answers: {} })
-        );
-
-        const { POST } = await import("@/app/api/ai/symptom-chat/route");
-        const response = await POST(makeTextOnlyRequest(session, ownerReply));
-        const payload = await response.json();
-
-        expect(response.status).toBe(200);
-        expect(payload.type).toBe("cannot_assess");
-        expect(payload.terminal_state).toBe("cannot_assess");
-        expect(payload.reason_code).toBe(
-          `owner_cannot_assess_${questionId}`
-        );
-        expect(payload.ready_for_report).toBe(false);
-      }
-    );
 
     it.each([
       {
@@ -7401,8 +7327,7 @@ describe("VET-900: world-class symptom checker regression pack", () => {
         bodySystems,
         redFlag,
       }) => {
-        let session = buildPendingQuestionSession(symptom, questionId);
-        session = recordAnswer(session, questionId, "unknown");
+        const session = buildPendingQuestionSession(symptom, questionId);
         session.candidate_diseases = candidateDiseases;
         session.body_systems_involved = bodySystems;
         session.case_memory = {
@@ -7410,7 +7335,7 @@ describe("VET-900: world-class symptom checker regression pack", () => {
           turn_count: 2,
           chief_complaints: [symptom],
           active_focus_symptoms: [symptom],
-          unresolved_question_ids: [],
+          unresolved_question_ids: [questionId],
         };
 
         mockExtractWithQwen.mockResolvedValueOnce(
@@ -7429,11 +7354,10 @@ describe("VET-900: world-class symptom checker regression pack", () => {
     );
 
     it("does not over-escalate carried-over seizure follow-ups when the dog is clearly normal now", async () => {
-      let session = buildPendingQuestionSession(
+      const session = buildPendingQuestionSession(
         "seizure_collapse",
         "consciousness_level"
       );
-      session = recordAnswer(session, "consciousness_level", "unknown");
       session.candidate_diseases = [
         "seizure_disorder",
         "toxin_exposure",
@@ -7445,7 +7369,7 @@ describe("VET-900: world-class symptom checker regression pack", () => {
         turn_count: 2,
         chief_complaints: ["seizure_collapse"],
         active_focus_symptoms: ["seizure_collapse"],
-        unresolved_question_ids: [],
+        unresolved_question_ids: ["consciousness_level"],
       };
 
       mockExtractWithQwen.mockResolvedValueOnce(
@@ -8458,7 +8382,7 @@ describe("VET-900: world-class symptom checker regression pack", () => {
       }
     );
 
-    it("VET-1327: escalates high-risk gum-color unknown follow-up answers to emergency after the alternate-observable retry was already offered", async () => {
+    it("VET-1327: escalates high-risk gum-color unknown follow-up answers to emergency", async () => {
       const { POST } = await import("@/app/api/ai/symptom-chat/route");
       const session = buildPendingQuestionSession(
         "difficulty_breathing",
@@ -8476,7 +8400,7 @@ describe("VET-900: world-class symptom checker regression pack", () => {
         chief_complaints: ["difficulty_breathing"],
         active_focus_symptoms: ["difficulty_breathing"],
         unresolved_question_ids: ["gum_color"],
-        ambiguity_flags: ["alternate_observable_prompted_gum_color"],
+        ambiguity_flags: [],
       };
 
       const response = await POST(


### PR DESCRIPTION
## Summary

Reverts stack-only route commit `bcbf9d9`, which regressed the Wave 3 green-stack after the stack had already reached a green candidate state at `6973b85`.

## Why

Clean benchmark comparison showed:

- stack tip `6973b85` -> dangerous `100.0% / 0.00% / 0`, full `100.0% / 0.00% / 0`
- later stack tip `bcbf9d9` -> dangerous `93.4% / 6.58% / 5`, full `93.4% / 2.21% / 5`

`bcbf9d9` was route-only and narrowed unknown carryover override behavior. The regression is route-owned, not extraction-owned.

## What changed

- Reverts `bcbf9d9`
- Restores the stack to the prior green route behavior
- Leaves VET-1335 extraction recovery intact

## Validation

- `npx jest tests/symptom-chat.route.test.ts --runInBand --verbose` — PASS
- `npm test` — PASS
- `APP_BASE_URL=http://localhost:3008 npm run eval:benchmark:dangerous -- --skip-preflight` — PASS (`100.0% / 0.00% / 0`)
- `APP_BASE_URL=http://localhost:3008 npm run eval:benchmark -- --skip-preflight` — PASS (`100.0% / 0.00% / 0`)
- `npm run eval:benchmark:release-gate` — FAIL (`6 blocking failure(s) still hit rare-but-critical or must-not-miss cases`)

## Scope

No extraction, matrix, engine, benchmark expectation, Wave 4, Wave 5, or cat/species changes.