### PR TITLE
VET-1354: harden outcome feedback ownership writes

### DIFF
--- a/scripts/backfill-outcome-feedback.ts
+++ b/scripts/backfill-outcome-feedback.ts
@@ -7,6 +7,7 @@ import { randomUUID } from "node:crypto";
 import { Pool } from "pg";
 import { buildThresholdProposalDraft } from "../src/lib/threshold-proposals";
 import { extractHistoricalOutcomeFeedback } from "../src/lib/outcome-feedback-backfill";
+import type { OutcomeFeedbackInput } from "../src/lib/report-storage";
 
 const rootDir = process.cwd();
 const defaultCheckpointPath = path.join(
@@ -65,6 +66,17 @@ interface SymptomCheckRow {
   symptoms: string | null;
   symptom_check_id: string;
   threshold_proposal_id: string | null;
+}
+
+function toDraftFeedback(
+  feedback: NonNullable<ReturnType<typeof extractHistoricalOutcomeFeedback>>["feedback"]
+): OutcomeFeedbackInput {
+  return {
+    ...feedback,
+    // Historical ai_response feedback does not preserve authenticated owner
+    // context. The draft builder only reads the clinical mismatch fields.
+    requestingUserId: "00000000-0000-0000-0000-000000000000",
+  };
 }
 
 function loadEnvFiles() {
@@ -342,7 +354,7 @@ async function insertThresholdProposal(
   }
 
   const proposal = buildThresholdProposalDraft({
-    feedback: historical.feedback,
+    feedback: toDraftFeedback(historical.feedback),
     report: historical.report,
     symptomSummary: row.symptoms || "unknown",
   });
@@ -535,7 +547,7 @@ async function main() {
         }
 
         const proposal = buildThresholdProposalDraft({
-          feedback: historical.feedback,
+          feedback: toDraftFeedback(historical.feedback),
           report: historical.report,
           symptomSummary: row.symptoms || "unknown",
         });

--- a/src/app/api/ai/outcome-feedback/route.ts
+++ b/src/app/api/ai/outcome-feedback/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import { saveOutcomeFeedbackToDB } from "@/lib/report-storage";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
 import {
@@ -7,13 +8,17 @@ import {
   getRateLimitId,
 } from "@/lib/rate-limit";
 
-interface OutcomeFeedbackRequestBody {
-  symptomCheckId?: string;
-  matchedExpectation?: "yes" | "partly" | "no";
-  confirmedDiagnosis?: string;
-  vetOutcome?: string;
-  ownerNotes?: string;
-}
+const OutcomeFeedbackRequestBodySchema = z.object({
+  symptomCheckId: z.string().uuid(),
+  matchedExpectation: z.enum(["yes", "partly", "no"]),
+  confirmedDiagnosis: z.string().trim().max(2000).optional(),
+  vetOutcome: z.string().trim().max(2000).optional(),
+  ownerNotes: z.string().trim().max(4000).optional(),
+});
+
+type OutcomeFeedbackRequestBody = z.infer<
+  typeof OutcomeFeedbackRequestBodySchema
+>;
 
 export async function POST(request: Request) {
   const rateLimitResult = await checkRateLimit(
@@ -64,19 +69,22 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Authentication required" }, { status: 401 });
   }
 
-  let body: OutcomeFeedbackRequestBody;
+  let requestBody: unknown;
   try {
-    body = (await request.json()) as OutcomeFeedbackRequestBody;
+    requestBody = await request.json();
   } catch {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  if (!body.symptomCheckId || !body.matchedExpectation) {
+  const parsedBody = OutcomeFeedbackRequestBodySchema.safeParse(requestBody);
+  if (!parsedBody.success) {
     return NextResponse.json(
-      { error: "symptomCheckId and matchedExpectation are required" },
+      { error: "Invalid request body", code: "VALIDATION_ERROR" },
       { status: 400 }
     );
   }
+
+  const body: OutcomeFeedbackRequestBody = parsedBody.data;
 
   const saved = await saveOutcomeFeedbackToDB({
     symptomCheckId: body.symptomCheckId,

--- a/src/lib/outcome-feedback-backfill.ts
+++ b/src/lib/outcome-feedback-backfill.ts
@@ -1,8 +1,13 @@
 import type { SymptomReport } from "@/components/symptom-report/types";
 import type { OutcomeFeedbackInput } from "./report-storage";
 
+type HistoricalOutcomeFeedbackInput = Omit<
+  OutcomeFeedbackInput,
+  "requestingUserId"
+>;
+
 export interface HistoricalOutcomeFeedbackRecord {
-  feedback: OutcomeFeedbackInput;
+  feedback: HistoricalOutcomeFeedbackInput;
   report: SymptomReport;
   reportRecord: Record<string, unknown>;
   submittedAt: string;

--- a/src/lib/report-storage.ts
+++ b/src/lib/report-storage.ts
@@ -21,6 +21,8 @@ export interface OutcomeFeedbackSaveResult {
   warnings: string[];
 }
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 function getServerSupabase() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -29,6 +31,15 @@ function getServerSupabase() {
   }
 
   return createClient(url, serviceKey);
+}
+
+function isUuid(value: string | null | undefined): value is string {
+  return typeof value === "string" && UUID_RE.test(value);
+}
+
+function normalizeOptionalText(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
 }
 
 export async function saveSymptomReportToDB(
@@ -87,6 +98,28 @@ export async function saveSymptomReportToDB(
 export async function saveOutcomeFeedbackToDB(
   input: OutcomeFeedbackInput
 ): Promise<OutcomeFeedbackSaveResult> {
+  if (!isUuid(input.symptomCheckId)) {
+    return {
+      errorCode: "not_found",
+      ok: false,
+      legacyUpdated: false,
+      proposalCreated: false,
+      structuredStored: false,
+      warnings: ["Invalid symptom check identifier"],
+    };
+  }
+
+  if (!isUuid(input.requestingUserId)) {
+    return {
+      errorCode: "forbidden",
+      ok: false,
+      legacyUpdated: false,
+      proposalCreated: false,
+      structuredStored: false,
+      warnings: ["Invalid authenticated user context"],
+    };
+  }
+
   const supabase = getServerSupabase();
   if (!supabase) {
     return {
@@ -165,9 +198,9 @@ export async function saveOutcomeFeedbackToDB(
 
   const feedbackPayload = {
     matched_expectation: input.matchedExpectation,
-    confirmed_diagnosis: input.confirmedDiagnosis?.trim() || null,
-    vet_outcome: input.vetOutcome?.trim() || null,
-    owner_notes: input.ownerNotes?.trim() || null,
+    confirmed_diagnosis: normalizeOptionalText(input.confirmedDiagnosis),
+    vet_outcome: normalizeOptionalText(input.vetOutcome),
+    owner_notes: normalizeOptionalText(input.ownerNotes),
     submitted_at: new Date().toISOString(),
   };
   aiResponse.outcome_feedback = feedbackPayload;
@@ -177,7 +210,8 @@ export async function saveOutcomeFeedbackToDB(
     .update({
       ai_response: JSON.stringify(aiResponse),
     })
-    .eq("id", input.symptomCheckId);
+    .eq("id", input.symptomCheckId)
+    .eq("pet_id", petId);
 
   if (updateError) {
     console.error("[DB] Failed to save outcome feedback:", updateError);
@@ -201,10 +235,10 @@ export async function saveOutcomeFeedbackToDB(
     const { data: feedbackEntry, error: feedbackError } = await supabase
       .from("outcome_feedback_entries")
       .insert({
-        confirmed_diagnosis: input.confirmedDiagnosis?.trim() || null,
+        confirmed_diagnosis: feedbackPayload.confirmed_diagnosis,
         feedback_source: "owner_feedback",
         matched_expectation: input.matchedExpectation,
-        owner_notes: input.ownerNotes?.trim() || null,
+        owner_notes: feedbackPayload.owner_notes,
         report_recommendation:
           typeof data.recommendation === "string" ? data.recommendation : null,
         report_severity:
@@ -216,7 +250,7 @@ export async function saveOutcomeFeedbackToDB(
         symptom_check_id: input.symptomCheckId,
         symptom_summary:
           typeof data.symptoms === "string" ? data.symptoms : null,
-        vet_outcome: input.vetOutcome?.trim() || null,
+        vet_outcome: feedbackPayload.vet_outcome,
       })
       .select("id")
       .maybeSingle();

--- a/tests/outcome-feedback.route.test.ts
+++ b/tests/outcome-feedback.route.test.ts
@@ -53,7 +53,7 @@ describe("outcome-feedback route", () => {
     const { POST } = await import("@/app/api/ai/outcome-feedback/route");
     const response = await POST(
       makeRequest({
-        symptomCheckId: "abc123",
+        symptomCheckId: "11111111-1111-1111-1111-111111111111",
         matchedExpectation: "partly",
         confirmedDiagnosis: "otitis externa",
         vetOutcome: "Cytology and medication",
@@ -67,7 +67,7 @@ describe("outcome-feedback route", () => {
     expect(payload.structuredStored).toBe(true);
     expect(mockSaveOutcomeFeedbackToDB).toHaveBeenCalledWith(
       expect.objectContaining({
-        symptomCheckId: "abc123",
+        symptomCheckId: "11111111-1111-1111-1111-111111111111",
         matchedExpectation: "partly",
         requestingUserId: "user-1",
       })
@@ -84,7 +84,9 @@ describe("outcome-feedback route", () => {
     const payload = await response.json();
 
     expect(response.status).toBe(400);
-    expect(payload.error).toContain("required");
+    expect(payload.error).toBe("Invalid request body");
+    expect(payload.code).toBe("VALIDATION_ERROR");
+    expect(mockSaveOutcomeFeedbackToDB).not.toHaveBeenCalled();
   });
 
   it("rejects unauthenticated feedback submissions", async () => {
@@ -100,12 +102,59 @@ describe("outcome-feedback route", () => {
     const { POST } = await import("@/app/api/ai/outcome-feedback/route");
     const response = await POST(
       makeRequest({
-        symptomCheckId: "abc123",
+        symptomCheckId: "11111111-1111-1111-1111-111111111111",
         matchedExpectation: "partly",
       })
     );
 
     expect(response.status).toBe(401);
     expect(mockSaveOutcomeFeedbackToDB).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed symptom check identifiers before storage writes", async () => {
+    const { POST } = await import("@/app/api/ai/outcome-feedback/route");
+    const response = await POST(
+      makeRequest({
+        symptomCheckId: "not-a-uuid",
+        matchedExpectation: "partly",
+      })
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toBe("Invalid request body");
+    expect(payload.code).toBe("VALIDATION_ERROR");
+    expect(mockSaveOutcomeFeedbackToDB).not.toHaveBeenCalled();
+  });
+
+  it("returns generic ownership failures without leaking private content", async () => {
+    mockSaveOutcomeFeedbackToDB.mockResolvedValue({
+      ok: false,
+      errorCode: "forbidden",
+      legacyUpdated: false,
+      structuredStored: false,
+      proposalCreated: false,
+      warnings: [
+        "Owner notes: Piper needed sedation after the emergency visit",
+      ],
+    });
+
+    const { POST } = await import("@/app/api/ai/outcome-feedback/route");
+    const response = await POST(
+      makeRequest({
+        symptomCheckId: "11111111-1111-1111-1111-111111111111",
+        matchedExpectation: "no",
+        ownerNotes: "Piper needed sedation after the emergency visit",
+      })
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(payload).toEqual({
+      ok: false,
+      error: "Unable to save outcome feedback",
+    });
+    expect(JSON.stringify(payload)).not.toContain("Piper");
+    expect(payload.warnings).toBeUndefined();
   });
 });

--- a/tests/report-storage.outcome-feedback.test.ts
+++ b/tests/report-storage.outcome-feedback.test.ts
@@ -1,0 +1,296 @@
+const mockCreateClient = jest.fn();
+const mockBuildThresholdProposalDraft = jest.fn();
+
+jest.mock("@supabase/supabase-js", () => ({
+  createClient: (...args: unknown[]) => mockCreateClient(...args),
+}));
+
+jest.mock("@/lib/threshold-proposals", () => ({
+  buildThresholdProposalDraft: (...args: unknown[]) =>
+    mockBuildThresholdProposalDraft(...args),
+}));
+
+type QueryResult = {
+  data: unknown;
+  error: unknown;
+};
+
+type TableConfig = {
+  selectResult?: QueryResult;
+  updateError?: unknown;
+  insertResult?: QueryResult;
+  insertError?: unknown;
+};
+
+type TableOperation = {
+  type: "eq" | "insert" | "select" | "update";
+  mode?: "insert" | "select" | "update";
+  column?: string;
+  payload?: Record<string, unknown>;
+  value?: unknown;
+};
+
+function createQueryBuilder(
+  tableName: string,
+  config: TableConfig,
+  operations: TableOperation[]
+) {
+  let mode: "insert" | "select" | "update" | null = null;
+  const builder: {
+    error: unknown;
+    eq: (column: string, value: unknown) => typeof builder;
+    insert: (payload: Record<string, unknown>) => typeof builder | { error: unknown };
+    maybeSingle: () => Promise<QueryResult>;
+    select: (columns: string) => typeof builder;
+    update: (payload: Record<string, unknown>) => typeof builder;
+  } = {
+    error: null,
+    eq(column, value) {
+      operations.push({ type: "eq", mode: mode ?? undefined, column, value });
+      return builder;
+    },
+    insert(payload) {
+      operations.push({ type: "insert", payload });
+      if (tableName === "threshold_proposals") {
+        return { error: config.insertError ?? null };
+      }
+      mode = "insert";
+      builder.error = null;
+      return builder;
+    },
+    maybeSingle() {
+      if (mode === "insert") {
+        return Promise.resolve(config.insertResult ?? { data: null, error: null });
+      }
+      return Promise.resolve(config.selectResult ?? { data: null, error: null });
+    },
+    select(columns) {
+      operations.push({ type: "select", payload: { columns } });
+      if (mode !== "insert") {
+        mode = "select";
+      }
+      return builder;
+    },
+    update(payload) {
+      operations.push({ type: "update", payload });
+      mode = "update";
+      builder.error = config.updateError ?? null;
+      return builder;
+    },
+  };
+
+  return builder;
+}
+
+function createSupabaseMock(configByTable: Record<string, TableConfig>) {
+  const operations: Record<string, TableOperation[]> = {};
+  const supabase = {
+    from(tableName: string) {
+      const tableOperations = operations[tableName] ?? [];
+      operations[tableName] = tableOperations;
+      return createQueryBuilder(
+        tableName,
+        configByTable[tableName] ?? {},
+        tableOperations
+      );
+    },
+  };
+
+  return { operations, supabase };
+}
+
+describe("saveOutcomeFeedbackToDB ownership guards", () => {
+  const SUPABASE_URL = "https://paw-vital.supabase.co";
+  const SERVICE_ROLE_KEY = "service-role-key";
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    process.env.NEXT_PUBLIC_SUPABASE_URL = SUPABASE_URL;
+    process.env.SUPABASE_SERVICE_ROLE_KEY = SERVICE_ROLE_KEY;
+    mockBuildThresholdProposalDraft.mockReturnValue({
+      payload: { change: "threshold" },
+      proposalType: "threshold_review",
+      rationale: "owner feedback materially disagreed with the report",
+      summary: "Review this threshold",
+    });
+  });
+
+  it("blocks non-owner writes before any service-role update or insert happens", async () => {
+    const { supabase, operations } = createSupabaseMock({
+      pets: {
+        selectResult: {
+          data: { user_id: "22222222-2222-2222-2222-222222222222" },
+          error: null,
+        },
+      },
+      symptom_checks: {
+        selectResult: {
+          data: {
+            id: "11111111-1111-1111-1111-111111111111",
+            pet_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            symptoms: "vomiting",
+            severity: "high",
+            recommendation: "vet_24h",
+            ai_response: JSON.stringify({
+              title: "Private report title",
+              private_notes: "Do not leak",
+            }),
+          },
+          error: null,
+        },
+      },
+    });
+    mockCreateClient.mockReturnValue(supabase);
+
+    const { saveOutcomeFeedbackToDB } = await import("@/lib/report-storage");
+    const result = await saveOutcomeFeedbackToDB({
+      symptomCheckId: "11111111-1111-1111-1111-111111111111",
+      matchedExpectation: "no",
+      confirmedDiagnosis: "pancreatitis",
+      requestingUserId: "33333333-3333-3333-3333-333333333333",
+      vetOutcome: "hospitalized",
+      ownerNotes: "private owner note",
+    });
+
+    expect(result).toEqual({
+      errorCode: "forbidden",
+      ok: false,
+      legacyUpdated: false,
+      proposalCreated: false,
+      structuredStored: false,
+      warnings: ["Symptom check does not belong to the authenticated user"],
+    });
+    expect(operations.symptom_checks?.some((entry) => entry.type === "update")).toBe(
+      false
+    );
+    expect(operations.outcome_feedback_entries).toBeUndefined();
+    expect(operations.threshold_proposals).toBeUndefined();
+  });
+
+  it("stores valid owner feedback only after ownership passes", async () => {
+    const { supabase, operations } = createSupabaseMock({
+      outcome_feedback_entries: {
+        insertResult: {
+          data: { id: "44444444-4444-4444-4444-444444444444" },
+          error: null,
+        },
+      },
+      pets: {
+        selectResult: {
+          data: { user_id: "33333333-3333-3333-3333-333333333333" },
+          error: null,
+        },
+      },
+      symptom_checks: {
+        selectResult: {
+          data: {
+            id: "11111111-1111-1111-1111-111111111111",
+            pet_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            symptoms: "vomiting",
+            severity: "high",
+            recommendation: "vet_24h",
+            ai_response: JSON.stringify({
+              title: "GI upset report",
+            }),
+          },
+          error: null,
+        },
+      },
+      threshold_proposals: {
+        insertError: null,
+      },
+    });
+    mockCreateClient.mockReturnValue(supabase);
+
+    const { saveOutcomeFeedbackToDB } = await import("@/lib/report-storage");
+    const result = await saveOutcomeFeedbackToDB({
+      symptomCheckId: "11111111-1111-1111-1111-111111111111",
+      matchedExpectation: "partly",
+      confirmedDiagnosis: "dietary indiscretion",
+      requestingUserId: "33333333-3333-3333-3333-333333333333",
+      vetOutcome: "supportive care",
+      ownerNotes: "  responded to fluids  ",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      legacyUpdated: true,
+      proposalCreated: true,
+      structuredStored: true,
+      warnings: [],
+    });
+
+    const updateOperation = operations.symptom_checks?.find(
+      (entry) => entry.type === "update"
+    );
+    expect(updateOperation?.payload?.ai_response).toBeDefined();
+    const updatedResponse = JSON.parse(
+      String(updateOperation?.payload?.ai_response)
+    ) as {
+      outcome_feedback: {
+        matched_expectation: string;
+        owner_notes: string | null;
+      };
+    };
+    expect(updatedResponse.outcome_feedback).toMatchObject({
+      matched_expectation: "partly",
+      owner_notes: "responded to fluids",
+    });
+
+    const updateEqFilters =
+      operations.symptom_checks?.filter((entry) => entry.type === "eq") ?? [];
+    expect(updateEqFilters).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          column: "id",
+          value: "11111111-1111-1111-1111-111111111111",
+        }),
+        expect.objectContaining({
+          column: "pet_id",
+          value: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        }),
+      ])
+    );
+
+    expect(
+      operations.outcome_feedback_entries?.find((entry) => entry.type === "insert")
+    ).toEqual(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          owner_notes: "responded to fluids",
+          symptom_check_id: "11111111-1111-1111-1111-111111111111",
+        }),
+      })
+    );
+    expect(
+      operations.threshold_proposals?.find((entry) => entry.type === "insert")
+    ).toEqual(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          outcome_feedback_id: "44444444-4444-4444-4444-444444444444",
+          symptom_check_id: "11111111-1111-1111-1111-111111111111",
+        }),
+      })
+    );
+  });
+
+  it("fails malformed identifiers without creating a service-role client", async () => {
+    const { saveOutcomeFeedbackToDB } = await import("@/lib/report-storage");
+    const result = await saveOutcomeFeedbackToDB({
+      symptomCheckId: "not-a-uuid",
+      matchedExpectation: "yes",
+      requestingUserId: "33333333-3333-3333-3333-333333333333",
+    });
+
+    expect(result).toEqual({
+      errorCode: "not_found",
+      ok: false,
+      legacyUpdated: false,
+      proposalCreated: false,
+      structuredStored: false,
+      warnings: ["Invalid symptom check identifier"],
+    });
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- validate outcome-feedback request bodies up front so malformed symptom-check identifiers never reach storage
- add defense-in-depth UUID and ownership guards around the service-role outcome feedback write path
- cover unauthenticated, non-owner, owner-success, malformed-id, and no-leak regressions with focused tests

## Verification
- npx jest tests/outcome-feedback.route.test.ts tests/report-storage.outcome-feedback.test.ts --runInBand
- npm test
- npm run build