### PR TITLE
fix: harden async-review webhook payload guards

### DIFF
--- a/scripts/backfill-outcome-feedback.ts
+++ b/scripts/backfill-outcome-feedback.ts
@@ -7,6 +7,7 @@ import { randomUUID } from "node:crypto";
 import { Pool } from "pg";
 import { buildThresholdProposalDraft } from "../src/lib/threshold-proposals";
 import { extractHistoricalOutcomeFeedback } from "../src/lib/outcome-feedback-backfill";
+import type { OutcomeFeedbackInput } from "../src/lib/report-storage";
 
 const rootDir = process.cwd();
 const defaultCheckpointPath = path.join(
@@ -65,6 +66,17 @@ interface SymptomCheckRow {
   symptoms: string | null;
   symptom_check_id: string;
   threshold_proposal_id: string | null;
+}
+
+function toDraftFeedback(
+  feedback: NonNullable<ReturnType<typeof extractHistoricalOutcomeFeedback>>["feedback"]
+): OutcomeFeedbackInput {
+  return {
+    ...feedback,
+    // Historical ai_response feedback does not preserve authenticated owner
+    // context. The draft builder only reads the clinical mismatch fields.
+    requestingUserId: "00000000-0000-0000-0000-000000000000",
+  };
 }
 
 function loadEnvFiles() {
@@ -342,7 +354,7 @@ async function insertThresholdProposal(
   }
 
   const proposal = buildThresholdProposalDraft({
-    feedback: historical.feedback,
+    feedback: toDraftFeedback(historical.feedback),
     report: historical.report,
     symptomSummary: row.symptoms || "unknown",
   });
@@ -535,7 +547,7 @@ async function main() {
         }
 
         const proposal = buildThresholdProposalDraft({
-          feedback: historical.feedback,
+          feedback: toDraftFeedback(historical.feedback),
           report: historical.report,
           symptomSummary: row.symptoms || "unknown",
         });

--- a/src/app/api/ai/async-review/route.ts
+++ b/src/app/api/ai/async-review/route.ts
@@ -83,7 +83,14 @@ function parseAsyncReviewRequestBody(
       return null;
     }
 
-    return parsed as AsyncReviewRequestBody;
+    return {
+      image: parsed.image,
+      pet: parsed.pet as unknown as PetProfile,
+      session: parsed.session as unknown as TriageSession,
+      ...(parsed.report !== undefined
+        ? { report: parsed.report as Record<string, unknown> }
+        : {}),
+    };
   } catch {
     return null;
   }

--- a/src/app/api/ai/async-review/route.ts
+++ b/src/app/api/ai/async-review/route.ts
@@ -11,16 +11,82 @@ import {
   getRateLimitId,
 } from "@/lib/rate-limit";
 
-const ASYNC_REVIEW_WEBHOOK_SECRET =
-  process.env.ASYNC_REVIEW_WEBHOOK_SECRET?.trim() || "";
 const MAX_CONTENT_LENGTH_BYTES = 10 * 1024 * 1024;
 const MAX_IMAGE_PAYLOAD_LENGTH = 8 * 1024 * 1024;
 
 interface AsyncReviewRequestBody {
-  image?: string;
-  pet?: PetProfile;
-  session?: TriageSession;
+  image: string;
+  pet: PetProfile;
+  session: TriageSession;
   report?: Record<string, unknown>;
+}
+
+function getAsyncReviewWebhookSecret(): string {
+  return process.env.ASYNC_REVIEW_WEBHOOK_SECRET?.trim() || "";
+}
+
+function isProduction(): boolean {
+  return process.env.NODE_ENV === "production";
+}
+
+function buildAsyncReviewUnavailableResponse() {
+  return NextResponse.json(
+    { error: "Async review is unavailable" },
+    { status: 503 }
+  );
+}
+
+function buildInvalidRequestBodyResponse() {
+  return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+}
+
+function buildPayloadTooLargeResponse() {
+  return NextResponse.json(
+    { error: "Async review payload is too large" },
+    { status: 413 }
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasOversizedContentLength(request: Request): boolean {
+  const contentLength = Number(request.headers.get("content-length") || "");
+  return Number.isFinite(contentLength) && contentLength > MAX_CONTENT_LENGTH_BYTES;
+}
+
+function isPayloadTooLarge(rawBody: string): boolean {
+  return new TextEncoder().encode(rawBody).length > MAX_CONTENT_LENGTH_BYTES;
+}
+
+function parseAsyncReviewRequestBody(
+  rawBody: string
+): AsyncReviewRequestBody | "missing-required" | null {
+  try {
+    const parsed = JSON.parse(rawBody) as unknown;
+    if (!isRecord(parsed)) {
+      return null;
+    }
+
+    if (!("image" in parsed) || !("pet" in parsed) || !("session" in parsed)) {
+      return "missing-required";
+    }
+
+    if (
+      typeof parsed.image !== "string" ||
+      !parsed.image ||
+      !isRecord(parsed.pet) ||
+      !isRecord(parsed.session) ||
+      (parsed.report !== undefined && !isRecord(parsed.report))
+    ) {
+      return null;
+    }
+
+    return parsed as AsyncReviewRequestBody;
+  } catch {
+    return null;
+  }
 }
 
 function buildFallbackPreprocess(session: TriageSession): VisionPreprocessResult {
@@ -79,49 +145,41 @@ export async function POST(request: Request) {
     );
   }
 
-  const contentLength = Number(request.headers.get("content-length") || "0");
-  if (Number.isFinite(contentLength) && contentLength > MAX_CONTENT_LENGTH_BYTES) {
-    return NextResponse.json(
-      { error: "Async review payload is too large" },
-      { status: 413 }
-    );
+  if (hasOversizedContentLength(request)) {
+    return buildPayloadTooLargeResponse();
   }
 
-  if (!ASYNC_REVIEW_WEBHOOK_SECRET) {
-    if (process.env.NODE_ENV === "production") {
-      return NextResponse.json(
-        { error: "Async review secret is not configured" },
-        { status: 503 }
-      );
-    }
+  const webhookSecret = getAsyncReviewWebhookSecret();
+  if (isProduction() && !webhookSecret) {
+    return buildAsyncReviewUnavailableResponse();
   }
 
   if (
-    ASYNC_REVIEW_WEBHOOK_SECRET &&
-    request.headers.get("x-async-review-secret") !== ASYNC_REVIEW_WEBHOOK_SECRET
+    webhookSecret &&
+    request.headers.get("x-async-review-secret") !== webhookSecret
   ) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   if (!isAsyncReviewServiceConfigured()) {
-    return NextResponse.json(
-      { error: "Async review service is not configured" },
-      { status: 503 }
-    );
+    return buildAsyncReviewUnavailableResponse();
   }
 
-  let body: AsyncReviewRequestBody;
-  try {
-    body = (await request.json()) as AsyncReviewRequestBody;
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  const rawBody = await request.text();
+  if (isPayloadTooLarge(rawBody)) {
+    return buildPayloadTooLargeResponse();
   }
 
-  if (!body.image || !body.pet || !body.session) {
+  const body = parseAsyncReviewRequestBody(rawBody);
+  if (body === "missing-required") {
     return NextResponse.json(
       { error: "image, pet, and session are required" },
       { status: 400 }
     );
+  }
+
+  if (!body) {
+    return buildInvalidRequestBodyResponse();
   }
 
   const image = body.image;

--- a/src/lib/outcome-feedback-backfill.ts
+++ b/src/lib/outcome-feedback-backfill.ts
@@ -1,8 +1,13 @@
 import type { SymptomReport } from "@/components/symptom-report/types";
 import type { OutcomeFeedbackInput } from "./report-storage";
 
+type HistoricalOutcomeFeedbackInput = Omit<
+  OutcomeFeedbackInput,
+  "requestingUserId"
+>;
+
 export interface HistoricalOutcomeFeedbackRecord {
-  feedback: OutcomeFeedbackInput;
+  feedback: HistoricalOutcomeFeedbackInput;
   report: SymptomReport;
   reportRecord: Record<string, unknown>;
   submittedAt: string;

--- a/tests/async-review.route.test.ts
+++ b/tests/async-review.route.test.ts
@@ -1,11 +1,19 @@
 const mockSubmitAsyncReviewToSidecar = jest.fn();
 const mockIsAsyncReviewServiceConfigured = jest.fn();
+const mockCheckRateLimit = jest.fn();
+const mockGetRateLimitId = jest.fn();
 
 jest.mock("@/lib/hf-sidecars", () => ({
   submitAsyncReviewToSidecar: (...args: unknown[]) =>
     mockSubmitAsyncReviewToSidecar(...args),
   isAsyncReviewServiceConfigured: (...args: unknown[]) =>
     mockIsAsyncReviewServiceConfigured(...args),
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  generalApiLimiter: {},
+  checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
+  getRateLimitId: (...args: unknown[]) => mockGetRateLimitId(...args),
 }));
 
 const PET = {
@@ -16,11 +24,17 @@ const PET = {
   species: "dog",
 };
 
-function makeRequest(body: Record<string, unknown>) {
+const VALID_SECRET = "secret-123";
+const VALID_IMAGE = "data:image/jpeg;base64,ZmFrZQ==";
+
+function makeRequest(
+  body: string | Record<string, unknown>,
+  headers: Record<string, string> = {}
+) {
   return new Request("http://localhost/api/ai/async-review", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json", ...headers },
+    body: typeof body === "string" ? body : JSON.stringify(body),
   });
 }
 
@@ -32,6 +46,11 @@ describe("async-review route", () => {
     jest.clearAllMocks();
     process.env = { ...originalEnv };
     delete process.env.ASYNC_REVIEW_WEBHOOK_SECRET;
+    mockCheckRateLimit.mockResolvedValue({
+      success: true,
+      reset: Date.now() + 30_000,
+    });
+    mockGetRateLimitId.mockReturnValue("ip:test");
     mockIsAsyncReviewServiceConfigured.mockReturnValue(true);
     mockSubmitAsyncReviewToSidecar.mockResolvedValue({
       ok: true,
@@ -45,7 +64,10 @@ describe("async-review route", () => {
     process.env = originalEnv;
   });
 
-  it("queues an async multimodal review with the session evidence", async () => {
+  it("queues an async multimodal review when the request includes the valid webhook secret", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.ASYNC_REVIEW_WEBHOOK_SECRET = VALID_SECRET;
+
     const session = {
       extracted_answers: { wound_location: "left hind leg" },
       latest_image_domain: "skin_wound",
@@ -73,10 +95,12 @@ describe("async-review route", () => {
     const { POST } = await import("@/app/api/ai/async-review/route");
     const response = await POST(
       makeRequest({
-        image: "data:image/jpeg;base64,ZmFrZQ==",
+        image: VALID_IMAGE,
         pet: PET,
         session,
         report: { explanation: "Initial report" },
+      }, {
+        "x-async-review-secret": VALID_SECRET,
       })
     );
     const payload = await response.json();
@@ -91,21 +115,27 @@ describe("async-review route", () => {
     );
   });
 
-  it("returns 503 when the async review sidecar is unavailable", async () => {
+  it("returns 503 without leaking config details when the async review sidecar is unavailable", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.ASYNC_REVIEW_WEBHOOK_SECRET = VALID_SECRET;
     mockIsAsyncReviewServiceConfigured.mockReturnValue(false);
 
     const { POST } = await import("@/app/api/ai/async-review/route");
     const response = await POST(
       makeRequest({
-        image: "data:image/jpeg;base64,ZmFrZQ==",
+        image: VALID_IMAGE,
         pet: PET,
         session: {},
+      }, {
+        "x-async-review-secret": VALID_SECRET,
       })
     );
     const payload = await response.json();
 
     expect(response.status).toBe(503);
-    expect(payload.error).toContain("not configured");
+    expect(payload.error).toBe("Async review is unavailable");
+    expect(payload.error.toLowerCase()).not.toContain("configured");
+    expect(payload.error.toLowerCase()).not.toContain("secret");
   });
 
   it("rejects missing image payloads", async () => {
@@ -117,13 +147,13 @@ describe("async-review route", () => {
     expect(payload.error).toContain("required");
   });
 
-  it("requires the async review secret in production", async () => {
+  it("blocks production requests when the webhook secret is missing", async () => {
     process.env.NODE_ENV = "production";
 
     const { POST } = await import("@/app/api/ai/async-review/route");
     const response = await POST(
       makeRequest({
-        image: "data:image/jpeg;base64,ZmFrZQ==",
+        image: VALID_IMAGE,
         pet: PET,
         session: {},
       })
@@ -131,6 +161,92 @@ describe("async-review route", () => {
     const payload = await response.json();
 
     expect(response.status).toBe(503);
-    expect(payload.error).toContain("secret");
+    expect(payload.error).toBe("Async review is unavailable");
+    expect(payload.error.toLowerCase()).not.toContain("secret");
+    expect(payload.error.toLowerCase()).not.toContain("config");
+    expect(mockSubmitAsyncReviewToSidecar).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid async review secrets", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.ASYNC_REVIEW_WEBHOOK_SECRET = VALID_SECRET;
+
+    const { POST } = await import("@/app/api/ai/async-review/route");
+    const response = await POST(
+      makeRequest(
+        {
+          image: VALID_IMAGE,
+          pet: PET,
+          session: {},
+        },
+        { "x-async-review-secret": "wrong-secret" }
+      )
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(payload.error).toBe("Unauthorized");
+    expect(mockSubmitAsyncReviewToSidecar).not.toHaveBeenCalled();
+  });
+
+  it("rejects requests whose declared payload size exceeds the cap", async () => {
+    const { POST } = await import("@/app/api/ai/async-review/route");
+    const response = await POST(
+      makeRequest(
+        {
+          image: VALID_IMAGE,
+          pet: PET,
+          session: {},
+        },
+        { "content-length": String(10 * 1024 * 1024 + 1) }
+      )
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(413);
+    expect(payload.error).toBe("Async review payload is too large");
+    expect(mockSubmitAsyncReviewToSidecar).not.toHaveBeenCalled();
+  });
+
+  it("rejects oversized image payloads", async () => {
+    const { POST } = await import("@/app/api/ai/async-review/route");
+    const response = await POST(
+      makeRequest({
+        image: "a".repeat(8 * 1024 * 1024 + 1),
+        pet: PET,
+        session: {},
+      })
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(413);
+    expect(payload.error).toBe("Async review image payload is too large");
+    expect(mockSubmitAsyncReviewToSidecar).not.toHaveBeenCalled();
+  });
+
+  it("fails safely on invalid JSON bodies", async () => {
+    const { POST } = await import("@/app/api/ai/async-review/route");
+    const response = await POST(makeRequest("{bad-json"));
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toBe("Invalid request body");
+    expect(mockSubmitAsyncReviewToSidecar).not.toHaveBeenCalled();
+  });
+
+  it("fails safely on malformed structured payloads", async () => {
+    const { POST } = await import("@/app/api/ai/async-review/route");
+    const response = await POST(
+      makeRequest({
+        image: 42,
+        pet: PET,
+        session: {},
+      })
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toBe("Invalid request body");
+    expect(mockSubmitAsyncReviewToSidecar).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- harden /api/ai/async-review so production requests fail closed when the webhook secret is missing and invalid secrets are rejected without leaking config details
- enforce payload caps using both declared content length and actual request body parsing, while failing safely on malformed JSON and malformed structured payloads
- expand the async-review route regression pack for valid-secret success, invalid/missing secret rejection, oversized payloads, and safe malformed-payload handling

## Testing
- npx jest tests/async-review.route.test.ts --runInBand --verbose
- npm test
- npm run build

Closes #298