### PR TITLE
test(VET-1362): cover security headers and browser smoke

### DIFF
--- a/docs/security-header-allowances.md
+++ b/docs/security-header-allowances.md
@@ -1,0 +1,19 @@
+# Security Header Allowances
+
+VET-1362 keeps the browser hardening policy centralized in `next.config.ts` so the app and Vercel runtime share one source of truth for security headers.
+
+## Intentional CSP allowances
+
+- `script-src 'self' 'unsafe-inline'` stays enabled because the current Next.js 16 app router still emits inline bootstrap and hydration script that would break without a nonce or hash-based rollout.
+- `script-src` adds `'unsafe-eval'` only in development so local Next.js debugging keeps working; production omits it.
+- `style-src 'self' 'unsafe-inline' https:` preserves framework-injected inline styles and any HTTPS-hosted stylesheet/font delivery already used by tester-facing routes.
+- `img-src 'self' data: blob: https:` is required for symptom-checker photo previews, uploaded image blobs, and report/reference images that resolve over HTTPS.
+- `font-src 'self' data: https:` keeps local/data URL fonts working while allowing HTTPS-hosted font assets when configured.
+- `connect-src 'self' https:` preserves same-origin browser fetches plus HTTPS SaaS backends such as Supabase without opening non-HTTPS origins.
+- `form-action 'self' https://checkout.stripe.com` preserves the checkout handoff for the pricing flow while keeping form submissions otherwise same-origin only.
+
+## Other enforced protections
+
+- `frame-ancestors 'none'` and `X-Frame-Options: DENY` both block framing/clickjacking attempts.
+- `Strict-Transport-Security` is production-only so local HTTP development stays usable while deployed environments enforce long-lived HTTPS.
+- `Referrer-Policy`, `Permissions-Policy`, and `X-Content-Type-Options` remain explicit and app-wide.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,37 +1,52 @@
 import type { NextConfig } from "next";
 
-const contentSecurityPolicy = [
-  "default-src 'self'",
-  `script-src 'self' 'unsafe-inline'${
-    process.env.NODE_ENV === "development" ? " 'unsafe-eval'" : ""
-  }`,
-  "style-src 'self' 'unsafe-inline' https:",
-  "img-src 'self' data: blob: https:",
-  "font-src 'self' data: https:",
-  "connect-src 'self' https:",
-  "frame-ancestors 'none'",
-  "object-src 'none'",
-  "base-uri 'self'",
-  "form-action 'self' https://checkout.stripe.com",
-].join("; ");
+export function buildContentSecurityPolicy(
+  nodeEnv: string | undefined = process.env.NODE_ENV,
+) {
+  return [
+    "default-src 'self'",
+    `script-src 'self' 'unsafe-inline'${
+      nodeEnv === "development" ? " 'unsafe-eval'" : ""
+    }`,
+    "style-src 'self' 'unsafe-inline' https:",
+    "img-src 'self' data: blob: https:",
+    "font-src 'self' data: https:",
+    "connect-src 'self' https:",
+    "frame-ancestors 'none'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self' https://checkout.stripe.com",
+  ].join("; ");
+}
 
-const securityHeaders = [
-  { key: "Content-Security-Policy", value: contentSecurityPolicy },
-  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
-  { key: "X-Content-Type-Options", value: "nosniff" },
-  { key: "X-Frame-Options", value: "DENY" },
-  { key: "Permissions-Policy", value: "camera=(), geolocation=(), microphone=()" },
-  { key: "Cross-Origin-Opener-Policy", value: "same-origin" },
-  { key: "Cross-Origin-Resource-Policy", value: "same-site" },
-  ...(process.env.NODE_ENV === "production"
-    ? [
-        {
-          key: "Strict-Transport-Security",
-          value: "max-age=63072000; includeSubDomains; preload",
-        },
-      ]
-    : []),
-];
+export function buildSecurityHeaders(
+  nodeEnv: string | undefined = process.env.NODE_ENV,
+) {
+  const headers = [
+    {
+      key: "Content-Security-Policy",
+      value: buildContentSecurityPolicy(nodeEnv),
+    },
+    { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+    { key: "X-Content-Type-Options", value: "nosniff" },
+    { key: "X-Frame-Options", value: "DENY" },
+    {
+      key: "Permissions-Policy",
+      value: "camera=(), geolocation=(), microphone=()",
+    },
+    { key: "Cross-Origin-Opener-Policy", value: "same-origin" },
+    { key: "Cross-Origin-Resource-Policy", value: "same-site" },
+  ];
+
+  if (nodeEnv === "production") {
+    headers.push({
+      key: "Strict-Transport-Security",
+      value: "max-age=63072000; includeSubDomains; preload",
+    });
+  }
+
+  return headers;
+}
 
 const nextConfig: NextConfig = {
   // Exclude Node.js-only packages from bundling
@@ -47,7 +62,8 @@ const nextConfig: NextConfig = {
     return [
       {
         source: "/:path*",
-        headers: securityHeaders,
+        // Intentional browser-flow allowances live in docs/security-header-allowances.md.
+        headers: buildSecurityHeaders(),
       },
     ];
   },

--- a/tests/outcome-feedback.section.test.ts
+++ b/tests/outcome-feedback.section.test.ts
@@ -1,0 +1,100 @@
+/** @jest-environment jsdom */
+
+import * as React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { OutcomeFeedbackSection } from "@/components/symptom-report/outcome-feedback";
+import type { SymptomReport } from "@/components/symptom-report";
+
+function buildReport(): SymptomReport {
+  return {
+    severity: "medium",
+    recommendation: "vet_48h",
+    title: "Ear irritation follow-up",
+    explanation: "A saved report for browser smoke coverage.",
+    actions: ["Schedule a vet visit."],
+    warning_signs: ["Head tilt"],
+    report_storage_id: "check-123",
+    outcome_feedback_enabled: true,
+  };
+}
+
+describe("OutcomeFeedbackSection", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete (globalThis as typeof globalThis & { fetch?: typeof fetch }).fetch;
+  });
+
+  it("submits same-origin outcome feedback and shows a saved state", async () => {
+    const fetchSpy = jest.fn().mockResolvedValue(
+      {
+        ok: true,
+        status: 200,
+      },
+    );
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      writable: true,
+      value: fetchSpy,
+    });
+
+    render(
+      React.createElement(OutcomeFeedbackSection, {
+        report: buildReport(),
+      }),
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /After Your Vet Visit/i }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Very close" }));
+    fireEvent.change(screen.getByPlaceholderText("Example: otitis externa"), {
+      target: { value: "otitis externa" },
+    });
+    fireEvent.change(
+      screen.getByPlaceholderText("Example: ear cytology + meds prescribed"),
+      {
+        target: { value: "Cytology and medication" },
+      },
+    );
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "Anything useful that the vet found, ruled out, or corrected.",
+      ),
+      {
+        target: { value: "The threshold felt right." },
+      },
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Save Outcome Feedback" }),
+    );
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/ai/outcome-feedback",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const [, requestInit] = fetchSpy.mock.calls[0];
+    expect(JSON.parse(String(requestInit?.body))).toEqual({
+      symptomCheckId: "check-123",
+      matchedExpectation: "yes",
+      confirmedDiagnosis: "otitis externa",
+      vetOutcome: "Cytology and medication",
+      ownerNotes: "The threshold felt right.",
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Feedback Saved" }),
+      ).toBeTruthy(),
+    );
+    expect(
+      screen.getByText(
+        /This case can now be used for future quality review and proposal drafting\./,
+      ),
+    ).toBeTruthy();
+  });
+});

