### PR TITLE
fix(VET-1359): harden production admin auth guard

### DIFF
--- a/src/lib/admin-auth.ts
+++ b/src/lib/admin-auth.ts
@@ -10,6 +10,18 @@ function isTruthyEnvFlag(value: string | undefined) {
   return value === "true" || value === "1";
 }
 
+function isProductionAdminRuntime() {
+  return (
+    process.env.NODE_ENV === "production" ||
+    process.env.VERCEL_ENV === "production"
+  );
+}
+
+function getAdminOverrideEmail() {
+  const overrideEmail = process.env.ADMIN_OVERRIDE_EMAIL?.trim().toLowerCase();
+  return overrideEmail || "admin-override@pawvital.local";
+}
+
 function getAdminEmailAllowlist() {
   return (process.env.ADMIN_EMAILS || "")
     .split(",")
@@ -40,12 +52,9 @@ async function isAdminViaUsersTable(
 }
 
 export async function getAdminRequestContext(): Promise<AdminRequestContext | null> {
-  if (
-    process.env.NODE_ENV !== "production" &&
-    isTruthyEnvFlag(process.env.ADMIN_OVERRIDE)
-  ) {
+  if (!isProductionAdminRuntime() && isTruthyEnvFlag(process.env.ADMIN_OVERRIDE)) {
     return {
-      email: process.env.ADMIN_OVERRIDE_EMAIL || "admin-override@pawvital.local",
+      email: getAdminOverrideEmail(),
       isDemo: false,
       userId: "admin-override",
     };
@@ -75,6 +84,10 @@ export async function getAdminRequestContext(): Promise<AdminRequestContext | nu
     }
   } catch (error) {
     if (error instanceof Error && error.message === "DEMO_MODE") {
+      if (isProductionAdminRuntime()) {
+        return null;
+      }
+
       return {
         email: "demo-admin@pawvital.local",
         isDemo: true,

--- a/tests/admin-auth.test.ts
+++ b/tests/admin-auth.test.ts
@@ -45,4 +45,28 @@ describe("admin auth override hardening", () => {
       userId: "admin-override",
     });
   });
+
+  it("fails closed on demo-mode auth fallback in production", async () => {
+    process.env.NODE_ENV = "production";
+    mockCreateServerSupabaseClient.mockImplementation(() => {
+      throw new Error("DEMO_MODE");
+    });
+
+    const { getAdminRequestContext } = await import("@/lib/admin-auth");
+    await expect(getAdminRequestContext()).resolves.toBeNull();
+  });
+
+  it("retains the demo admin fallback outside production", async () => {
+    process.env.NODE_ENV = "development";
+    mockCreateServerSupabaseClient.mockImplementation(() => {
+      throw new Error("DEMO_MODE");
+    });
+
+    const { getAdminRequestContext } = await import("@/lib/admin-auth");
+    await expect(getAdminRequestContext()).resolves.toEqual({
+      email: "demo-admin@pawvital.local",
+      isDemo: true,
+      userId: "demo-admin",
+    });
+  });
 });

--- a/tests/admin-route-guard-sweep.test.ts
+++ b/tests/admin-route-guard-sweep.test.ts
@@ -1,0 +1,214 @@
+const mockGetAdminRequestContext = jest.fn();
+const mockBuildAdminShadowRolloutDashboardData = jest.fn();
+const mockUpdateAdminShadowRolloutControl = jest.fn();
+const mockLoadAdminTelemetryDashboardData = jest.fn();
+const mockGetServiceSupabase = jest.fn();
+const mockCreateServerSupabaseClient = jest.fn();
+const mockOctokitIssuesCreate = jest.fn();
+const mockOctokitConstructor = jest.fn(() => ({
+  rest: {
+    issues: {
+      create: mockOctokitIssuesCreate,
+    },
+  },
+}));
+const mockFetch = jest.fn();
+
+jest.mock("@/lib/admin-auth", () => ({
+  getAdminRequestContext: (...args: unknown[]) =>
+    mockGetAdminRequestContext(...args),
+}));
+
+jest.mock("@/lib/admin-shadow-rollout", () => ({
+  buildAdminShadowRolloutDashboardData: (...args: unknown[]) =>
+    mockBuildAdminShadowRolloutDashboardData(...args),
+  updateAdminShadowRolloutControl: (...args: unknown[]) =>
+    mockUpdateAdminShadowRolloutControl(...args),
+}));
+
+jest.mock("@/lib/admin-telemetry", () => ({
+  loadAdminTelemetryDashboardData: (...args: unknown[]) =>
+    mockLoadAdminTelemetryDashboardData(...args),
+}));
+
+jest.mock("@/lib/supabase-admin", () => ({
+  getServiceSupabase: (...args: unknown[]) => mockGetServiceSupabase(...args),
+}));
+
+jest.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: (...args: unknown[]) =>
+    mockCreateServerSupabaseClient(...args),
+}));
+
+jest.mock("@octokit/rest", () => ({
+  Octokit: mockOctokitConstructor,
+}));
+
+function makeJsonRequest(
+  url: string,
+  method: "PATCH" | "POST",
+  body: Record<string, unknown>
+) {
+  return new Request(url, {
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+    method,
+  });
+}
+
+const routeSpecs = [
+  {
+    expectedStatus: 403,
+    invoke: async () => (await import("@/app/api/admin/deployment/route")).GET(),
+    label: "deployment GET",
+  },
+  {
+    expectedStatus: 403,
+    invoke: async () =>
+      (
+        await import("@/app/api/admin/issues/route")
+      ).POST(
+        makeJsonRequest("http://localhost/api/admin/issues", "POST", {
+          body: "Need review",
+          title: "Security test issue",
+        })
+      ),
+    label: "issues POST",
+  },
+  {
+    expectedStatus: 403,
+    invoke: async () =>
+      (await import("@/app/api/admin/shadow-rollout/route")).GET(),
+    label: "shadow-rollout GET",
+  },
+  {
+    expectedStatus: 403,
+    invoke: async () =>
+      (
+        await import("@/app/api/admin/shadow-rollout/route")
+      ).PATCH(
+        makeJsonRequest("http://localhost/api/admin/shadow-rollout", "PATCH", {
+          liveSplitPct: 10,
+          service: "text-retrieval-service",
+        })
+      ),
+    label: "shadow-rollout PATCH",
+  },
+  {
+    expectedStatus: 403,
+    invoke: async () => (await import("@/app/api/admin/sidecars/route")).GET(),
+    label: "sidecars GET",
+  },
+  {
+    expectedStatus: 403,
+    invoke: async () =>
+      (
+        await import("@/app/api/admin/sidecars/route")
+      ).PATCH(
+        makeJsonRequest("http://localhost/api/admin/sidecars", "PATCH", {
+          liveSplitPct: 10,
+          service: "text-retrieval-service",
+        })
+      ),
+    label: "sidecars PATCH",
+  },
+  {
+    expectedStatus: 403,
+    invoke: async () => (await import("@/app/api/admin/stats/route")).GET(),
+    label: "stats GET",
+  },
+  {
+    expectedStatus: 401,
+    invoke: async () => (await import("@/app/api/admin/telemetry/route")).GET(),
+    label: "telemetry GET",
+  },
+  {
+    expectedStatus: 403,
+    invoke: async () =>
+      (await import("@/app/api/admin/threshold-proposals/route")).GET(),
+    label: "threshold proposals GET",
+  },
+  {
+    expectedStatus: 403,
+    invoke: async () =>
+      (
+        await import("@/app/api/admin/threshold-proposals/route")
+      ).PATCH(
+        makeJsonRequest(
+          "http://localhost/api/admin/threshold-proposals",
+          "PATCH",
+          {
+            proposalId: "proposal-1",
+            reviewerNotes: "Looks good.",
+            status: "approved",
+          }
+        )
+      ),
+    label: "threshold proposals PATCH",
+  },
+  {
+    expectedStatus: 403,
+    invoke: async () =>
+      (
+        await import("@/app/api/admin/threshold-proposals/pr-draft/route")
+      ).POST(
+        makeJsonRequest(
+          "http://localhost/api/admin/threshold-proposals/pr-draft",
+          "POST",
+          { proposalIds: ["proposal-1"] }
+        )
+      ),
+    label: "threshold proposals PR draft POST",
+  },
+  {
+    expectedStatus: 403,
+    invoke: async () =>
+      (
+        await import("@/app/api/admin/threshold-proposals/review-cycle/route")
+      ).POST(
+        makeJsonRequest(
+          "http://localhost/api/admin/threshold-proposals/review-cycle",
+          "POST",
+          { cycleSlug: "round1", proposalIds: ["proposal-1"] }
+        )
+      ),
+    label: "threshold proposals review-cycle POST",
+  },
+] as const;
+
+describe("admin route guard sweep", () => {
+  const originalFetch = global.fetch;
+
+  beforeAll(() => {
+    global.fetch = mockFetch as typeof global.fetch;
+  });
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    mockGetAdminRequestContext.mockResolvedValue(null);
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it.each(routeSpecs)(
+    "blocks unauthorized $label via getAdminRequestContext",
+    async ({ expectedStatus, invoke }) => {
+      const response = await invoke();
+      const payload = await response.json();
+
+      expect(response.status).toBe(expectedStatus);
+      expect(payload).toEqual({ error: "Unauthorized" });
+      expect(mockBuildAdminShadowRolloutDashboardData).not.toHaveBeenCalled();
+      expect(mockUpdateAdminShadowRolloutControl).not.toHaveBeenCalled();
+      expect(mockLoadAdminTelemetryDashboardData).not.toHaveBeenCalled();
+      expect(mockGetServiceSupabase).not.toHaveBeenCalled();
+      expect(mockCreateServerSupabaseClient).not.toHaveBeenCalled();
+      expect(mockOctokitConstructor).not.toHaveBeenCalled();
+      expect(mockOctokitIssuesCreate).not.toHaveBeenCalled();
+      expect(mockFetch).not.toHaveBeenCalled();
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- fail closed in production when admin auth falls into synthetic demo-mode fallback
- keep local/dev ADMIN_OVERRIDE behavior explicit and covered in admin auth tests
- sweep every admin API route on this base for canonical `getAdminRequestContext()` unauthorized handling, while preserving authorized threshold proposal coverage

## Verification
- `npm test -- --runInBand --runTestsByPath tests/admin-auth.test.ts tests/admin-route-guard-sweep.test.ts tests/admin-shadow-rollout.route.test.ts tests/admin-sidecars.route.test.ts tests/admin-telemetry.route.test.ts tests/admin-threshold-proposals.route.test.ts`
- `npm test`
- `npm run build`

## Security notes
- `ADMIN_OVERRIDE` remains blocked in production.
- Production now also fails closed if admin auth would otherwise synthesize the demo admin via `DEMO_MODE`.
- All admin API routes present on `codex/security-green-stack` are covered by the unauthorized guard sweep.
- This base branch does not contain the later `admin/private-tester` admin route from the stacked VET-1352 work, so this PR does not widen or modify any private-tester admin response surface.