### PR TITLE
fix: quarantine private tester out-of-scope surfaces

### DIFF
--- a/src/app/(dashboard)/analytics/page.tsx
+++ b/src/app/(dashboard)/analytics/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { subDays } from "date-fns";
 import { BarChart3, Loader2 } from "lucide-react";
+import { PrivateTesterQuarantinedSurface } from "@/components/private-tester/quarantined-surface";
 import Card from "@/components/ui/card";
 import Select from "@/components/ui/select";
 import {
@@ -13,6 +14,7 @@ import {
 } from "@/components/analytics";
 import type { SymptomCheckEntry } from "@/components/timeline/types";
 import { symptomCheckRowToEntry, type SymptomCheckDbRow } from "@/lib/symptom-check-entry-map";
+import { getPrivateTesterQuarantinedSurface } from "@/lib/private-tester-scope";
 import { createClient, isSupabaseConfigured } from "@/lib/supabase";
 import { DEMO_ANALYTICS_SYMPTOM_ENTRIES } from "@/lib/demo-health-data";
 import { useAppStore } from "@/store/app-store";
@@ -32,7 +34,7 @@ function inDateRange(entry: SymptomCheckEntry, rangeKey: string, now: Date): boo
   return new Date(entry.created_at) >= cutoff;
 }
 
-export default function AnalyticsPage() {
+function AnalyticsPageContent() {
   const { pets } = useAppStore();
   const [rawEntries, setRawEntries] = useState<SymptomCheckEntry[]>([]);
   const [loading, setLoading] = useState(true);
@@ -178,4 +180,14 @@ export default function AnalyticsPage() {
       )}
     </div>
   );
+}
+
+export default function AnalyticsPage() {
+  const quarantinedSurface = getPrivateTesterQuarantinedSurface("/analytics");
+
+  if (quarantinedSurface) {
+    return <PrivateTesterQuarantinedSurface {...quarantinedSurface} />;
+  }
+
+  return <AnalyticsPageContent />;
 }

--- a/src/app/(dashboard)/community/page.tsx
+++ b/src/app/(dashboard)/community/page.tsx
@@ -8,6 +8,8 @@ import Textarea from "@/components/ui/textarea";
 import Input from "@/components/ui/input";
 import Select from "@/components/ui/select";
 import Modal from "@/components/ui/modal";