--- a/tests/security-headers-config.test.ts
+++ b/tests/security-headers-config.test.ts
@@ -1,0 +1,75 @@
+import nextConfig, {
+  buildContentSecurityPolicy,
+  buildSecurityHeaders,
+} from "../next.config";
+
+function getHeaderMap(nodeEnv: string) {
+  return new Map(
+    buildSecurityHeaders(nodeEnv).map(({ key, value }) => [key, value]),
+  );
+}
+
+describe("security header config", () => {
+  it("builds an explicit CSP for active tester-facing browser flows", () => {
+    const directives = buildContentSecurityPolicy("production").split("; ");
+
+    expect(directives).toEqual(
+      expect.arrayContaining([
+        "default-src 'self'",
+        "script-src 'self' 'unsafe-inline'",
+        "style-src 'self' 'unsafe-inline' https:",
+        "img-src 'self' data: blob: https:",
+        "font-src 'self' data: https:",
+        "connect-src 'self' https:",
+        "frame-ancestors 'none'",
+        "object-src 'none'",
+        "base-uri 'self'",
+        "form-action 'self' https://checkout.stripe.com",
+      ]),
+    );
+  });
+
+  it("keeps unsafe-eval limited to local development", () => {
+    expect(buildContentSecurityPolicy("development")).toContain("'unsafe-eval'");
+    expect(buildContentSecurityPolicy("production")).not.toContain(
+      "'unsafe-eval'",
+    );
+  });
+
+  it("includes the required browser hardening headers in production", () => {
+    const headers = getHeaderMap("production");
+
+    expect(headers.get("Content-Security-Policy")).toContain(
+      "frame-ancestors 'none'",
+    );
+    expect(headers.get("Referrer-Policy")).toBe(
+      "strict-origin-when-cross-origin",
+    );
+    expect(headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(headers.get("X-Frame-Options")).toBe("DENY");
+    expect(headers.get("Permissions-Policy")).toBe(
+      "camera=(), geolocation=(), microphone=()",
+    );
+    expect(headers.get("Strict-Transport-Security")).toBe(
+      "max-age=63072000; includeSubDomains; preload",
+    );
+  });
+
+  it("keeps HSTS out of non-production configs and applies headers app-wide", async () => {
+    const nonProdHeaders = getHeaderMap("test");
+    expect(nonProdHeaders.has("Strict-Transport-Security")).toBe(false);
+
+    const routes = await nextConfig.headers?.();
+    expect(routes).toHaveLength(1);
+    const firstRoute = routes?.[0];
+    expect(firstRoute?.source).toBe("/:path*");
+
+    const routeHeaders = new Map(
+      firstRoute?.headers.map(({ key, value }) => [key, value]) ?? [],
+    );
+    expect(routeHeaders.get("Content-Security-Policy")).toContain(
+      "form-action 'self' https://checkout.stripe.com",
+    );
+    expect(routeHeaders.get("X-Frame-Options")).toBe("DENY");
+  });
+});


### PR DESCRIPTION
## Summary
- make the shared security header policy testable from `next.config.ts` and lock the required CSP/HSTS/frame/referrer/permissions/nosniff assertions
- add a browser-style outcome feedback widget smoke test plus a short docs note for the intentional CSP allowances
- verify symptom checker, report/history, feedback, and Stripe checkout paths stay green alongside the full repo gates

## Verification
- `npx jest --runInBand --runTestsByPath tests/security-headers-config.test.ts tests/outcome-feedback.section.test.ts tests/history.page.test.ts tests/outcome-feedback.route.test.ts tests/stripe.checkout.route.test.ts tests/symptom-chat.route.test.ts`
- `npm test`
- `npm run build`
- local `next start --port 3100` smoke for `/symptom-checker`, `/history`, `/pricing`, including header checks and `_next/static` asset fetches