### PR TITLE
VET-1355: quarantine legacy triage proxy regressions

### DIFF
--- a/src/app/api/triage/next/route.ts
+++ b/src/app/api/triage/next/route.ts
@@ -7,10 +7,22 @@ const DEPRECATION_PAYLOAD = {
     "Use /api/ai/symptom-chat for active symptom-check conversations.",
 } as const;
 
-export async function GET() {
-  return NextResponse.json(DEPRECATION_PAYLOAD, { status: 410 });
+const DEPRECATION_HEADERS = {
+  "Cache-Control": "no-store",
+} as const;
+
+function buildRetiredRouteResponse() {
+  return NextResponse.json(DEPRECATION_PAYLOAD, {
+    status: 410,
+    headers: DEPRECATION_HEADERS,
+  });
 }
 
-export async function POST() {
-  return NextResponse.json(DEPRECATION_PAYLOAD, { status: 410 });
+// Ignore caller-controlled request data so this retired endpoint cannot proxy or bind sessions.
+export async function GET(_request: Request) {
+  return buildRetiredRouteResponse();
+}
+
+export async function POST(_request: Request) {
+  return buildRetiredRouteResponse();
 }

--- a/src/lib/session-store.ts
+++ b/src/lib/session-store.ts
@@ -77,7 +77,7 @@ export function deleteSession(sessionId: string): void {
 
 // Cleanup expired sessions periodically
 if (typeof setInterval !== "undefined") {
-  setInterval(() => {
+  const cleanupTimer = setInterval(() => {
     const now = Date.now();
     for (const [id, session] of sessions) {
       if (now - session.lastActiveAt > SESSION_TTL_MS) {
@@ -85,4 +85,13 @@ if (typeof setInterval !== "undefined") {
       }
     }
   }, 60 * 60 * 1000); // Every hour
+
+  if (
+    typeof cleanupTimer === "object" &&
+    cleanupTimer !== null &&
+    "unref" in cleanupTimer &&
+    typeof cleanupTimer.unref === "function"
+  ) {
+    cleanupTimer.unref();
+  }
 }

--- a/tests/triage-next.route.test.ts
+++ b/tests/triage-next.route.test.ts
@@ -1,19 +1,116 @@
+import {
+  createOrGetSession,
+  deleteSession,
+  getSession,
+  updateSession,
+} from "@/lib/session-store";
+
+const RETIRED_PAYLOAD = {
+  error: "The legacy triage proxy endpoint has been retired.",
+  code: "LEGACY_TRIAGE_ENDPOINT_DISABLED",
+  message: "Use /api/ai/symptom-chat for active symptom-check conversations.",
+} as const;
+
+const SEEDED_SESSION_ID = "legacy-route-existing-session";
+const HOSTILE_SESSION_ID = "legacy-route-attacker-session";
+const SECRET_NOTE = "owner-secret-note";
+
 describe("legacy triage proxy route", () => {
+  afterEach(() => {
+    deleteSession(SEEDED_SESSION_ID);
+    deleteSession(HOSTILE_SESSION_ID);
+    jest.resetModules();
+  });
+
   it("returns 410 for GET requests", async () => {
     const { GET } = await import("@/app/api/triage/next/route");
-    const response = await GET();
+    const response = await GET(
+      new Request("https://pawvital.test/api/triage/next")
+    );
     const payload = await response.json();
 
     expect(response.status).toBe(410);
-    expect(payload.code).toBe("LEGACY_TRIAGE_ENDPOINT_DISABLED");
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(payload).toEqual(RETIRED_PAYLOAD);
   });
 
   it("returns 410 for POST requests", async () => {
     const { POST } = await import("@/app/api/triage/next/route");
-    const response = await POST();
+    const response = await POST(
+      new Request("https://pawvital.test/api/triage/next", { method: "POST" })
+    );
     const payload = await response.json();
 
     expect(response.status).toBe(410);
-    expect(payload.code).toBe("LEGACY_TRIAGE_ENDPOINT_DISABLED");
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(payload).toEqual(RETIRED_PAYLOAD);
+  });
+
+  it("ignores hostile headers, attacker session ids, and seeded session data", async () => {
+    const seededConversationHistory = [
+      { role: "user" as const, content: SECRET_NOTE },
+      { role: "assistant" as const, content: "internal-triage-state" },
+    ];
+
+    createOrGetSession(SEEDED_SESSION_ID, {
+      name: "Scout",
+      breed: "Mixed Breed",
+      age_years: 5,
+      weight: 24,
+    });
+    updateSession(SEEDED_SESSION_ID, {
+      conversationHistory: seededConversationHistory,
+    });
+
+    const originalSession = getSession(SEEDED_SESSION_ID);
+    expect(originalSession).not.toBeNull();
+    const originalLastActiveAt = originalSession!.lastActiveAt;
+
+    const { POST } = await import("@/app/api/triage/next/route");
+    const response = await POST(
+      new Request("https://pawvital.test/api/triage/next", {
+        method: "POST",
+        headers: {
+          host: "attacker.example",
+          origin: "https://attacker.example",
+          referer: "https://attacker.example/phish",
+          "x-forwarded-host": "attacker.example",
+          "x-forwarded-proto": "https",
+          "x-session-id": HOSTILE_SESSION_ID,
+          cookie: `legacySessionId=${HOSTILE_SESSION_ID}; trustedSessionId=${SEEDED_SESSION_ID}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          sessionId: HOSTILE_SESSION_ID,
+          petProfile: {
+            name: "Scout",
+            breed: "Mixed Breed",
+            age_years: 5,
+            weight: 24,
+          },
+          conversationHistory: seededConversationHistory,
+        }),
+      })
+    );
+    const payload = await response.json();
+    const serializedPayload = JSON.stringify(payload);
+
+    expect(response.status).toBe(410);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("location")).toBeNull();
+    expect(response.headers.get("set-cookie")).toBeNull();
+    expect(payload).toEqual(RETIRED_PAYLOAD);
+
+    expect(serializedPayload).not.toContain("attacker.example");
+    expect(serializedPayload).not.toContain(HOSTILE_SESSION_ID);
+    expect(serializedPayload).not.toContain(SEEDED_SESSION_ID);
+    expect(serializedPayload).not.toContain(SECRET_NOTE);
+    expect(serializedPayload).not.toContain("internal-triage-state");
+
+    expect(getSession(HOSTILE_SESSION_ID)).toBeNull();
+    expect(getSession(SEEDED_SESSION_ID)?.conversationHistory).toEqual(
+      seededConversationHistory
+    );
+    expect(getSession(SEEDED_SESSION_ID)?.lastActiveAt).toBe(originalLastActiveAt);
   });
 });


### PR DESCRIPTION
## Summary\n- keep the retired legacy triage proxy on a constant 410 Gone response path with no-store semantics\n- add regression coverage proving hostile headers, cookies, request bodies, and attacker-supplied session ids are ignored\n- unref the legacy session-store cleanup timer so the new regression suite exits cleanly in Node test runs\n\n## Verification\n- npx jest --runInBand --runTestsByPath tests/triage-next.route.test.ts\n- npm test\n- npm run build\n\nCloses #295