+import { PrivateTesterQuarantinedSurface } from "@/components/private-tester/quarantined-surface";
+import { getPrivateTesterQuarantinedSurface } from "@/lib/private-tester-scope";
 
 interface Post {
   id: string;
@@ -108,6 +110,7 @@ const initialPosts: Post[] = [
 ];
 
 export default function CommunityPage() {
+  const quarantinedSurface = getPrivateTesterQuarantinedSurface("/community");
   const [posts, setPosts] = useState(initialPosts);
   const [filter, setFilter] = useState("all");
   const [showNewPost, setShowNewPost] = useState(false);
@@ -159,6 +162,10 @@ export default function CommunityPage() {
       p.content.toLowerCase().includes(searchQuery.toLowerCase());
     return matchesCategory && matchesSearch;
   });
+
+  if (quarantinedSurface) {
+    return <PrivateTesterQuarantinedSurface {...quarantinedSurface} />;
+  }
 
   return (
     <div className="mx-auto max-w-4xl space-y-6">

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -3,18 +3,23 @@
 import { useState } from "react";
 import {
   Activity,
-  Stethoscope,
-  Pill,
-  Bell,
-  TrendingUp,
   AlertCircle,
+  Bell,
+  ClipboardList,
   Plus,
+  PawPrint,
+  ShieldAlert,
+  Stethoscope,
   Clock,
+  Pill,
+  TrendingUp,
 } from "lucide-react";
 import Link from "next/link";
 import Card from "@/components/ui/card";
 import Button from "@/components/ui/button";
 import HealthScoreCircle from "@/components/ui/health-score-circle";
+import { isPrivateTesterModeEnabled } from "@/lib/private-tester-access";
+import { PRIVATE_TESTER_FOCUS_SUMMARY } from "@/lib/private-tester-scope";
 import { useAppStore } from "@/store/app-store";
 
 const quickActions = [
@@ -91,9 +96,106 @@ const upcomingReminders = [
   { title: "Annual Vet Checkup", time: "In 5 days", type: "vet_appointment" },
 ];
 
+const privateTesterActions = [
+  {
+    description: "Run the dog symptom checker and review urgency guidance.",
+    href: "/symptom-checker",
+    icon: Stethoscope,
+    label: "Start symptom check",
+  },
+  {
+    description: "Open saved reports and share tester feedback from history.",
+    href: "/history",
+    icon: ClipboardList,
+    label: "Review reports and feedback",
+  },
+  {
+    description: "Add or update your dog profile for the private test.",
+    href: "/pets",
+    icon: PawPrint,
+    label: "Update dog profile",
+  },
+];
+
+function PrivateTesterDashboard({
+  activePetName,
+}: {
+  activePetName: string | null;
+}) {
+  return (
+    <div className="mx-auto max-w-5xl space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <h1 className="text-2xl font-bold text-gray-900">Private tester home</h1>
+          <p className="mt-1 text-gray-600">
+            {PRIVATE_TESTER_FOCUS_SUMMARY}
+          </p>
+        </div>
+        <Link href="/symptom-checker" className="w-full sm:w-auto">
+          <Button className="w-full sm:w-auto">
+            <Stethoscope className="mr-2 h-4 w-4" />
+            Open symptom checker
+          </Button>
+        </Link>
+      </div>
+
+      <Card className="border-amber-200 bg-amber-50 p-5">
+        <div className="flex items-start gap-3">
+          <div className="rounded-2xl bg-amber-100 p-3 text-amber-700">
+            <ShieldAlert className="h-6 w-6" />
+          </div>
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-wide text-amber-900">
+              Not part of this private test
+            </p>
+            <p className="mt-2 text-sm leading-6 text-amber-900">
+              Supplements, Paw Circle, analytics, reminders, and journal tools
+              are hidden or disabled for private testers.
+            </p>
+          </div>
+        </div>
+      </Card>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        {privateTesterActions.map((action) => (
+          <Card key={action.href} className="p-5">
+            <action.icon className="h-6 w-6 text-blue-600" />
+            <h2 className="mt-4 text-lg font-semibold text-gray-900">
+              {action.label}
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-gray-600">
+              {action.description}
+            </p>
+            <Link href={action.href} className="mt-4 inline-flex">
+              <Button variant="outline" size="sm">
+                {action.label}
+              </Button>
+            </Link>
+          </Card>
+        ))}
+      </div>
+
+      <Card className="p-5">
+        <h2 className="text-lg font-semibold text-gray-900">
+          Keep the private test focused
+        </h2>
+        <p className="mt-2 text-sm leading-6 text-gray-600">
+          Use the symptom checker for {activePetName || "your dog"}, open saved
+          reports from History, and share feedback from the report view so we can
+          improve the private test safely.
+        </p>
+      </Card>
+    </div>
+  );
+}
+
 export default function DashboardPage() {
   const { activePet } = useAppStore();
   const [healthScore] = useState(87);
+
+  if (isPrivateTesterModeEnabled()) {
+    return <PrivateTesterDashboard activePetName={activePet?.name ?? null} />;
+  }
 
   return (
     <div className="mx-auto max-w-7xl space-y-6">

--- a/src/app/(dashboard)/journal/page.tsx
+++ b/src/app/(dashboard)/journal/page.tsx
@@ -13,12 +13,14 @@ import {
   Trash2,
   Loader2,
 } from "lucide-react";
+import { PrivateTesterQuarantinedSurface } from "@/components/private-tester/quarantined-surface";
 import Card from "@/components/ui/card";
 import Button from "@/components/ui/button";
 import Textarea from "@/components/ui/textarea";
 import Select from "@/components/ui/select";
 import Modal from "@/components/ui/modal";
 import Badge from "@/components/ui/badge";
+import { getPrivateTesterQuarantinedSurface } from "@/lib/private-tester-scope";
 import { useAppStore } from "@/store/app-store";
 import { isSupabaseConfigured } from "@/lib/supabase";
 import type { JournalEntry, JournalMood, JournalSummary } from "@/types/journal";
@@ -66,7 +68,7 @@ function trendBadgeVariant(
   return "default";
 }
 
-export default function JournalPage() {
+function JournalPageContent() {
   const { activePet, pets } = useAppStore();
   const [entries, setEntries] = useState<JournalEntry[]>([]);
   const [loading, setLoading] = useState(true);
@@ -615,4 +617,14 @@ export default function JournalPage() {
       </Modal>
     </div>
   );
+}
+
+export default function JournalPage() {
+  const quarantinedSurface = getPrivateTesterQuarantinedSurface("/journal");
+
+  if (quarantinedSurface) {
+    return <PrivateTesterQuarantinedSurface {...quarantinedSurface} />;
+  }
+
+  return <JournalPageContent />;
 }

--- a/src/app/(dashboard)/reminders/page.tsx
+++ b/src/app/(dashboard)/reminders/page.tsx
@@ -13,11 +13,13 @@ import {
   Trash2,
   Edit2,
 } from "lucide-react";
+import { PrivateTesterQuarantinedSurface } from "@/components/private-tester/quarantined-surface";
 import Card from "@/components/ui/card";
 import Button from "@/components/ui/button";
 import Input from "@/components/ui/input";
 import Select from "@/components/ui/select";
 import Modal from "@/components/ui/modal";
+import { getPrivateTesterQuarantinedSurface } from "@/lib/private-tester-scope";
 
 interface ReminderItem {
   id: string;
@@ -110,7 +112,7 @@ const initialReminders: ReminderItem[] = [
   },
 ];
 
-export default function RemindersPage() {
+function RemindersPageContent() {
   const [reminders, setReminders] = useState(initialReminders);
   const [showAddModal, setShowAddModal] = useState(false);
   const [newReminder, setNewReminder] = useState({
@@ -310,4 +312,14 @@ export default function RemindersPage() {
       </Modal>
     </div>
   );
+}
+
+export default function RemindersPage() {
+  const quarantinedSurface = getPrivateTesterQuarantinedSurface("/reminders");
+
+  if (quarantinedSurface) {
+    return <PrivateTesterQuarantinedSurface {...quarantinedSurface} />;
+  }
+
+  return <RemindersPageContent />;
 }

--- a/src/app/(dashboard)/supplements/page.tsx
+++ b/src/app/(dashboard)/supplements/page.tsx
@@ -5,6 +5,8 @@ import { Pill, ExternalLink, Sparkles } from "lucide-react";
 import Card from "@/components/ui/card";
 import Button from "@/components/ui/button";
 import Badge from "@/components/ui/badge";
+import { PrivateTesterQuarantinedSurface } from "@/components/private-tester/quarantined-surface";
+import { getPrivateTesterQuarantinedSurface } from "@/lib/private-tester-scope";
 import { useAppStore } from "@/store/app-store";
 
 interface SupplementItem {
@@ -84,6 +86,7 @@ const priorityConfig = {
 };
 
 export default function SupplementsPage() {
+  const quarantinedSurface = getPrivateTesterQuarantinedSurface("/supplements");
   const { activePet } = useAppStore();
   const [supplements, setSupplements] = useState(aiRecommendations);
   const [generating, setGenerating] = useState(false);
@@ -105,6 +108,10 @@ export default function SupplementsPage() {
   const monthlyCost = supplements
     .filter((s) => s.isActive)
     .reduce((sum, s) => sum + parseInt(s.price.replace(/[^0-9]/g, "")), 0);
+
+  if (quarantinedSurface) {
+    return <PrivateTesterQuarantinedSurface {...quarantinedSurface} />;
+  }
 
   return (
     <div className="max-w-4xl mx-auto space-y-6">

--- a/src/components/dashboard/sidebar.tsx
+++ b/src/components/dashboard/sidebar.tsx
@@ -19,6 +19,7 @@ import {
   BarChart3,
   PawPrint,
 } from "lucide-react";
+import { filterPrivateTesterNavItems } from "@/lib/private-tester-scope";
 import { useAppStore } from "@/store/app-store";
 import { useAuth } from "@/hooks/useSupabase";
 
@@ -41,6 +42,7 @@ export default function Sidebar() {
   const { signOut } = useAuth();
   const [isDesktop, setIsDesktop] = useState(true);
   const previousIsDesktopRef = useRef<boolean | null>(null);
+  const visibleNavItems = filterPrivateTesterNavItems(navItems);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -134,7 +136,7 @@ export default function Sidebar() {
 
         {/* Navigation */}
         <nav className="flex-1 space-y-1 overflow-y-auto px-3 py-4">
-          {navItems.map((item) => {
+          {visibleNavItems.map((item) => {
             const isActive = pathname === item.href;
             return (
               <Link

--- a/src/components/private-tester/quarantined-surface.tsx
+++ b/src/components/private-tester/quarantined-surface.tsx
@@ -1,0 +1,86 @@
+import Link from "next/link";
+import {
+  ClipboardList,
+  PawPrint,
+  ShieldAlert,
+  Stethoscope,
+} from "lucide-react";
+import Button from "@/components/ui/button";
+import Card from "@/components/ui/card";
+import { PRIVATE_TESTER_FOCUS_SUMMARY } from "@/lib/private-tester-scope";
+
+interface PrivateTesterQuarantinedSurfaceProps {
+  detail: string;
+  featureLabel: string;
+}
+
+const fallbackActions = [
+  {
+    description: "Run the dog symptom checker and review urgency guidance.",
+    href: "/symptom-checker",
+    icon: Stethoscope,
+    label: "Open symptom checker",
+  },
+  {
+    description: "Review saved reports and open tester feedback from history.",
+    href: "/history",
+    icon: ClipboardList,
+    label: "Open reports and feedback",
+  },
+  {
+    description: "Add or update your dog profile during the private test.",
+    href: "/pets",
+    icon: PawPrint,
+    label: "Open dog profile",
+  },
+];
+
+export function PrivateTesterQuarantinedSurface({
+  detail,
+  featureLabel,
+}: PrivateTesterQuarantinedSurfaceProps) {
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <Card className="border-amber-200 bg-amber-50 p-6 sm:p-8">
+        <div className="flex items-start gap-3">
+          <div className="rounded-2xl bg-amber-100 p-3 text-amber-700">
+            <ShieldAlert className="h-6 w-6" />
+          </div>
+          <div className="space-y-3">
+            <p className="text-sm font-semibold uppercase tracking-wide text-amber-900">
+              Not part of this private test
+            </p>
+            <div>
+              <h1 className="text-2xl font-bold text-gray-900">
+                {featureLabel} is disabled for private testers
+              </h1>
+              <p className="mt-2 text-sm leading-6 text-gray-700">{detail}</p>
+            </div>
+            <p className="text-sm leading-6 text-amber-900">
+              {PRIVATE_TESTER_FOCUS_SUMMARY}
+            </p>
+          </div>
+        </div>
+      </Card>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        {fallbackActions.map((action) => (
+          <Card key={action.href} className="p-5">
+            <action.icon className="h-6 w-6 text-blue-600" />
+            <h2 className="mt-4 text-lg font-semibold text-gray-900">
+              {action.label}
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-gray-600">
+              {action.description}
+            </p>
+            <Link href={action.href} className="mt-4 inline-flex">
+              <Button variant="outline" size="sm">
+                {action.label}
+              </Button>
+            </Link>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/private-tester-scope.ts
+++ b/src/lib/private-tester-scope.ts
@@ -1,0 +1,62 @@
+import { isPrivateTesterModeEnabled } from "./private-tester-access";
+
+type EnvLike = Record<string, string | undefined>;
+
+export interface PrivateTesterScopedNavItem {
+  href: string;
+}
+
+export interface PrivateTesterQuarantinedSurface {
+  detail: string;
+  featureLabel: string;
+}
+
+export const PRIVATE_TESTER_FOCUS_SUMMARY =
+  "This private test is focused on dog symptom triage, urgency guidance, vet handoff reports, feedback, and onboarding.";
+
+const QUARANTINED_SURFACES: Record<string, PrivateTesterQuarantinedSurface> = {
+  "/analytics": {
+    detail: "Analytics dashboards are not part of this private test.",
+    featureLabel: "Health analytics",
+  },
+  "/community": {
+    detail: "Community features are not part of this private test.",
+    featureLabel: "Paw Circle",
+  },
+  "/journal": {
+    detail: "Journal tools are not part of this private test.",
+    featureLabel: "Journal",
+  },
+  "/reminders": {
+    detail: "Reminder tools are not part of this private test.",
+    featureLabel: "Reminder tools",
+  },
+  "/supplements": {
+    detail: "Supplement plans are not part of this private test.",
+    featureLabel: "Supplement plan",
+  },
+};
+
+export function getPrivateTesterQuarantinedSurface(
+  pathname: string | null | undefined,
+  env: EnvLike = process.env
+): PrivateTesterQuarantinedSurface | null {
+  if (!isPrivateTesterModeEnabled(env) || typeof pathname !== "string") {
+    return null;
+  }
+
+  return QUARANTINED_SURFACES[pathname] ?? null;
+}
+
+export function filterPrivateTesterNavItems<T extends PrivateTesterScopedNavItem>(
+  items: readonly T[],
+  env: EnvLike = process.env
+) {
+  if (!isPrivateTesterModeEnabled(env)) {
+    return [...items];
+  }
+
+  return items.filter(
+    (item) => getPrivateTesterQuarantinedSurface(item.href, env) === null
+  );
+}

--- a/tests/private-tester-scope-ui.test.ts
+++ b/tests/private-tester-scope-ui.test.ts
@@ -13,7 +13,7 @@ const mockUsePathname = jest.fn();
 const mockSignOut = jest.fn();
 
 jest.mock("next/link", () => {
-  const React = require("react");
+  const ReactActual = jest.requireActual<typeof import("react")>("react");
 
   return {
     __esModule: true,
@@ -24,7 +24,7 @@ jest.mock("next/link", () => {
     }: {
       children: React.ReactNode;
       href: string;
-    }) => React.createElement("a", { href, ...props }, children),
+    }) => ReactActual.createElement("a", { href, ...props }, children),
   };
 });
 

--- a/tests/private-tester-scope-ui.test.ts
+++ b/tests/private-tester-scope-ui.test.ts
@@ -2,8 +2,11 @@
 
 import * as React from "react";
 import { render, screen } from "@testing-library/react";
+import AnalyticsPage from "@/app/(dashboard)/analytics/page";
 import DashboardPage from "@/app/(dashboard)/dashboard/page";
 import CommunityPage from "@/app/(dashboard)/community/page";
+import JournalPage from "@/app/(dashboard)/journal/page";
+import RemindersPage from "@/app/(dashboard)/reminders/page";
 import SupplementsPage from "@/app/(dashboard)/supplements/page";
 import Sidebar from "@/components/dashboard/sidebar";
 import { useAppStore } from "@/store/app-store";
@@ -193,5 +196,43 @@ describe("private tester scope UI", () => {
     expect(screen.queryByText("Supplement Plan")).toBeNull();
     expect(screen.queryByText("Glucosamine & Chondroitin")).toBeNull();
     expect(screen.queryByText(/73% improvement in mobility/i)).toBeNull();
+  });
+
+  it("VET-1368 tester scope UI: quarantines direct route access for analytics, reminders, and journal", () => {
+    setPrivateTesterMode(true);
+
+    const directRoutes = [
+      {
+        component: AnalyticsPage,
+        detail: "Analytics dashboards are not part of this private test.",
+        heading: "Health analytics is disabled for private testers",
+      },
+      {
+        component: RemindersPage,
+        detail: "Reminder tools are not part of this private test.",
+        heading: "Reminder tools is disabled for private testers",
+      },
+      {
+        component: JournalPage,
+        detail: "Journal tools are not part of this private test.",
+        heading: "Journal is disabled for private testers",
+      },
+    ];
+
+    for (const route of directRoutes) {
+      const { unmount } = render(React.createElement(route.component));
+      expect(screen.getByText(route.heading)).toBeTruthy();
+      expect(screen.getByText(route.detail)).toBeTruthy();
+      expect(
+        screen.getByText(
+          "This private test is focused on dog symptom triage, urgency guidance, vet handoff reports, feedback, and onboarding."
+        )
+      ).toBeTruthy();
+      unmount();
+    }
+
+    expect(screen.queryByText("Health analytics")).toBeNull();
+    expect(screen.queryByText("Never miss a medication or appointment")).toBeNull();
+    expect(screen.queryByText("AI Weekly Summary")).toBeNull();
   });
 });

--- a/tests/private-tester-scope-ui.test.ts
+++ b/tests/private-tester-scope-ui.test.ts
@@ -1,0 +1,197 @@
+/** @jest-environment jsdom */
+
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import DashboardPage from "@/app/(dashboard)/dashboard/page";
+import CommunityPage from "@/app/(dashboard)/community/page";
+import SupplementsPage from "@/app/(dashboard)/supplements/page";
+import Sidebar from "@/components/dashboard/sidebar";
+import { useAppStore } from "@/store/app-store";
+import type { Pet, UserProfile } from "@/types";
+
+const mockUsePathname = jest.fn();
+const mockSignOut = jest.fn();
+
+jest.mock("next/link", () => {
+  const React = require("react");
+
+  return {
+    __esModule: true,
+    default: ({
+      children,
+      href,
+      ...props
+    }: {
+      children: React.ReactNode;
+      href: string;
+    }) => React.createElement("a", { href, ...props }, children),
+  };
+});
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => mockUsePathname(),
+}));
+
+jest.mock("@/hooks/useSupabase", () => ({
+  useAuth: () => ({
+    signOut: mockSignOut,
+  }),
+}));
+
+const TEST_PET = {
+  id: "pet-1",
+  user_id: "user-1",
+  name: "Buddy",
+  breed: "Golden Retriever",
+  species: "dog",
+  age_years: 4,
+  age_months: 0,
+  weight: 55,
+  existing_conditions: [],
+} as Pet;
+
+const TEST_USER = {
+  id: "user-1",
+  email: "tester@example.com",
+  full_name: "Tester",
+  subscription_status: "free_trial",
+  created_at: "2026-04-21T12:00:00.000Z",
+} as UserProfile;
+
+function seedStore() {
+  useAppStore.setState((state) => ({
+    ...state,
+    activePet: TEST_PET,
+    pets: [TEST_PET],
+    sidebarOpen: true,
+    user: TEST_USER,
+    userDataLoaded: true,
+  }));
+}
+
+function setPrivateTesterMode(enabled: boolean) {
+  if (enabled) {
+    process.env.NEXT_PUBLIC_PRIVATE_TESTER_MODE = "1";
+    return;
+  }
+
+  delete process.env.NEXT_PUBLIC_PRIVATE_TESTER_MODE;
+}
+
+describe("private tester scope UI", () => {
+  const originalPrivateTesterMode = process.env.NEXT_PUBLIC_PRIVATE_TESTER_MODE;
+
+  beforeEach(() => {
+    seedStore();
+    jest.clearAllMocks();
+    mockUsePathname.mockReturnValue("/dashboard");
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: jest.fn().mockImplementation((query: string) => ({
+        addEventListener: jest.fn(),
+        addListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+        matches: true,
+        media: query,
+        onchange: null,
+        removeEventListener: jest.fn(),
+        removeListener: jest.fn(),
+      })),
+    });
+  });
+
+  afterAll(() => {
+    if (originalPrivateTesterMode) {
+      process.env.NEXT_PUBLIC_PRIVATE_TESTER_MODE = originalPrivateTesterMode;
+      return;
+    }
+
+    delete process.env.NEXT_PUBLIC_PRIVATE_TESTER_MODE;
+  });
+
+  it("VET-1368 tester scope UI: hides out-of-scope sidebar navigation in private tester mode", () => {
+    setPrivateTesterMode(true);
+
+    render(React.createElement(Sidebar));
+
+    expect(screen.getByText("Dashboard")).toBeTruthy();
+    expect(screen.getByText("My Dogs")).toBeTruthy();
+    expect(screen.getByText("Symptom Checker")).toBeTruthy();
+    expect(screen.getByText("History")).toBeTruthy();
+    expect(screen.queryByText("Analytics")).toBeNull();
+    expect(screen.queryByText("Supplements")).toBeNull();
+    expect(screen.queryByText("Reminders")).toBeNull();
+    expect(screen.queryByText("Journal")).toBeNull();
+    expect(screen.queryByText("Paw Circle")).toBeNull();
+  });
+
+  it("VET-1368 tester scope UI: keeps the full sidebar navigation when private tester mode is off", () => {
+    setPrivateTesterMode(false);
+
+    render(React.createElement(Sidebar));
+
+    expect(screen.getByText("Analytics")).toBeTruthy();
+    expect(screen.getByText("Supplements")).toBeTruthy();
+    expect(screen.getByText("Reminders")).toBeTruthy();
+    expect(screen.getByText("Journal")).toBeTruthy();
+    expect(screen.getByText("Paw Circle")).toBeTruthy();
+  });
+
+  it("VET-1368 tester scope UI: swaps the dashboard to private-test-safe focus content", () => {
+    setPrivateTesterMode(true);
+
+    render(React.createElement(DashboardPage));
+
+    expect(screen.getByText("Private tester home")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "This private test is focused on dog symptom triage, urgency guidance, vet handoff reports, feedback, and onboarding."
+      )
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Supplements, Paw Circle, analytics, reminders, and journal tools are hidden or disabled for private testers."
+      )
+    ).toBeTruthy();
+    expect(screen.getAllByText("Start symptom check").length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText("Review reports and feedback").length
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText("Daily Health Score")).toBeNull();
+    expect(screen.queryByText("View Supplements")).toBeNull();
+    expect(screen.queryByText("Joint supplement administered")).toBeNull();
+  });
+
+  it("VET-1368 tester scope UI: quarantines Paw Circle with safe private-test copy", () => {
+    setPrivateTesterMode(true);
+
+    render(React.createElement(CommunityPage));
+
+    expect(
+      screen.getByText("Paw Circle is disabled for private testers")
+    ).toBeTruthy();
+    expect(
+      screen.getByText("Community features are not part of this private test.")
+    ).toBeTruthy();
+    expect(screen.queryByText("Connect with fellow dog parents")).toBeNull();
+    expect(
+      screen.queryByText("Cooper's mobility improved so much in 3 months!")
+    ).toBeNull();
+  });
+
+  it("VET-1368 tester scope UI: quarantines supplements with safe private-test copy", () => {
+    setPrivateTesterMode(true);
+
+    render(React.createElement(SupplementsPage));
+
+    expect(
+      screen.getByText("Supplement plan is disabled for private testers")
+    ).toBeTruthy();
+    expect(
+      screen.getByText("Supplement plans are not part of this private test.")
+    ).toBeTruthy();
+    expect(screen.queryByText("Supplement Plan")).toBeNull();
+    expect(screen.queryByText("Glucosamine & Chondroitin")).toBeNull();
+    expect(screen.queryByText(/73% improvement in mobility/i)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- quarantine dashboard, supplements, and community surfaces for private tester mode
- hide out-of-scope sidebar routes and route testers back to symptom checker, reports, feedback, and dog onboarding
- add UI regression coverage for tester-mode surface visibility and quarantine copy

## Verification
- npm test
- npm run smoke:private-tester:access
- npm run build

Closes #331