### PR TITLE
VET-1360: Harden Stripe canonical checkout redirects

### DIFF
--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -228,8 +228,18 @@ export async function POST(request: Request) {
     if (error instanceof Error && error.message === "APP_URL_NOT_CONFIGURED") {
       return NextResponse.json(
         {
-          error: "Stripe checkout requires a configured application URL.",
+          error: "Stripe checkout requires a configured canonical application URL.",
           code: "APP_URL_NOT_CONFIGURED",
+        },
+        { status: 503 }
+      );
+    }
+
+    if (error instanceof Error && error.message === "APP_URL_INVALID") {
+      return NextResponse.json(
+        {
+          error: "Stripe checkout requires a valid canonical application URL.",
+          code: "APP_URL_INVALID",
         },
         { status: 503 }
       );

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -14,18 +14,50 @@ export const isStripeWebhookConfigured =
   !!process.env.STRIPE_WEBHOOK_SECRET &&
   !process.env.STRIPE_WEBHOOK_SECRET.startsWith("whsec_placeholder");
 
+function normalizeStripeAppUrl(rawValue: string, options?: { allowImplicitHttps?: boolean }) {
+  const candidate = rawValue.trim();
+  const value = options?.allowImplicitHttps && !/^[a-z][a-z\d+\-.]*:\/\//i.test(candidate)
+    ? `https://${candidate}`
+    : candidate;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error("APP_URL_INVALID");
+  }
+
+  if (!/^https?:$/.test(parsed.protocol)) {
+    throw new Error("APP_URL_INVALID");
+  }
+
+  if (parsed.username || parsed.password || parsed.search || parsed.hash) {
+    throw new Error("APP_URL_INVALID");
+  }
+
+  if (parsed.pathname && parsed.pathname !== "/") {
+    throw new Error("APP_URL_INVALID");
+  }
+
+  return parsed.origin;
+}
+
 export function getStripeAppUrl(request?: Request) {
   const configured = process.env.NEXT_PUBLIC_APP_URL?.trim();
-  if (configured && /^https?:\/\//.test(configured)) {
-    return configured.replace(/\/$/, "");
+  if (configured) {
+    return normalizeStripeAppUrl(configured);
+  }
+
+  if (process.env.NODE_ENV === "production") {
+    throw new Error("APP_URL_NOT_CONFIGURED");
   }
 
   const vercelUrl = process.env.VERCEL_URL?.trim();
   if (vercelUrl) {
-    return `https://${vercelUrl.replace(/\/$/, "")}`;
+    return normalizeStripeAppUrl(vercelUrl, { allowImplicitHttps: true });
   }
 
-  if (process.env.NODE_ENV !== "production" && request) {
+  if (request) {
     return new URL(request.url).origin;
   }
 

--- a/tests/stripe.checkout.route.test.ts
+++ b/tests/stripe.checkout.route.test.ts
@@ -3,35 +3,47 @@ const mockCustomerCreate = jest.fn();
 const mockCustomerList = jest.fn();
 const mockCustomerUpdate = jest.fn();
 const mockCheckoutSessionCreate = jest.fn();
+const originalEnv = process.env;
 
 jest.mock("@/lib/supabase-server", () => ({
   createServerSupabaseClient: (...args: unknown[]) =>
     mockCreateServerSupabaseClient(...args),
 }));
 
-jest.mock("@/lib/stripe", () => ({
-  getStripeAppUrl: jest.fn(() => "https://app.pawvital.test"),
-  getSubscriptionLineItems: jest.fn(() => [{ price: "price_test", quantity: 1 }]),
-  isStripeConfigured: true,
-  stripe: {
-    checkout: {
-      sessions: {
-        create: (...args: unknown[]) => mockCheckoutSessionCreate(...args),
+jest.mock("@/lib/stripe", () => {
+  const actual = jest.requireActual("@/lib/stripe") as typeof import("@/lib/stripe");
+
+  return {
+    ...actual,
+    getSubscriptionLineItems: jest.fn(() => [{ price: "price_test", quantity: 1 }]),
+    isStripeConfigured: true,
+    stripe: {
+      checkout: {
+        sessions: {
+          create: (...args: unknown[]) => mockCheckoutSessionCreate(...args),
+        },
+      },
+      customers: {
+        create: (...args: unknown[]) => mockCustomerCreate(...args),
+        list: (...args: unknown[]) => mockCustomerList(...args),
+        update: (...args: unknown[]) => mockCustomerUpdate(...args),
       },
     },
-    customers: {
-      create: (...args: unknown[]) => mockCustomerCreate(...args),
-      list: (...args: unknown[]) => mockCustomerList(...args),
-      update: (...args: unknown[]) => mockCustomerUpdate(...args),
-    },
-  },
-}));
+  };
+});
 
-function makeRequest(body: Record<string, unknown> = {}) {
-  return new Request("http://localhost/api/stripe/checkout", {
+function makeRequest(
+  body: Record<string, unknown> = {},
+  options?: {
+    headers?: Record<string, string>;
+    url?: string;
+  }
+) {
+  return new Request(options?.url ?? "http://localhost/api/stripe/checkout", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
+      ...options?.headers,
     },
     body: JSON.stringify(body),
   });
@@ -116,12 +128,19 @@ describe("POST /api/stripe/checkout", () => {
   beforeEach(() => {
     jest.resetModules();
     jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    delete process.env.VERCEL_URL;
     mockCheckoutSessionCreate.mockResolvedValue({
       url: "https://checkout.stripe.com/test-session",
     });
     mockCustomerCreate.mockResolvedValue({ id: "cus_created" });
     mockCustomerList.mockResolvedValue({ data: [] });
     mockCustomerUpdate.mockResolvedValue({ id: "cus_existing" });
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
   });
 
   it("rejects unauthenticated checkout attempts", async () => {
@@ -136,6 +155,7 @@ describe("POST /api/stripe/checkout", () => {
   });
 
   it("creates a checkout session with the authenticated identity and persists the customer id", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.pawvital.test";
     const { profileUpdate, profileUpdateEq, supabase } = buildSupabaseMock();
     mockCreateServerSupabaseClient.mockResolvedValue(supabase);
 
@@ -166,6 +186,7 @@ describe("POST /api/stripe/checkout", () => {
     expect(profileUpdateEq).toHaveBeenCalledWith("id", "user-1");
     expect(mockCheckoutSessionCreate).toHaveBeenCalledWith(
       expect.objectContaining({
+        cancel_url: "https://app.pawvital.test/pricing",
         client_reference_id: "user-1",
         customer: "cus_created",
         metadata: expect.objectContaining({
@@ -176,6 +197,80 @@ describe("POST /api/stripe/checkout", () => {
           "https://app.pawvital.test/dashboard?session_id={CHECKOUT_SESSION_ID}",
       })
     );
+  });
+
+  it("uses the configured canonical app url instead of hostile host or origin headers", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.pawvital.test";
+    const { supabase } = buildSupabaseMock();
+    mockCreateServerSupabaseClient.mockResolvedValue(supabase);
+
+    const { POST } = await import("@/app/api/stripe/checkout/route");
+    const response = await POST(
+      makeRequest(
+        {},
+        {
+          headers: {
+            Host: "evil.example",
+            Origin: "https://evil.example",
+          },
+          url: "https://evil.example/api/stripe/checkout",
+        }
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockCheckoutSessionCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cancel_url: "https://app.pawvital.test/pricing",
+        success_url:
+          "https://app.pawvital.test/dashboard?session_id={CHECKOUT_SESSION_ID}",
+      })
+    );
+  });
+
+  it("fails safely when production checkout lacks a canonical app url", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.VERCEL_URL = "preview.pawvital.ai";
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const { supabase } = buildSupabaseMock();
+    mockCreateServerSupabaseClient.mockResolvedValue(supabase);
+
+    const { POST } = await import("@/app/api/stripe/checkout/route");
+    const response = await POST(makeRequest({}, { url: "https://evil.example/api/stripe/checkout" }));
+    const payload = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(payload).toEqual({
+      error: "Stripe checkout requires a configured canonical application URL.",
+      code: "APP_URL_NOT_CONFIGURED",
+    });
+    expect(mockCheckoutSessionCreate).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("fails safely when the canonical app url is malformed", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.pawvital.ai/path?secret=topsecret";
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const { supabase } = buildSupabaseMock();
+    mockCreateServerSupabaseClient.mockResolvedValue(supabase);
+
+    const { POST } = await import("@/app/api/stripe/checkout/route");
+    const response = await POST(makeRequest());
+    const payload = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(payload).toEqual({
+      error: "Stripe checkout requires a valid canonical application URL.",
+      code: "APP_URL_INVALID",
+    });
+    expect(JSON.stringify(payload)).not.toContain("topsecret");
+    expect(mockCheckoutSessionCreate).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
   });
 
   it("prevents duplicate paid checkout sessions when a subscription is already live", async () => {

--- a/tests/stripe.test.ts
+++ b/tests/stripe.test.ts
@@ -30,12 +30,30 @@ describe("getStripeAppUrl", () => {
     );
   });
 
+  it("falls back to the request origin only outside production when no canonical url exists", async () => {
+    const { getStripeAppUrl } = await import("@/lib/stripe");
+
+    expect(getStripeAppUrl(new Request("http://localhost:3000/test"))).toBe(
+      "http://localhost:3000"
+    );
+  });
+
   it("throws in production when no canonical app url is configured", async () => {
     process.env.NODE_ENV = "production";
+    process.env.VERCEL_URL = "preview.pawvital.ai";
     const { getStripeAppUrl } = await import("@/lib/stripe");
 
     expect(() =>
       getStripeAppUrl(new Request("https://attacker.example/test"))
     ).toThrow("APP_URL_NOT_CONFIGURED");
+  });
+
+  it("rejects malformed canonical app urls", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.pawvital.ai/path?token=secret";
+    const { getStripeAppUrl } = await import("@/lib/stripe");
+
+    expect(() =>
+      getStripeAppUrl(new Request("https://attacker.example/test"))
+    ).toThrow("APP_URL_INVALID");
   });
 });


### PR DESCRIPTION
## Summary
- require a valid canonical app URL for production Stripe checkout before redirect URLs are built
- ignore hostile request Host/Origin values by sourcing checkout redirects from the configured canonical URL only
- add focused Stripe tests for missing canonical config, malformed URLs, and valid checkout redirect behavior

Closes #300