### PR TITLE
VET-1357: cover rate-limit fallback abuse and spoofed identity

### DIFF
--- a/scripts/backfill-outcome-feedback.ts
+++ b/scripts/backfill-outcome-feedback.ts
@@ -7,6 +7,7 @@ import { randomUUID } from "node:crypto";
 import { Pool } from "pg";
 import { buildThresholdProposalDraft } from "../src/lib/threshold-proposals";
 import { extractHistoricalOutcomeFeedback } from "../src/lib/outcome-feedback-backfill";
+import type { OutcomeFeedbackInput } from "../src/lib/report-storage";
 
 const rootDir = process.cwd();
 const defaultCheckpointPath = path.join(
@@ -65,6 +66,17 @@ interface SymptomCheckRow {
   symptoms: string | null;
   symptom_check_id: string;
   threshold_proposal_id: string | null;
+}
+
+function toDraftFeedback(
+  feedback: NonNullable<ReturnType<typeof extractHistoricalOutcomeFeedback>>["feedback"]
+): OutcomeFeedbackInput {
+  return {
+    ...feedback,
+    // Historical ai_response feedback does not preserve authenticated owner
+    // context. The draft builder only reads the clinical mismatch fields.
+    requestingUserId: "00000000-0000-0000-0000-000000000000",
+  };
 }
 
 function loadEnvFiles() {
@@ -342,7 +354,7 @@ async function insertThresholdProposal(
   }
 
   const proposal = buildThresholdProposalDraft({
-    feedback: historical.feedback,
+    feedback: toDraftFeedback(historical.feedback),
     report: historical.report,
     symptomSummary: row.symptoms || "unknown",
   });
@@ -535,7 +547,7 @@ async function main() {
         }
 
         const proposal = buildThresholdProposalDraft({
-          feedback: historical.feedback,
+          feedback: toDraftFeedback(historical.feedback),
           report: historical.report,
           symptomSummary: row.symptoms || "unknown",
         });

--- a/src/lib/outcome-feedback-backfill.ts
+++ b/src/lib/outcome-feedback-backfill.ts
@@ -1,8 +1,13 @@
 import type { SymptomReport } from "@/components/symptom-report/types";
 import type { OutcomeFeedbackInput } from "./report-storage";
 
+type HistoricalOutcomeFeedbackInput = Omit<
+  OutcomeFeedbackInput,
+  "requestingUserId"
+>;
+
 export interface HistoricalOutcomeFeedbackRecord {
-  feedback: OutcomeFeedbackInput;
+  feedback: HistoricalOutcomeFeedbackInput;
   report: SymptomReport;
   reportRecord: Record<string, unknown>;
   submittedAt: string;

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -27,7 +27,7 @@ const DEFAULT_FALLBACK_WINDOW_MS = 60_000;
 const DEFAULT_FALLBACK_LIMIT = 30;
 let lastRateLimitErrorLogAt = 0;
 
-type LocalFallbackConfig = {
+export type RateLimitFallbackConfig = {
   limit: number;
   scope: string;
   windowMs: number;
@@ -38,16 +38,24 @@ type LocalFallbackState = {
   reset: number;
 };
 
-const limiterFallbackConfigs = new WeakMap<object, LocalFallbackConfig>();
+const limiterFallbackConfigs = new WeakMap<object, RateLimitFallbackConfig>();
 const localFallbackState = new Map<string, LocalFallbackState>();
 
 function registerFallbackConfig<T extends object>(
   limiter: T | null,
-  config: LocalFallbackConfig
+  config: RateLimitFallbackConfig
 ): T | null {
   if (limiter) {
     limiterFallbackConfigs.set(limiter, config);
   }
+  return limiter;
+}
+
+export function __registerRateLimitFallbackForTests<T extends object>(
+  limiter: T,
+  config: RateLimitFallbackConfig
+): T {
+  registerFallbackConfig(limiter, config);
   return limiter;
 }
 

--- a/tests/breeds-risk.rate-limit.test.ts
+++ b/tests/breeds-risk.rate-limit.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 
 const mockGetBreedRiskProfiles = jest.fn();
-const mockGetRateLimitId = jest.fn();
 const mockGeneralApiLimiter = {
   limit: jest.fn(),
 };
@@ -16,14 +15,14 @@ jest.mock("@/lib/rate-limit", () => {
   return {
     ...actual,
     generalApiLimiter: mockGeneralApiLimiter,
-    getRateLimitId: (request: Request) => mockGetRateLimitId(request),
   };
 });
 
 describe("GET /api/breeds/risk rate-limit failover", () => {
   beforeEach(() => {
+    jest.resetModules();
     jest.clearAllMocks();
-    mockGetRateLimitId.mockReturnValue("ip:breed-risk");
+    jest.useRealTimers();
     mockGetBreedRiskProfiles.mockResolvedValue([
       {
         breed: "beagle",
@@ -34,13 +33,26 @@ describe("GET /api/breeds/risk rate-limit failover", () => {
     ]);
   });
 
-  it("fails open when the shared limiter throws", async () => {
+  it("allows the first request through the local fallback when Redis is degraded", async () => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-04-20T12:00:00.000Z"));
     const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const { __registerRateLimitFallbackForTests } = await import(
+      "../src/lib/rate-limit"
+    );
+    __registerRateLimitFallbackForTests(mockGeneralApiLimiter, {
+      limit: 60,
+      scope: "general",
+      windowMs: 60_000,
+    });
     mockGeneralApiLimiter.limit.mockRejectedValue(new Error("ECONNRESET"));
 
     const { GET } = await import("../src/app/api/breeds/risk/route");
     const response = await GET(
-      new Request("http://localhost/api/breeds/risk?breed=beagle&top=2")
+      new Request("http://localhost/api/breeds/risk?breed=beagle&top=2", {
+        headers: {
+          "x-forwarded-for": "198.51.100.22, 203.0.113.5",
+        },
+      })
     );
     const payload = (await response.json()) as {
       breed: string;
@@ -56,6 +68,52 @@ describe("GET /api/breeds/risk rate-limit failover", () => {
     expect(Array.isArray(payload.modifierProvenance)).toBe(true);
     expect(mockGetBreedRiskProfiles).toHaveBeenCalledWith("beagle", 2);
     expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks repeated abuse through the local fallback and ignores spoofed x-user-id headers", async () => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-04-20T12:00:00.000Z"));
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+    const { __registerRateLimitFallbackForTests } = await import(
+      "../src/lib/rate-limit"
+    );
+    __registerRateLimitFallbackForTests(mockGeneralApiLimiter, {
+      limit: 60,
+      scope: "general",
+      windowMs: 60_000,
+    });
+    mockGeneralApiLimiter.limit.mockRejectedValue(new Error("ECONNRESET"));
+
+    const { GET } = await import("../src/app/api/breeds/risk/route");
+
+    for (let attempt = 0; attempt < 60; attempt += 1) {
+      const response = await GET(
+        new Request("http://localhost/api/breeds/risk?breed=beagle&top=2", {
+          headers: {
+            "x-real-ip": "203.0.113.7",
+            "x-user-id": `attacker-${attempt}`,
+          },
+        })
+      );
+
+      expect(response.status).toBe(200);
+    }
+
+    const blockedResponse = await GET(
+      new Request("http://localhost/api/breeds/risk?breed=beagle&top=2", {
+        headers: {
+          "x-real-ip": "203.0.113.7",
+          "x-user-id": "final-attacker",
+        },
+      })
+    );
+    const payload = (await blockedResponse.json()) as { error: string };
+
+    expect(blockedResponse.status).toBe(429);
+    expect(payload.error).toContain("Too many requests");
+    expect(Number(blockedResponse.headers.get("Retry-After"))).toBeGreaterThan(
+      0
+    );
+    expect(mockGetBreedRiskProfiles).toHaveBeenCalledTimes(60);
   });
 
   it("still returns 429 when the limiter denies the request", async () => {

--- a/tests/rate-limit.test.ts
+++ b/tests/rate-limit.test.ts
@@ -39,6 +39,24 @@ describe("rate-limit helper", () => {
     });
   });
 
+  it("returns success when the Redis-backed limiter allows the request", async () => {
+    const { checkRateLimit } = await import("../src/lib/rate-limit");
+    const limiter = {
+      limit: jest.fn().mockResolvedValue({
+        success: true,
+        reset: Date.now() + 60_000,
+        remaining: 29,
+      }),
+    };
+
+    await expect(checkRateLimit(limiter as never, "user:allowed")).resolves.toEqual(
+      {
+        success: true,
+      }
+    );
+    expect(limiter.limit).toHaveBeenCalledWith("user:allowed");
+  });
+
   it("allows the same client again after the limiter window resets", async () => {
     jest.useFakeTimers().setSystemTime(new Date("2026-04-14T12:00:00.000Z"));
     const resetAt = Date.now() + 1_000;
@@ -143,17 +161,43 @@ describe("rate-limit helper", () => {
     expect(warnSpy).toHaveBeenCalledTimes(2);
   });
 
-  it("uses a trusted server-side user id before falling back to proxy IP headers", async () => {
+  it("prefers trusted user ids and the strongest proxy-derived IP header", async () => {
     const { getRateLimitId } = await import("../src/lib/rate-limit");
-    const ipRequest = new Request("http://localhost/api/test", {
+    const cfRequest = new Request("http://localhost/api/test", {
+      headers: {
+        "cf-connecting-ip": "192.0.2.10",
+        "x-real-ip": "198.51.100.8",
+        "x-forwarded-for": "203.0.113.4, 203.0.113.5",
+      },
+    });
+    const realIpRequest = new Request("http://localhost/api/test", {
+      headers: {
+        "x-real-ip": "198.51.100.8",
+        "x-forwarded-for": "203.0.113.4, 203.0.113.5",
+      },
+    });
+    const forwardedIpRequest = new Request("http://localhost/api/test", {
       headers: { "x-forwarded-for": "198.51.100.22, 203.0.113.5" },
     });
+
+    expect(getRateLimitId(cfRequest, "user-123")).toBe("user:user-123");
+    expect(getRateLimitId(cfRequest)).toBe("ip:192.0.2.10");
+    expect(getRateLimitId(realIpRequest)).toBe("ip:198.51.100.8");
+    expect(getRateLimitId(forwardedIpRequest)).toBe("ip:198.51.100.22");
+    expect(getRateLimitId(new Request("http://localhost/api/test"))).toBe(
+      "ip:anonymous"
+    );
+  });
+
+  it("ignores spoofed x-user-id headers when no trusted server identity is present", async () => {
+    const { getRateLimitId } = await import("../src/lib/rate-limit");
     const spoofedHeaderRequest = new Request("http://localhost/api/test", {
-      headers: { "x-user-id": "attacker-controlled", "x-real-ip": "203.0.113.7" },
+      headers: {
+        "x-user-id": "attacker-controlled",
+        "x-real-ip": "203.0.113.7",
+      },
     });
 
-    expect(getRateLimitId(ipRequest, "user-123")).toBe("user:user-123");
-    expect(getRateLimitId(ipRequest)).toBe("ip:198.51.100.22");
     expect(getRateLimitId(spoofedHeaderRequest)).toBe("ip:203.0.113.7");
   });
 });


### PR DESCRIPTION
## Summary
- add route-level coverage for degraded Redis fallback on `/api/breeds/risk`
- prove repeated abuse is blocked by the local fallback quota even when `x-user-id` is spoofed
- expand unit coverage for Redis success and rate-limit key-selection policy

## Verification
- npx jest --runInBand --runTestsByPath tests/rate-limit.test.ts tests/breeds-risk.rate-limit.test.ts tests/rate-limit-failover-harness.test.ts tests/usage-limit-gate.test.ts
- npx jest --runInBand --runTestsByPath tests/symptom-chat.route.test.ts -t "bypasses the usage gate for emergency-start conversations"
- npm test
- npm run build