### PR TITLE
docs(VET-1364): add production security readiness checklist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # Core app runtime configuration
 # Copy this file to .env.local and fill in real values.
+# Keep production secrets out of git. Leave required secrets blank until you
+# provision them in your deployment platform.
 
 # NVIDIA NIM shared key for all models
 NVIDIA_API_KEY=nvapi-REPLACE_WITH_YOUR_REAL_NVIDIA_NIM_KEY
@@ -17,11 +19,34 @@ HF_TEXT_RETRIEVAL_URL=http://localhost:8081/search
 HF_IMAGE_RETRIEVAL_URL=http://localhost:8082/search
 HF_MULTIMODAL_CONSULT_URL=http://localhost:8083/consult
 HF_ASYNC_REVIEW_URL=http://localhost:8084/review
+HF_SIDECAR_API_KEY=
+ASYNC_REVIEW_WEBHOOK_SECRET=
 
 # Supabase (required for data pipeline)
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_url_here
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key_here
 SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key_here
+
+# Canonical app URL (required in production for checkout/report/share URLs)
+NEXT_PUBLIC_APP_URL=https://your-app.example.com
+
+# Stripe (required for paid flows and webhook persistence)
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+STRIPE_PRICE_ID=
+
+# Upstash Redis (required in production if you want shared rate-limit state)
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
+
+# Auth/session note
+# PawVital uses Supabase Auth for user sessions. Configure JWT, cookie, and
+# session policies in Supabase/Auth settings; this repo does not read a local
+# AUTH_SECRET or SESSION_SECRET env var today.
+
+# Storage bucket note
+# Create a private `journal-photos` bucket before enabling journal uploads in
+# production. Shared report links use database tables/RPC, not a storage bucket.
 
 # Database (required for image/audio indexing scripts)
 DATABASE_URL=your_database_url_here

