### PR TITLE
fix(VET-1361): harden journal upload validation

### DIFF
--- a/src/app/api/journal/upload/route.ts
+++ b/src/app/api/journal/upload/route.ts
@@ -5,59 +5,19 @@ import {
   checkRateLimit,
   getRateLimitId,
 } from "@/lib/rate-limit";
-
-const MAX_BYTES = 5 * 1024 * 1024;
-const ALLOWED = new Set([
-  "image/jpeg",
-  "image/png",
-  "image/webp",
-  "image/gif",
-]);
+import {
+  MAX_JOURNAL_UPLOAD_BYTES,
+  validateJournalUploadFile,
+} from "./validation";
 
 function safeFileStem(name: string): string {
   const base = name.split(/[/\\]/).pop() || "photo";
   return base.replace(/[^a-zA-Z0-9._-]+/g, "_").slice(0, 120) || "photo";
 }
 
-function sniffImageContentType(buffer: Buffer): string | null {
-  if (
-    buffer.length >= 3 &&
-    buffer[0] === 0xff &&
-    buffer[1] === 0xd8 &&
-    buffer[2] === 0xff
-  ) {
-    return "image/jpeg";
-  }
-
-  if (
-    buffer.length >= 8 &&
-    buffer[0] === 0x89 &&
-    buffer[1] === 0x50 &&
-    buffer[2] === 0x4e &&
-    buffer[3] === 0x47 &&
-    buffer[4] === 0x0d &&
-    buffer[5] === 0x0a &&
-    buffer[6] === 0x1a &&
-    buffer[7] === 0x0a
-  ) {
-    return "image/png";
-  }
-
-  if (
-    buffer.length >= 12 &&
-    buffer.subarray(0, 4).toString("ascii") === "RIFF" &&
-    buffer.subarray(8, 12).toString("ascii") === "WEBP"
-  ) {
-    return "image/webp";
-  }
-
-  const gifHeader = buffer.subarray(0, 6).toString("ascii");
-  if (gifHeader === "GIF87a" || gifHeader === "GIF89a") {
-    return "image/gif";
-  }
-
-  return null;
-}
+const MAX_JOURNAL_UPLOAD_MB = Math.floor(
+  MAX_JOURNAL_UPLOAD_BYTES / (1024 * 1024)
+);
 
 async function getSupabaseOrResponse() {
   try {
@@ -132,40 +92,31 @@ export async function POST(request: Request) {
     );
   }
 
-  if (file.size > MAX_BYTES) {
+  const validation = await validateJournalUploadFile(file);
+  if (!validation.ok && validation.reason === "file-too-large") {
     return NextResponse.json(
-      { error: "File too large (max 5MB)" },
+      { error: `File too large (max ${MAX_JOURNAL_UPLOAD_MB}MB)` },
       { status: 400 }
     );
   }
 
-  const type = file.type || "application/octet-stream";
-  if (!ALLOWED.has(type)) {
+  if (!validation.ok && validation.reason === "unsupported-file-type") {
     return NextResponse.json(
       { error: "Unsupported file type" },
       { status: 400 }
     );
   }
 
-  const buffer = Buffer.from(await file.arrayBuffer());
-  const detectedType = sniffImageContentType(buffer);
-  if (!detectedType || detectedType !== type) {
+  if (!validation.ok) {
     return NextResponse.json(
-      { error: "Uploaded file contents do not match the declared image type" },
+      { error: "Uploaded file contents do not match a supported image file" },
       { status: 400 }
     );
   }
 
-  const ext =
-    detectedType === "image/jpeg"
-      ? "jpg"
-      : detectedType === "image/png"
-        ? "png"
-        : detectedType === "image/webp"
-          ? "webp"
-          : "gif";
+  const { buffer, detectedType, extension } = validation;
 
-  const objectPath = `${user.id}/${Date.now()}-${safeFileStem(file.name)}.${ext}`;
+  const objectPath = `${user.id}/${Date.now()}-${safeFileStem(file.name)}.${extension}`;
 
   const { error: uploadError } = await supabase.storage
     .from("journal-photos")
@@ -176,11 +127,8 @@ export async function POST(request: Request) {
 
   if (uploadError) {
     console.error("[Journal Upload] Storage error:", uploadError);
-    return NextResponse.json(
-      { error: "Upload failed", detail: uploadError.message },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "Upload failed" }, { status: 500 });
   }
 
-  return NextResponse.json({ path: objectPath, bucket: "journal-photos" });
+  return NextResponse.json({ path: objectPath });
 }

--- a/src/app/api/journal/upload/validation.ts
+++ b/src/app/api/journal/upload/validation.ts
@@ -1,0 +1,150 @@
+const PNG_SIGNATURE = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+const PNG_IEND = Buffer.from([
+  0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+]);
+const WEBP_CHUNKS = new Set(["VP8 ", "VP8L", "VP8X"]);
+const GENERIC_TYPES = new Set(["", "application/octet-stream"]);
+
+export const MAX_JOURNAL_UPLOAD_BYTES = 5 * 1024 * 1024;
+
+export const JOURNAL_IMAGE_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+] as const;
+
+export type JournalImageType = (typeof JOURNAL_IMAGE_TYPES)[number];
+type NormalizedDeclaredType = JournalImageType | "generic" | null;
+
+const SUPPORTED_TYPES = new Set<JournalImageType>(JOURNAL_IMAGE_TYPES);
+
+type UploadValidationResult =
+  | {
+      ok: true;
+      buffer: Buffer;
+      detectedType: JournalImageType;
+      extension: "jpg" | "png" | "webp" | "gif";
+    }
+  | {
+      ok: false;
+      reason:
+        | "file-too-large"
+        | "unsupported-file-type"
+        | "declared-type-mismatch"
+        | "invalid-image-content";
+    };
+
+function isJpeg(buffer: Buffer): boolean {
+  return (
+    buffer.length >= 4 &&
+    buffer[0] === 0xff &&
+    buffer[1] === 0xd8 &&
+    buffer[2] === 0xff &&
+    buffer[buffer.length - 2] === 0xff &&
+    buffer[buffer.length - 1] === 0xd9
+  );
+}
+
+function isPng(buffer: Buffer): boolean {
+  if (buffer.length < 33 || !buffer.subarray(0, 8).equals(PNG_SIGNATURE)) {
+    return false;
+  }
+
+  return (
+    buffer.readUInt32BE(8) === 13 &&
+    buffer.subarray(12, 16).toString("ascii") === "IHDR" &&
+    buffer.subarray(buffer.length - 12).equals(PNG_IEND)
+  );
+}
+
+function isWebp(buffer: Buffer): boolean {
+  if (
+    buffer.length < 20 ||
+    buffer.subarray(0, 4).toString("ascii") !== "RIFF" ||
+    buffer.subarray(8, 12).toString("ascii") !== "WEBP"
+  ) {
+    return false;
+  }
+
+  const riffSize = buffer.readUInt32LE(4);
+  const chunkType = buffer.subarray(12, 16).toString("ascii");
+  return riffSize + 8 === buffer.length && WEBP_CHUNKS.has(chunkType);
+}
+
+function isGif(buffer: Buffer): boolean {
+  if (buffer.length < 14) {
+    return false;
+  }
+
+  const header = buffer.subarray(0, 6).toString("ascii");
+  return (
+    (header === "GIF87a" || header === "GIF89a") &&
+    buffer[buffer.length - 1] === 0x3b
+  );
+}
+
+export function detectJournalImageType(buffer: Buffer): JournalImageType | null {
+  if (isJpeg(buffer)) return "image/jpeg";
+  if (isPng(buffer)) return "image/png";
+  if (isWebp(buffer)) return "image/webp";
+  if (isGif(buffer)) return "image/gif";
+  return null;
+}
+
+function normalizeDeclaredType(type: string | null | undefined): NormalizedDeclaredType {
+  const normalized = (type ?? "").trim().toLowerCase();
+  if (GENERIC_TYPES.has(normalized)) {
+    return "generic";
+  }
+
+  return SUPPORTED_TYPES.has(normalized as JournalImageType)
+    ? (normalized as JournalImageType)
+    : null;
+}
+
+function extensionForImageType(type: JournalImageType): "jpg" | "png" | "webp" | "gif" {
+  switch (type) {
+    case "image/jpeg":
+      return "jpg";
+    case "image/png":
+      return "png";
+    case "image/webp":
+      return "webp";
+    case "image/gif":
+      return "gif";
+  }
+}
+
+export async function validateJournalUploadFile(
+  file: File
+): Promise<UploadValidationResult> {
+  if (file.size > MAX_JOURNAL_UPLOAD_BYTES) {
+    return { ok: false, reason: "file-too-large" };
+  }
+
+  const declaredType = normalizeDeclaredType(file.type);
+  if (declaredType === null) {
+    return { ok: false, reason: "unsupported-file-type" };
+  }
+
+  const buffer = Buffer.from(await file.arrayBuffer());
+  const detectedType = detectJournalImageType(buffer);
+
+  if (!detectedType) {
+    return { ok: false, reason: "invalid-image-content" };
+  }
+
+  if (declaredType !== "generic" && declaredType !== detectedType) {
+    return { ok: false, reason: "declared-type-mismatch" };
+  }
+
+  return {
+    ok: true,
+    buffer,
+    detectedType,
+    extension: extensionForImageType(detectedType),
+  };
+}

--- a/tests/journal-upload.route.test.ts
+++ b/tests/journal-upload.route.test.ts
@@ -1,6 +1,7 @@
 const mockCreateServerSupabaseClient = jest.fn();
 const mockCheckRateLimit = jest.fn();
 const mockGetRateLimitId = jest.fn();
+const mockUpload = jest.fn();
 
 jest.mock("@/lib/supabase-server", () => ({
   createServerSupabaseClient: () => mockCreateServerSupabaseClient(),
@@ -12,10 +13,50 @@ jest.mock("@/lib/rate-limit", () => ({
   getRateLimitId: (...args: unknown[]) => mockGetRateLimitId(...args),
 }));
 
+const JPEG_BYTES = Uint8Array.from([
+  0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01,
+  0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0xff, 0xd9,
+]);
+
+const PNG_BYTES = Uint8Array.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  0x00, 0x00, 0x00, 0x0d,
+  0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01,
+  0x00, 0x00, 0x00, 0x01,
+  0x08, 0x02, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00,
+  0x49, 0x45, 0x4e, 0x44,
+  0xae, 0x42, 0x60, 0x82,
+]);
+
+const WEBP_BYTES = Uint8Array.from([
+  0x52, 0x49, 0x46, 0x46,
+  0x0c, 0x00, 0x00, 0x00,
+  0x57, 0x45, 0x42, 0x50,
+  0x56, 0x50, 0x38, 0x20,
+  0x00, 0x00, 0x00, 0x00,
+]);
+
+async function postFile(file: File) {
+  const formData = new FormData();
+  formData.set("file", file);
+
+  const { POST } = await import("@/app/api/journal/upload/route");
+  return POST(
+    new Request("http://localhost/api/journal/upload", {
+      method: "POST",
+      body: formData,
+    })
+  );
+}
+
 describe("journal upload route", () => {
   beforeEach(() => {
     jest.resetModules();
     jest.clearAllMocks();
+    mockUpload.mockResolvedValue({ error: null });
     mockCheckRateLimit.mockResolvedValue({ success: true });
     mockGetRateLimitId.mockReturnValue("ip:test");
     mockCreateServerSupabaseClient.mockResolvedValue({
@@ -27,32 +68,140 @@ describe("journal upload route", () => {
       },
       storage: {
         from: jest.fn().mockReturnValue({
-          upload: jest.fn(),
+          upload: mockUpload,
         }),
       },
     });
   });
 
-  it("rejects files whose bytes do not match the declared image type", async () => {
-    const formData = new FormData();
-    const pngBytes = new Uint8Array([
-      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
-    ]);
-    formData.set(
-      "file",
-      new File([pngBytes], "mismatch.jpg", { type: "image/jpeg" })
+  it.each([
+    ["image/jpeg", "photo.jpg", JPEG_BYTES, "jpg"],
+    ["image/png", "photo.png", PNG_BYTES, "png"],
+    ["image/webp", "photo.webp", WEBP_BYTES, "webp"],
+  ])(
+    "accepts valid %s uploads and stores normalized metadata",
+    async (type, name, bytes, extension) => {
+      const response = await postFile(new File([bytes], name, { type }));
+      const payload = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(payload.path).toEqual(expect.stringMatching(/^user-1\//));
+      expect(mockUpload).toHaveBeenCalledTimes(1);
+
+      const [storedPath, storedBuffer, options] = mockUpload.mock.calls[0];
+      expect(storedPath).toEqual(expect.stringContaining(`.${extension}`));
+      expect(Buffer.isBuffer(storedBuffer)).toBe(true);
+      expect(options).toEqual({
+        contentType: type,
+        upsert: false,
+      });
+    }
+  );
+
+  it("normalizes generic client mime types to the validated image type", async () => {
+    const response = await postFile(
+      new File([PNG_BYTES], "generic-upload.bin", {
+        type: "application/octet-stream",
+      })
     );
 
-    const { POST } = await import("@/app/api/journal/upload/route");
-    const response = await POST(
-      new Request("http://localhost/api/journal/upload", {
-        method: "POST",
-        body: formData,
-      })
+    expect(response.status).toBe(200);
+    expect(mockUpload).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Buffer),
+      {
+        contentType: "image/png",
+        upsert: false,
+      }
+    );
+  });
+
+  it("rejects files whose bytes do not match the declared image type", async () => {
+    const response = await postFile(
+      new File([PNG_BYTES], "mismatch.jpg", { type: "image/jpeg" })
     );
     const payload = await response.json();
 
     expect(response.status).toBe(400);
     expect(payload.error).toContain("do not match");
+    expect(mockUpload).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["text payload", new TextEncoder().encode("hello from a fake image"), "image/png"],
+    [
+      "executable payload",
+      Uint8Array.from([0x4d, 0x5a, 0x90, 0x00, 0x03, 0x00, 0x00, 0x00]),
+      "image/jpeg",
+    ],
+  ])("rejects disguised %s uploads", async (_label, bytes, type) => {
+    const response = await postFile(new File([bytes], "spoofed.bin", { type }));
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toContain("supported image file");
+    expect(mockUpload).not.toHaveBeenCalled();
+  });
+
+  it("rejects png polyglot payloads with trailing content", async () => {
+    const response = await postFile(
+      new File(
+        [PNG_BYTES, new TextEncoder().encode("<script>alert(1)</script>")],
+        "polyglot.png",
+        { type: "image/png" }
+      )
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockUpload).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed image signatures that do not close cleanly", async () => {
+    const response = await postFile(
+      new File([JPEG_BYTES.slice(0, JPEG_BYTES.length - 2)], "truncated.jpg", {
+        type: "image/jpeg",
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockUpload).not.toHaveBeenCalled();
+  });
+
+  it("rejects files larger than the 5MB size cap", async () => {
+    const largeBuffer = new Uint8Array(5 * 1024 * 1024 + 1);
+    largeBuffer[0] = 0x89;
+    largeBuffer[1] = 0x50;
+    largeBuffer[2] = 0x4e;
+    largeBuffer[3] = 0x47;
+
+    const response = await postFile(
+      new File([largeBuffer], "too-large.png", { type: "image/png" })
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toContain("5MB");
+    expect(mockUpload).not.toHaveBeenCalled();
+  });
+
+  it("does not leak storage configuration details on upload rejection", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    mockUpload.mockResolvedValueOnce({
+      error: { message: "journal-photos bucket is misconfigured in us-east-1" },
+    });
+
+    const response = await postFile(
+      new File([PNG_BYTES], "storage.png", { type: "image/png" })
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(payload).toEqual({ error: "Upload failed" });
+    expect(JSON.stringify(payload)).not.toContain("journal-photos");
+    expect(JSON.stringify(payload)).not.toContain("us-east-1");
+
+    consoleErrorSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- move journal upload file validation into a route-local helper with stricter JPEG, PNG, WebP, and GIF signature checks plus a shared size cap
- normalize stored `contentType` from validated bytes, reject mismatched or hostile payloads, and stop returning storage error detail in rejection responses
- add regression coverage for valid uploads, MIME spoofing, disguised text and executable payloads, polyglot or malformed files, size caps, and sanitized storage failures

## Testing
- `npx jest tests/journal-upload.route.test.ts --runInBand --verbose`
- `npm test`
- `npm run build`

Closes #301