### PR TITLE
fix: harden costly ai endpoint request guards

### DIFF
--- a/src/app/api/ai/health-score/route.ts
+++ b/src/app/api/ai/health-score/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import {
   generateNvidiaJson,
   isNvidiaGenerationConfigured,
@@ -9,6 +10,127 @@ import {
   generalApiLimiter,
   getRateLimitId,
 } from "@/lib/rate-limit";
+
+const MAX_REQUEST_BYTES = 24 * 1024;
+
+const PetSchema = z
+  .object({
+    name: z.string().trim().min(1).optional(),
+    breed: z.string().trim().min(1).optional(),
+    age_years: z.number().finite().optional(),
+    weight: z.number().finite().optional(),
+    weight_unit: z.string().trim().min(1).optional(),
+    existing_conditions: z.array(z.string()).optional(),
+    medications: z.array(z.string()).optional(),
+  })
+  .passthrough();
+
+const BodySchema = z.object({
+  pet: PetSchema,
+  recentSymptoms: z.string().trim().optional().nullable(),
+  recentActivity: z.string().trim().optional().nullable(),
+  supplements: z.union([z.string().trim(), z.array(z.string())]).optional().nullable(),
+});
+
+type BodyParseResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; response: Response };
+
+function jsonError(error: string, status: number, code: string) {
+  return NextResponse.json({ error, code }, { status });
+}
+
+function decodeUtf8(chunks: Uint8Array[], totalBytes: number) {
+  const merged = new Uint8Array(totalBytes);
+  let offset = 0;
+
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return new TextDecoder().decode(merged);
+}
+
+async function readJsonBody<T>(
+  request: Request,
+  maxBytes: number
+): Promise<BodyParseResult<T>> {
+  const declaredLength = Number(request.headers.get("content-length") ?? "");
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    return {
+      ok: false,
+      response: jsonError(
+        "Request body too large",
+        413,
+        "PAYLOAD_TOO_LARGE"
+      ),
+    };
+  }
+
+  const reader = request.body?.getReader();
+  if (!reader) {
+    return {
+      ok: false,
+      response: jsonError("Request body is required", 400, "INVALID_JSON"),
+    };
+  }
+
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (!value) {
+        continue;
+      }
+
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBytes) {
+        try {
+          await reader.cancel();
+        } catch {}
+
+        return {
+          ok: false,
+          response: jsonError(
+            "Request body too large",
+            413,
+            "PAYLOAD_TOO_LARGE"
+          ),
+        };
+      }
+
+      chunks.push(value);
+    }
+  } catch {
+    return {
+      ok: false,
+      response: jsonError("Malformed JSON body", 400, "INVALID_JSON"),
+    };
+  }
+
+  const rawBody = decodeUtf8(chunks, totalBytes).trim();
+  if (!rawBody) {
+    return {
+      ok: false,
+      response: jsonError("Request body is required", 400, "INVALID_JSON"),
+    };
+  }
+
+  try {
+    return { ok: true, value: JSON.parse(rawBody) as T };
+  } catch {
+    return {
+      ok: false,
+      response: jsonError("Malformed JSON body", 400, "INVALID_JSON"),
+    };
+  }
+}
 
 export async function POST(request: Request) {
   const rateLimitResult = await checkRateLimit(
@@ -36,31 +158,58 @@ export async function POST(request: Request) {
     return auth.response;
   }
 
+  const parsedBody = await readJsonBody<unknown>(request, MAX_REQUEST_BYTES);
+  if (!parsedBody.ok) {
+    return parsedBody.response;
+  }
+
+  const body = BodySchema.safeParse(parsedBody.value);
+  if (!body.success) {
+    return jsonError(
+      "Provide a pet profile for health score analysis",
+      400,
+      "VALIDATION_ERROR"
+    );
+  }
+
+  const { pet, recentSymptoms, recentActivity, supplements } = body.data;
+  const supplementsSummary = Array.isArray(supplements)
+    ? supplements.join(", ")
+    : supplements;
+
+  if (!isNvidiaGenerationConfigured("phrasing_verifier")) {
+    return NextResponse.json({
+      score: 85,
+      factors: {
+        activity: 82,
+        nutrition: 88,
+        weight: 80,
+        symptoms: 90,
+        mood: 85,
+      },
+      summary: `${pet.name || "Your pet"} is in good overall health. Connect an NVIDIA NIM API key for personalized AI analysis.`,
+      tips: [
+        "Maintain current supplement routine",
+        "Increase daily walk by 5 minutes",
+        "Schedule annual checkup",
+      ],
+    });
+  }
+
   try {
-    const { pet, recentSymptoms, recentActivity, supplements } = await request.json();
-
-    if (!isNvidiaGenerationConfigured("phrasing_verifier")) {
-      return NextResponse.json({
-        score: 85,
-        factors: { activity: 82, nutrition: 88, weight: 80, symptoms: 90, mood: 85 },
-        summary: `${pet?.name || "Your pet"} is in good overall health. Connect an NVIDIA NIM API key for personalized AI analysis.`,
-        tips: ["Maintain current supplement routine", "Increase daily walk by 5 minutes", "Schedule annual checkup"],
-      });
-    }
-
     const prompt = `You are a veterinary health AI. Calculate a health score (1-100) for this pet.
 
 Pet Profile:
-- Name: ${pet.name}
-- Breed: ${pet.breed}
-- Age: ${pet.age_years} years
-- Weight: ${pet.weight} ${pet.weight_unit}
+- Name: ${pet.name || "your dog"}
+- Breed: ${pet.breed || "Unknown breed"}
+- Age: ${typeof pet.age_years === "number" ? pet.age_years : "Unknown"} years
+- Weight: ${typeof pet.weight === "number" ? pet.weight : "Unknown"} ${pet.weight_unit || "lbs"}
 - Existing conditions: ${pet.existing_conditions?.join(", ") || "None"}
 - Current medications: ${pet.medications?.join(", ") || "None"}
 
 Recent symptoms: ${recentSymptoms || "None reported"}
 Activity level: ${recentActivity || "Normal"}
-Active supplements: ${supplements || "None"}
+Active supplements: ${supplementsSummary || "None"}
 
 Calculate a health score and breakdown. Respond in this exact JSON format:
 {

--- a/src/app/api/ai/supplements/route.ts
+++ b/src/app/api/ai/supplements/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import {
   generateNvidiaJson,
   isNvidiaGenerationConfigured,
@@ -9,6 +10,128 @@ import {
   generalApiLimiter,
   getRateLimitId,
 } from "@/lib/rate-limit";
+
+const MAX_REQUEST_BYTES = 24 * 1024;
+
+const PetSchema = z
+  .object({
+    name: z.string().trim().min(1).optional(),
+    breed: z.string().trim().min(1).optional(),
+    species: z.string().trim().min(1).optional(),
+    age_years: z.number().finite().optional(),
+    age_months: z.number().finite().optional(),
+    weight: z.number().finite().optional(),
+    weight_unit: z.string().trim().min(1).optional(),
+    gender: z.string().trim().min(1).optional(),
+    is_neutered: z.boolean().optional(),
+    existing_conditions: z.array(z.string()).optional(),
+    medications: z.array(z.string()).optional(),
+  })
+  .passthrough();
+
+const BodySchema = z.object({
+  pet: PetSchema,
+});
+
+type BodyParseResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; response: Response };
+
+function jsonError(error: string, status: number, code: string) {
+  return NextResponse.json({ error, code }, { status });
+}
+
+function decodeUtf8(chunks: Uint8Array[], totalBytes: number) {
+  const merged = new Uint8Array(totalBytes);
+  let offset = 0;
+
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return new TextDecoder().decode(merged);
+}
+
+async function readJsonBody<T>(
+  request: Request,
+  maxBytes: number
+): Promise<BodyParseResult<T>> {
+  const declaredLength = Number(request.headers.get("content-length") ?? "");
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    return {
+      ok: false,
+      response: jsonError(
+        "Request body too large",
+        413,
+        "PAYLOAD_TOO_LARGE"
+      ),
+    };
+  }
+
+  const reader = request.body?.getReader();
+  if (!reader) {
+    return {
+      ok: false,
+      response: jsonError("Request body is required", 400, "INVALID_JSON"),
+    };
+  }
+
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (!value) {
+        continue;
+      }
+
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBytes) {
+        try {
+          await reader.cancel();
+        } catch {}
+
+        return {
+          ok: false,
+          response: jsonError(
+            "Request body too large",
+            413,
+            "PAYLOAD_TOO_LARGE"
+          ),
+        };
+      }
+
+      chunks.push(value);
+    }
+  } catch {
+    return {
+      ok: false,
+      response: jsonError("Malformed JSON body", 400, "INVALID_JSON"),
+    };
+  }
+
+  const rawBody = decodeUtf8(chunks, totalBytes).trim();
+  if (!rawBody) {
+    return {
+      ok: false,
+      response: jsonError("Request body is required", 400, "INVALID_JSON"),
+    };
+  }
+
+  try {
+    return { ok: true, value: JSON.parse(rawBody) as T };
+  } catch {
+    return {
+      ok: false,
+      response: jsonError("Malformed JSON body", 400, "INVALID_JSON"),
+    };
+  }
+}
 
 export async function POST(request: Request) {
   const rateLimitResult = await checkRateLimit(
@@ -37,27 +160,41 @@ export async function POST(request: Request) {
     return auth.response;
   }
 
+  const parsedBody = await readJsonBody<unknown>(request, MAX_REQUEST_BYTES);
+  if (!parsedBody.ok) {
+    return parsedBody.response;
+  }
+
+  const body = BodySchema.safeParse(parsedBody.value);
+  if (!body.success) {
+    return jsonError(
+      "Provide a pet profile for supplement recommendations",
+      400,
+      "VALIDATION_ERROR"
+    );
+  }
+
+  const { pet } = body.data;
+
+  if (!isNvidiaGenerationConfigured("diagnosis")) {
+    return NextResponse.json({
+      supplements: [],
+      nutrition_grade: "B+",
+      monthly_cost: "$90",
+      summary: `Demo mode: Connect an NVIDIA NIM API key for personalized supplement recommendations for ${pet.name || "your pet"}.`,
+    });
+  }
+
   try {
-    const { pet } = await request.json();
-
-    if (!isNvidiaGenerationConfigured("diagnosis")) {
-      return NextResponse.json({
-        supplements: [],
-        nutrition_grade: "B+",
-        monthly_cost: "$90",
-        summary: `Demo mode: Connect an NVIDIA NIM API key for personalized supplement recommendations for ${pet?.name || "your pet"}.`,
-      });
-    }
-
     const prompt = `You are a veterinary nutrition AI expert. Create a personalized supplement plan.
 
 Pet Profile:
-- Name: ${pet.name}
-- Breed: ${pet.breed}
-- Species: ${pet.species}
-- Age: ${pet.age_years} years, ${pet.age_months} months
-- Weight: ${pet.weight} ${pet.weight_unit}
-- Gender: ${pet.gender}, ${pet.is_neutered ? "neutered/spayed" : "intact"}
+- Name: ${pet.name || "your dog"}
+- Breed: ${pet.breed || "Unknown breed"}
+- Species: ${pet.species || "Dog"}
+- Age: ${typeof pet.age_years === "number" ? pet.age_years : "Unknown"} years, ${typeof pet.age_months === "number" ? pet.age_months : "Unknown"} months
+- Weight: ${typeof pet.weight === "number" ? pet.weight : "Unknown"} ${pet.weight_unit || "lbs"}
+- Gender: ${pet.gender || "Unknown"}, ${pet.is_neutered ? "neutered/spayed" : "intact"}
 - Existing conditions: ${pet.existing_conditions?.join(", ") || "None"}
 - Medications: ${pet.medications?.join(", ") || "None"}
 

--- a/src/app/api/ai/symptom-check/route.ts
+++ b/src/app/api/ai/symptom-check/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import {
   generateNvidiaJson,
   isNvidiaGenerationConfigured,
@@ -9,6 +10,126 @@ import {
   getRateLimitId,
   symptomChatLimiter,
 } from "@/lib/rate-limit";
+
+const MAX_REQUEST_BYTES = 32 * 1024;
+
+const PetSchema = z
+  .object({
+    name: z.string().trim().min(1).optional(),
+    species: z.string().trim().min(1).optional(),
+    breed: z.string().trim().min(1).optional(),
+    age_years: z.number().finite().optional(),
+    weight: z.number().finite().optional(),
+    existing_conditions: z.array(z.string()).optional(),
+    medications: z.array(z.string()).optional(),
+    vaccination_status: z.string().trim().min(1).optional(),
+  })
+  .passthrough();
+
+const BodySchema = z.object({
+  symptoms: z.string().trim().min(1),
+  pet: PetSchema,
+});
+
+type BodyParseResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; response: Response };
+
+function jsonError(error: string, status: number, code: string) {
+  return NextResponse.json({ error, code }, { status });
+}
+
+function decodeUtf8(chunks: Uint8Array[], totalBytes: number) {
+  const merged = new Uint8Array(totalBytes);
+  let offset = 0;
+
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return new TextDecoder().decode(merged);
+}
+
+async function readJsonBody<T>(
+  request: Request,
+  maxBytes: number
+): Promise<BodyParseResult<T>> {
+  const declaredLength = Number(request.headers.get("content-length") ?? "");
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    return {
+      ok: false,
+      response: jsonError(
+        "Request body too large",
+        413,
+        "PAYLOAD_TOO_LARGE"
+      ),
+    };
+  }
+
+  const reader = request.body?.getReader();
+  if (!reader) {
+    return {
+      ok: false,
+      response: jsonError("Request body is required", 400, "INVALID_JSON"),
+    };
+  }
+
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (!value) {
+        continue;
+      }
+
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBytes) {
+        try {
+          await reader.cancel();
+        } catch {}
+
+        return {
+          ok: false,
+          response: jsonError(
+            "Request body too large",
+            413,
+            "PAYLOAD_TOO_LARGE"
+          ),
+        };
+      }
+
+      chunks.push(value);
+    }
+  } catch {
+    return {
+      ok: false,
+      response: jsonError("Malformed JSON body", 400, "INVALID_JSON"),
+    };
+  }
+
+  const rawBody = decodeUtf8(chunks, totalBytes).trim();
+  if (!rawBody) {
+    return {
+      ok: false,
+      response: jsonError("Request body is required", 400, "INVALID_JSON"),
+    };
+  }
+
+  try {
+    return { ok: true, value: JSON.parse(rawBody) as T };
+  } catch {
+    return {
+      ok: false,
+      response: jsonError("Malformed JSON body", 400, "INVALID_JSON"),
+    };
+  }
+}
 
 export async function POST(request: Request) {
   const rateLimitResult = await checkRateLimit(
@@ -36,50 +157,76 @@ export async function POST(request: Request) {
     return auth.response;
   }
 
+  const parsedBody = await readJsonBody<unknown>(request, MAX_REQUEST_BYTES);
+  if (!parsedBody.ok) {
+    return parsedBody.response;
+  }
+
+  const body = BodySchema.safeParse(parsedBody.value);
+  if (!body.success) {
+    return jsonError(
+      "Provide a symptom description and pet profile",
+      400,
+      "VALIDATION_ERROR"
+    );
+  }
+
+  const { pet, symptoms } = body.data;
+
+  if (!isNvidiaGenerationConfigured("diagnosis")) {
+    return NextResponse.json({
+      severity: "high",
+      recommendation: "vet_48h",
+      title: "AI Assessment (Demo Mode)",
+      explanation: `Based on the symptoms described for ${pet.name || "your dog"}: "${symptoms}". This is demo mode — add your NVIDIA NIM API key to get full AI-powered veterinary symptom analysis.`,
+      differential_diagnoses: [
+        {
+          condition: "Demo Mode — Configure API Key",
+          likelihood: "high",
+          description:
+            "Add your NVIDIA NIM API key to unlock full veterinary-grade differential diagnosis with clinical specificity.",
+        },
+      ],
+      clinical_notes:
+        "Demo mode active. Real analysis will include ICD-10-CM veterinary codes, breed-specific epidemiological data, and evidence-based diagnostic pathways.",
+      recommended_tests: [
+        {
+          test: "Complete Blood Count (CBC)",
+          reason: "Baseline hematological assessment",
+          urgency: "routine",
+        },
+      ],
+      home_care: [
+        {
+          instruction: "Monitor symptoms closely",
+          duration: "24-48 hours",
+          details: "Track frequency, duration, and any changes in severity",
+        },
+      ],
+      actions: [
+        "Monitor your dog closely for the next 24-48 hours",
+        "Keep a log of when symptoms occur and their duration",
+        "Schedule a vet visit if no improvement in 48 hours",
+      ],
+      warning_signs: [
+        "Symptoms suddenly worsen or new symptoms appear",
+        "Loss of appetite persists beyond 24 hours",
+        "Difficulty breathing or rapid breathing at rest",
+        "Inability to stand or walk",
+      ],
+      vet_questions: ["Ask your vet about breed-specific risk factors"],
+    });
+  }
+
   try {
-    const { symptoms, pet } = await request.json();
-
-    if (!isNvidiaGenerationConfigured("diagnosis")) {
-      return NextResponse.json({
-        severity: "high",
-        recommendation: "vet_48h",
-        title: "AI Assessment (Demo Mode)",
-        explanation: `Based on the symptoms described for ${pet?.name || "your dog"}: "${symptoms}". This is demo mode — add your NVIDIA NIM API key to get full AI-powered veterinary symptom analysis.`,
-        differential_diagnoses: [
-          { condition: "Demo Mode — Configure API Key", likelihood: "high", description: "Add your NVIDIA NIM API key to unlock full veterinary-grade differential diagnosis with clinical specificity." },
-        ],
-        clinical_notes: "Demo mode active. Real analysis will include ICD-10-CM veterinary codes, breed-specific epidemiological data, and evidence-based diagnostic pathways.",
-        recommended_tests: [
-          { test: "Complete Blood Count (CBC)", reason: "Baseline hematological assessment", urgency: "routine" },
-        ],
-        home_care: [
-          { instruction: "Monitor symptoms closely", duration: "24-48 hours", details: "Track frequency, duration, and any changes in severity" },
-        ],
-        actions: [
-          "Monitor your dog closely for the next 24-48 hours",
-          "Keep a log of when symptoms occur and their duration",
-          "Schedule a vet visit if no improvement in 48 hours",
-        ],
-        warning_signs: [
-          "Symptoms suddenly worsen or new symptoms appear",
-          "Loss of appetite persists beyond 24 hours",
-          "Difficulty breathing or rapid breathing at rest",
-          "Inability to stand or walk",
-        ],
-        vet_questions: [
-          "Ask your vet about breed-specific risk factors",
-        ],
-      });
-    }
-
     const prompt = `You are a board-certified veterinary internist (DACVIM) with 20+ years of clinical experience, fellowship training in emergency medicine, and deep expertise in breed-specific pathology. You think like a specialist — not a Google search. Your analysis must reflect the depth and specificity of a $300 specialist consultation.
 
 PATIENT HISTORY:
-- Patient: ${pet.name}
+- Patient: ${pet.name || "your dog"}
 - Species: ${pet.species || "Dog"}
-- Breed: ${pet.breed}
-- Age: ${pet.age_years} years ${pet.age_years >= 7 ? "(GERIATRIC — elevated oncological, orthopedic, and organ-failure risk)" : pet.age_years <= 1 ? "(PEDIATRIC — elevated infectious, congenital, and developmental risk)" : ""}
-- Weight: ${pet.weight} lbs
+- Breed: ${pet.breed || "Unknown breed"}
+- Age: ${typeof pet.age_years === "number" ? pet.age_years : "Unknown"} years ${typeof pet.age_years === "number" ? (pet.age_years >= 7 ? "(GERIATRIC — elevated oncological, orthopedic, and organ-failure risk)" : pet.age_years <= 1 ? "(PEDIATRIC — elevated infectious, congenital, and developmental risk)" : "") : ""}
+- Weight: ${typeof pet.weight === "number" ? pet.weight : "Unknown"} lbs
 - Known conditions: ${pet.existing_conditions?.join(", ") || "None documented"}
 - Current medications: ${pet.medications?.join(", ") || "None"}
 - Vaccination status: ${pet.vaccination_status || "Unknown"}

--- a/tests/ai-endpoint-auth.test.ts
+++ b/tests/ai-endpoint-auth.test.ts
@@ -3,6 +3,11 @@ import { NextResponse } from "next/server";
 const mockRequireAuthenticatedApiUser = jest.fn();
 const mockCheckRateLimit = jest.fn();
 const mockGetRateLimitId = jest.fn();
+const mockGenerateNvidiaJson = jest.fn();
+const mockIsNvidiaGenerationConfigured = jest.fn();
+
+const generalApiLimiter = { scope: "general" };
+const symptomChatLimiter = { scope: "symptom-chat" };
 
 jest.mock("@/lib/api-auth", () => ({
   requireAuthenticatedApiUser: (...args: unknown[]) =>
@@ -10,46 +15,247 @@ jest.mock("@/lib/api-auth", () => ({
 }));
 
 jest.mock("@/lib/rate-limit", () => ({
-  generalApiLimiter: {},
-  symptomChatLimiter: {},
+  generalApiLimiter,
+  symptomChatLimiter,
   checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
   getRateLimitId: (...args: unknown[]) => mockGetRateLimitId(...args),
 }));
 
 jest.mock("@/lib/nvidia-generation", () => ({
-  generateNvidiaJson: jest.fn(),
-  isNvidiaGenerationConfigured: jest.fn().mockReturnValue(true),
+  generateNvidiaJson: (...args: unknown[]) => mockGenerateNvidiaJson(...args),
+  isNvidiaGenerationConfigured: (...args: unknown[]) =>
+    mockIsNvidiaGenerationConfigured(...args),
 }));
 
-describe("AI endpoint auth guards", () => {
+type RouteCase = {
+  label: string;
+  modulePath: string;
+  limiter: object;
+  validBody: Record<string, unknown>;
+  invalidBody: Record<string, unknown>;
+};
+
+const ROUTES: RouteCase[] = [
+  {
+    label: "symptom-check",
+    modulePath: "@/app/api/ai/symptom-check/route",
+    limiter: symptomChatLimiter,
+    validBody: {
+      symptoms: "vomiting and refusing dinner",
+      pet: {
+        name: "Bruno",
+        species: "dog",
+        breed: "Golden Retriever",
+        age_years: 5,
+        weight: 72,
+        existing_conditions: ["arthritis"],
+        medications: ["carprofen"],
+        vaccination_status: "current",
+      },
+    },
+    invalidBody: {
+      pet: {
+        name: "Bruno",
+      },
+    },
+  },
+  {
+    label: "health-score",
+    modulePath: "@/app/api/ai/health-score/route",
+    limiter: generalApiLimiter,
+    validBody: {
+      pet: {
+        name: "Bruno",
+        breed: "Golden Retriever",
+        age_years: 5,
+        weight: 72,
+        weight_unit: "lbs",
+        existing_conditions: ["arthritis"],
+        medications: ["carprofen"],
+      },
+      recentSymptoms: "mild stiffness",
+      recentActivity: "normal walks",
+      supplements: ["omega-3", "glucosamine"],
+    },
+    invalidBody: {
+      recentSymptoms: "mild stiffness",
+    },
+  },
+  {
+    label: "supplements",
+    modulePath: "@/app/api/ai/supplements/route",
+    limiter: generalApiLimiter,
+    validBody: {
+      pet: {
+        name: "Bruno",
+        species: "dog",
+        breed: "Golden Retriever",
+        age_years: 5,
+        age_months: 4,
+        weight: 72,
+        weight_unit: "lbs",
+        gender: "male",
+        is_neutered: true,
+        existing_conditions: ["arthritis"],
+        medications: ["carprofen"],
+      },
+    },
+    invalidBody: {
+      pet: "Bruno",
+    },
+  },
+];
+
+function makeAuthenticatedContext(userId = "user-123") {
+  return {
+    supabase: {},
+    user: { id: userId },
+  };
+}
+
+function makeJsonRequest(body: Record<string, unknown> | string, headers?: HeadersInit) {
+  const rawBody = typeof body === "string" ? body : JSON.stringify(body);
+  return new Request("http://localhost/api/test", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...headers,
+    },
+    body: rawBody,
+  });
+}
+
+function buildOversizedBody(body: Record<string, unknown>) {
+  const oversizedBody = {
+    ...body,
+    filler: "x".repeat(100_000),
+  };
+  const rawBody = JSON.stringify(oversizedBody);
+  const byteLength = new TextEncoder().encode(rawBody).byteLength;
+  return { rawBody, byteLength };
+}
+
+describe("AI endpoint auth, quota, and body caps", () => {
   beforeEach(() => {
     jest.resetModules();
     jest.clearAllMocks();
     mockCheckRateLimit.mockResolvedValue({ success: true });
     mockGetRateLimitId.mockReturnValue("ip:test");
-    mockRequireAuthenticatedApiUser.mockResolvedValue({
-      response: NextResponse.json(
-        { error: "Authentication required" },
-        { status: 401 }
-      ),
-    });
-  });
-
-  it.each([
-    "@/app/api/ai/symptom-check/route",
-    "@/app/api/ai/health-score/route",
-    "@/app/api/ai/supplements/route",
-    "@/app/api/journal/summary/route",
-  ])("returns 401 before expensive work for %s", async (modulePath) => {
-    const { POST } = await import(modulePath);
-    const response = await POST(
-      new Request("http://localhost/api/test", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
-      })
+    mockRequireAuthenticatedApiUser.mockResolvedValue(
+      makeAuthenticatedContext()
     );
-
-    expect(response.status).toBe(401);
+    mockIsNvidiaGenerationConfigured.mockReturnValue(true);
+    mockGenerateNvidiaJson.mockResolvedValue({ ok: true });
   });
+
+  it.each(ROUTES)(
+    "blocks unauthenticated costly access for $label",
+    async ({ modulePath, validBody }) => {
+      mockRequireAuthenticatedApiUser.mockResolvedValue({
+        response: NextResponse.json(
+          { error: "Authentication required" },
+          { status: 401 }
+        ),
+      });
+
+      const { POST } = await import(modulePath);
+      const response = await POST(makeJsonRequest(validBody));
+
+      expect(response.status).toBe(401);
+      expect(mockGenerateNvidiaJson).not.toHaveBeenCalled();
+      expect(mockIsNvidiaGenerationConfigured).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(ROUTES)(
+    "enforces rate limits for $label",
+    async ({ limiter, modulePath, validBody }) => {
+      mockCheckRateLimit.mockResolvedValue({
+        success: false,
+        reset: Date.now() + 15_000,
+        remaining: 0,
+      });
+
+      const { POST } = await import(modulePath);
+      const response = await POST(makeJsonRequest(validBody));
+      const payload = (await response.json()) as { error: string };
+
+      expect(response.status).toBe(429);
+      expect(payload.error).toContain("Too many requests");
+      expect(response.headers.get("Retry-After")).toBeTruthy();
+      expect(mockCheckRateLimit).toHaveBeenCalledWith(limiter, "ip:test");
+      expect(mockRequireAuthenticatedApiUser).not.toHaveBeenCalled();
+      expect(mockGenerateNvidiaJson).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(ROUTES)(
+    "rejects oversized request bodies for $label",
+    async ({ modulePath, validBody }) => {
+      const { rawBody, byteLength } = buildOversizedBody(validBody);
+      const { POST } = await import(modulePath);
+      const response = await POST(
+        makeJsonRequest(rawBody, {
+          "Content-Length": String(byteLength),
+        })
+      );
+      const payload = (await response.json()) as { code: string; error: string };
+
+      expect(response.status).toBe(413);
+      expect(payload.code).toBe("PAYLOAD_TOO_LARGE");
+      expect(payload.error).toContain("too large");
+      expect(mockGenerateNvidiaJson).not.toHaveBeenCalled();
+      expect(mockIsNvidiaGenerationConfigured).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(ROUTES)(
+    "fails safely on malformed JSON for $label",
+    async ({ modulePath }) => {
+      const { POST } = await import(modulePath);
+      const response = await POST(makeJsonRequest('{"broken":'));
+      const payload = (await response.json()) as { code: string };
+
+      expect(response.status).toBe(400);
+      expect(payload.code).toBe("INVALID_JSON");
+      expect(mockGenerateNvidiaJson).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(ROUTES)(
+    "fails safely on invalid payload shapes for $label",
+    async ({ modulePath, invalidBody }) => {
+      const { POST } = await import(modulePath);
+      const response = await POST(makeJsonRequest(invalidBody));
+      const payload = (await response.json()) as { code: string };
+
+      expect(response.status).toBe(400);
+      expect(payload.code).toBe("VALIDATION_ERROR");
+      expect(mockGenerateNvidiaJson).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(ROUTES)(
+    "still allows valid authenticated use for $label",
+    async ({ modulePath, validBody }) => {
+      mockGenerateNvidiaJson.mockResolvedValue({
+        endpoint: modulePath,
+        ok: true,
+      });
+
+      const { POST } = await import(modulePath);
+      const response = await POST(makeJsonRequest(validBody));
+      const payload = (await response.json()) as {
+        endpoint: string;
+        ok: boolean;
+      };
+
+      expect(response.status).toBe(200);
+      expect(payload).toEqual({
+        endpoint: modulePath,
+        ok: true,
+      });
+      expect(mockGenerateNvidiaJson).toHaveBeenCalledTimes(1);
+    }
+  );
 });


### PR DESCRIPTION
## Summary
- add streaming body caps plus explicit malformed JSON and payload-shape handling for the costly `symptom-check`, `health-score`, and `supplements` AI endpoints
- preserve auth and quota short-circuiting so unauthenticated and rate-limited requests never reach NVIDIA generation work
- extend the route regression pack to cover unauthenticated access, 429s, 413s, malformed JSON, invalid payloads, and valid authenticated requests across all three endpoints

## Testing
- `node node_modules/jest/bin/jest.js --runInBand --runTestsByPath tests/ai-endpoint-auth.test.ts`
- `node node_modules/jest/bin/jest.js --runInBand --runTestsByPath tests/rate-limit.test.ts`
- `node node_modules/jest/bin/jest.js --runInBand --runTestsByPath tests/symptom-chat.payload-safety.test.ts`
- `node node_modules/jest/bin/jest.js --runInBand --runTestsByPath tests/symptom-chat.route.test.ts -t "bypasses the usage gate for emergency-start conversations"`
- `npm test`
- `npm run build`

Closes #296