--- a/docs/security/production-security-readiness-checklist.md
+++ b/docs/security/production-security-readiness-checklist.md
@@ -1,0 +1,118 @@
+# Production Security Readiness Checklist
+
+Use this checklist before deploying the private-tester security stack to
+production.
+
+## Release preconditions
+
+- Emergency release gate is green and benchmark expectations are unchanged.
+- `npm test`, `npm run build`, `npm audit`, and `npm audit --omit=dev` pass on
+  the exact branch being deployed.
+- The deployment target uses the canonical production hostname for owner-facing
+  links and Stripe redirects.
+
+## Required runtime configuration
+
+### Canonical app URL
+
+- `NEXT_PUBLIC_APP_URL`
+  - Required in production.
+  - Used by Stripe checkout and report/share link generation.
+  - Must be the public HTTPS origin for the deployed app.
+  - Do not rely on `VERCEL_URL` as the canonical production URL.
+
+### Async review webhook protection
+
+- `ASYNC_REVIEW_WEBHOOK_SECRET`
+  - Required in production when `/api/ai/async-review` is enabled.
+  - Used by:
+    - `src/app/api/ai/async-review/route.ts`
+    - `src/lib/async-review-client.ts`
+  - Missing secret fails closed in production.
+
+### Stripe secrets
+
+- `STRIPE_SECRET_KEY`
+  - Required for checkout and billing flows.
+- `STRIPE_WEBHOOK_SECRET`
+  - Required for webhook verification and persistence.
+- `STRIPE_PRICE_ID`
+  - Required if production should use a specific configured Stripe price.
+
+### Supabase separation
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY`
+  - Never reuse the anon key as a service-role key.
+  - Service-role access is for trusted server-side flows only.
+  - User-originated routes must still enforce ownership/auth checks before any
+    service-role-backed write path executes.
+
+### Rate limiting / abuse controls
+
+- `UPSTASH_REDIS_REST_URL`
+- `UPSTASH_REDIS_REST_TOKEN`
+  - Recommended for shared rate-limit state across instances.
+  - If omitted, PawVital now falls back to a local in-memory limiter instead of
+    failing open, but production should still provide Redis for consistent
+    quota enforcement across replicas.
+
+### Sidecar protection
+
+- `HF_SIDECAR_API_KEY`
+  - Required whenever secured sidecar routes are enabled.
+- `HF_VISION_PREPROCESS_URL`
+- `HF_TEXT_RETRIEVAL_URL`
+- `HF_IMAGE_RETRIEVAL_URL`
+- `HF_MULTIMODAL_CONSULT_URL`
+- `HF_ASYNC_REVIEW_URL`
+  - Set only for the services you actually run.
+
+## Auth and session controls
+
+- PawVital currently relies on Supabase Auth for owner sessions.
+- This repo does not currently read a local `AUTH_SECRET`, `NEXTAUTH_SECRET`,
+  or `SESSION_SECRET`.
+- Production session/JWT rotation, cookie policy, and email auth settings must
+  be configured in the Supabase project itself before private tester rollout.
+
+## Storage requirements
+
+- Create a private `journal-photos` storage bucket before enabling journal
+  uploads.
+- Verify bucket permissions only allow authenticated server-mediated access.
+- Shared report links rely on database tables/RPC, not a public storage bucket.
+
+## Secret hygiene
+
+- Do not commit real values into `.env.example`, docs, tests, fixtures, or PR
+  bodies.
+- Use deployment-platform secrets for production values.
+- Confirm logs and error responses do not echo raw keys, secrets, or private
+  report content.
+
+## Private tester deployment checks
+
+1. Configure the required production env vars in the deployment target.
+2. Confirm `NEXT_PUBLIC_APP_URL` matches the production domain exactly.
+3. Trigger one authenticated checkout creation and verify redirects stay on the
+   canonical domain.
+4. Trigger one async-review request in production/staging and confirm missing or
+   invalid secrets fail safely.
+5. Verify outcome feedback, shared reports, and journal upload still require
+   authenticated access/ownership.
+6. Verify the `journal-photos` bucket exists and rejected uploads do not expose
+   storage internals.
+7. Verify admin-only pages remain protected with `ADMIN_OVERRIDE` disabled in
+   production.
+8. Re-run `npm audit --omit=dev` and `npm audit` in CI for the release branch.
+
+## Fail-safe expectations
+
+- Missing `NEXT_PUBLIC_APP_URL` blocks production Stripe checkout creation.
+- Missing `ASYNC_REVIEW_WEBHOOK_SECRET` blocks production async-review queue
+  access.
+- Missing `STRIPE_WEBHOOK_SECRET` blocks webhook processing.
+- Missing `SUPABASE_SERVICE_ROLE_KEY` prevents service-role server helpers from
+  initializing.

--- a/scripts/backfill-outcome-feedback.ts
+++ b/scripts/backfill-outcome-feedback.ts
@@ -7,6 +7,7 @@ import { randomUUID } from "node:crypto";
 import { Pool } from "pg";
 import { buildThresholdProposalDraft } from "../src/lib/threshold-proposals";
 import { extractHistoricalOutcomeFeedback } from "../src/lib/outcome-feedback-backfill";
+import type { OutcomeFeedbackInput } from "../src/lib/report-storage";
 
 const rootDir = process.cwd();
 const defaultCheckpointPath = path.join(
@@ -65,6 +66,17 @@ interface SymptomCheckRow {
   symptoms: string | null;
   symptom_check_id: string;
   threshold_proposal_id: string | null;
+}
+
+function toDraftFeedback(
+  feedback: NonNullable<ReturnType<typeof extractHistoricalOutcomeFeedback>>["feedback"]
+): OutcomeFeedbackInput {
+  return {
+    ...feedback,
+    // Historical ai_response feedback does not preserve authenticated owner
+    // context. The draft builder only reads the clinical mismatch fields.
+    requestingUserId: "00000000-0000-0000-0000-000000000000",
+  };
 }
 
 function loadEnvFiles() {
@@ -342,7 +354,7 @@ async function insertThresholdProposal(
   }
 
   const proposal = buildThresholdProposalDraft({
-    feedback: historical.feedback,
+    feedback: toDraftFeedback(historical.feedback),
     report: historical.report,
     symptomSummary: row.symptoms || "unknown",
   });
@@ -535,7 +547,7 @@ async function main() {
         }
 
         const proposal = buildThresholdProposalDraft({
-          feedback: historical.feedback,
+          feedback: toDraftFeedback(historical.feedback),
           report: historical.report,
           symptomSummary: row.symptoms || "unknown",
         });

--- a/src/lib/outcome-feedback-backfill.ts
+++ b/src/lib/outcome-feedback-backfill.ts
@@ -1,8 +1,13 @@
 import type { SymptomReport } from "@/components/symptom-report/types";
 import type { OutcomeFeedbackInput } from "./report-storage";
 
+type HistoricalOutcomeFeedbackInput = Omit<
+  OutcomeFeedbackInput,
+  "requestingUserId"
+>;
+
 export interface HistoricalOutcomeFeedbackRecord {
-  feedback: OutcomeFeedbackInput;
+  feedback: HistoricalOutcomeFeedbackInput;
   report: SymptomReport;
   reportRecord: Record<string, unknown>;
   submittedAt: string;

--- a/tests/security-env-readiness.test.ts
+++ b/tests/security-env-readiness.test.ts
@@ -1,0 +1,105 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+function parseEnvFile(raw: string): Record<string, string> {
+  const values: Record<string, string> = {};
+
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+
+    const separatorIndex = trimmed.indexOf("=");
+    if (separatorIndex === -1) {
+      continue;
+    }
+
+    const key = trimmed.slice(0, separatorIndex).trim();
+    const value = trimmed.slice(separatorIndex + 1).trim();
+    values[key] = value;
+  }
+
+  return values;
+}
+
+describe("security env readiness", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    delete process.env.VERCEL_URL;
+    delete process.env.ASYNC_REVIEW_WEBHOOK_SECRET;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it(".env.example documents required security vars with placeholders only", () => {
+    const envExample = readFileSync(
+      path.join(process.cwd(), ".env.example"),
+      "utf8"
+    );
+    const parsed = parseEnvFile(envExample);
+
+    expect(parsed.NEXT_PUBLIC_APP_URL).toBe("https://your-app.example.com");
+    expect(parsed.ASYNC_REVIEW_WEBHOOK_SECRET).toBe("");
+    expect(parsed.HF_SIDECAR_API_KEY).toBe("");
+    expect(parsed.STRIPE_SECRET_KEY).toBe("");
+    expect(parsed.STRIPE_WEBHOOK_SECRET).toBe("");
+    expect(parsed.STRIPE_PRICE_ID).toBe("");
+    expect(parsed.UPSTASH_REDIS_REST_URL).toBe("");
+    expect(parsed.UPSTASH_REDIS_REST_TOKEN).toBe("");
+    expect(parsed.NEXT_PUBLIC_SUPABASE_URL).toBe("your_supabase_url_here");
+    expect(parsed.NEXT_PUBLIC_SUPABASE_ANON_KEY).toBe(
+      "your_supabase_anon_key_here"
+    );
+    expect(parsed.SUPABASE_SERVICE_ROLE_KEY).toBe(
+      "your_supabase_service_role_key_here"
+    );
+
+    expect(envExample).not.toMatch(/sk_live_|ghp_|gho_|xox[baprs]-/);
+  });
+
+  it("fails closed for Stripe redirects in production without a canonical app url", async () => {
+    process.env.NODE_ENV = "production";
+    const { getStripeAppUrl } = await import("@/lib/stripe");
+
+    expect(() =>
+      getStripeAppUrl(new Request("https://attacker.example/checkout"))
+    ).toThrow("APP_URL_NOT_CONFIGURED");
+  });
+
+  it("disables async review queueing in production without the webhook secret", async () => {
+    process.env.NODE_ENV = "production";
+    const { isAsyncReviewQueueConfigured } = await import(
+      "@/lib/async-review-client"
+    );
+
+    expect(isAsyncReviewQueueConfigured("https://queue.example.com")).toBe(
+      false
+    );
+  });
+
+  it("refuses to create a service-role Supabase client without the service key", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+
+    const { getServiceSupabase } = await import("@/lib/supabase-admin");
+
+    expect(getServiceSupabase()).toBeNull();
+  });
+
+  it("refuses to create a service-role client when the example Supabase URL is still present", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "your_supabase_url_here";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role-key";
+
+    const { getServiceSupabase } = await import("@/lib/supabase-admin");
+
+    expect(getServiceSupabase()).toBeNull();
+  });
+});


### PR DESCRIPTION
Base:
- `origin/codex/security-green-stack`

## Summary

- add a production security readiness checklist for the hardened private-tester stack
- expand `.env.example` with canonical URL, Stripe, Upstash, sidecar, and storage/auth notes using placeholders only
- add focused env/config regression coverage for production fail-safe behavior

## Validation

- `npx jest tests/security-env-readiness.test.ts tests/async-review-client.test.ts tests/async-review.route.test.ts tests/stripe.test.ts --runInBand --verbose`
- `npm test`
- `npm run build`