### PR TITLE
fix: sanitize raw auth fetch failures

### DIFF
--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -11,6 +11,7 @@ import {
   buildCallbackUrl,
   buildRecoveryRedirectPath,
   getAuthFeedbackMessage,
+  getAuthActionErrorMessage,
   resolvePostAuthRedirect,
 } from "@/lib/auth-routing";
 import { createClient, isSupabaseConfigured } from "@/lib/supabase";
@@ -53,7 +54,12 @@ export default function ForgotPasswordPage() {
       if (resetError) throw resetError;
       setSent(true);
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : "Failed to send reset email";
+      console.error("Failed to send reset email", err);
+      const message = getAuthActionErrorMessage(
+        err,
+        "password_reset",
+        "We couldn't send the reset email right now. Please try again."
+      );
       setError(message);
     } finally {
       setLoading(false);

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -9,6 +9,7 @@ import Input from "@/components/ui/input";
 import {
   appendRedirectParam,
   getAuthFeedbackMessage,
+  getAuthActionErrorMessage,
   resolvePostAuthRedirect,
 } from "@/lib/auth-routing";
 import { createClient, isSupabaseConfigured } from "@/lib/supabase";
@@ -50,7 +51,12 @@ export default function LoginPage() {
       if (authError) throw authError;
       router.replace(redirectTarget);
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : "Failed to sign in";
+      console.error("Failed to sign in", err);
+      const message = getAuthActionErrorMessage(
+        err,
+        "login",
+        "We couldn't sign you in right now. Please try again."
+      );
       setError(message);
     } finally {
       setLoading(false);

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -10,6 +10,7 @@ import {
   appendRedirectParam,
   buildCallbackUrl,
   getAuthFeedbackMessage,
+  getAuthActionErrorMessage,
   resolvePostAuthRedirect,
 } from "@/lib/auth-routing";
 import { createClient, isSupabaseConfigured } from "@/lib/supabase";
@@ -71,7 +72,12 @@ export default function SignupPage() {
 
       setSuccessMessage("Check your email to confirm your account and continue.");
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : "Failed to create account";
+      console.error("Failed to create account", err);
+      const message = getAuthActionErrorMessage(
+        err,
+        "signup",
+        "We couldn't create your account right now. Please try again."
+      );
       setError(message);
     } finally {
       setLoading(false);

--- a/src/lib/auth-routing.ts
+++ b/src/lib/auth-routing.ts
@@ -31,6 +31,21 @@ export const AUTH_REASON_MESSAGES: Record<string, string> = {
   check_email: "Check your email for the link to continue.",
 };
 
+const AUTH_NETWORK_ERROR_PATTERNS = [
+  "Failed to fetch",
+  "Load failed",
+  "NetworkError",
+  "Network request failed",
+  "ERR_NAME_NOT_RESOLVED",
+];
+
+const AUTH_NETWORK_ERROR_MESSAGES = {
+  login: "We couldn't reach secure sign-in right now. Please try again in a moment.",
+  password_reset:
+    "We couldn't reach password reset right now. Please try again in a moment.",
+  signup: "We couldn't reach account setup right now. Please try again in a moment.",
+} as const;
+
 function toPath(url: URL) {
   return `${url.pathname}${url.search}${url.hash}`;
 }
@@ -173,4 +188,22 @@ export function getAuthFeedbackMessage(reason: string | null, error: string | nu
   }
 
   return null;
+}
+
+export function getAuthActionErrorMessage(
+  error: unknown,
+  action: keyof typeof AUTH_NETWORK_ERROR_MESSAGES,
+  fallbackMessage: string
+) {
+  const rawMessage = error instanceof Error ? error.message.trim() : "";
+
+  if (!rawMessage) {
+    return fallbackMessage;
+  }
+
+  if (AUTH_NETWORK_ERROR_PATTERNS.some((pattern) => rawMessage.includes(pattern))) {
+    return AUTH_NETWORK_ERROR_MESSAGES[action];
+  }
+
+  return rawMessage;
 }

--- a/tests/auth-pages.network-error.test.tsx
+++ b/tests/auth-pages.network-error.test.tsx
@@ -1,0 +1,170 @@
+/** @jest-environment jsdom */
+
+import * as React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import ForgotPasswordPage from "@/app/(auth)/forgot-password/page";
+import LoginPage from "@/app/(auth)/login/page";
+import SignupPage from "@/app/(auth)/signup/page";
+
+const mockReplace = jest.fn();
+const mockSearchParams = new URLSearchParams();
+const mockCreateClient = jest.fn();
+
+jest.mock("next/link", () => {
+  const ReactActual = jest.requireActual<typeof import("react")>("react");
+
+  return {
+    __esModule: true,
+    default: ({
+      children,
+      href,
+      ...props
+    }: {
+      children: React.ReactNode;
+      href: string;
+    }) => ReactActual.createElement("a", { href, ...props }, children),
+  };
+});
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    replace: mockReplace,
+  }),
+  useSearchParams: () => mockSearchParams,
+}));
+
+jest.mock("@/lib/supabase", () => ({
+  createClient: () => mockCreateClient(),
+  isSupabaseConfigured: true,
+}));
+
+function fillRequiredAuthFields() {
+  fireEvent.change(screen.getByLabelText("Email"), {
+    target: { value: "owner@example.com" },
+  });
+  fireEvent.change(screen.getByLabelText("Password"), {
+    target: { value: "super-secret-password" },
+  });
+}
+
+describe("auth page network error handling", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows a friendly login message instead of the raw fetch failure", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    mockCreateClient.mockReturnValue({
+      auth: {
+        signInWithPassword: jest
+          .fn()
+          .mockRejectedValue(new TypeError("Failed to fetch")),
+      },
+    });
+
+    try {
+      render(React.createElement(LoginPage));
+      fillRequiredAuthFields();
+
+      fireEvent.click(screen.getByRole("button", { name: "Sign In" }));
+
+      await waitFor(() =>
+        expect(
+          screen.getByText(
+            "We couldn't reach secure sign-in right now. Please try again in a moment."
+          )
+        ).toBeTruthy()
+      );
+
+      expect(screen.queryByText("Failed to fetch")).toBeNull();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("keeps explicit credential errors on the login form", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    mockCreateClient.mockReturnValue({
+      auth: {
+        signInWithPassword: jest
+          .fn()
+          .mockResolvedValue({ error: new Error("Invalid login credentials") }),
+      },
+    });
+
+    try {
+      render(React.createElement(LoginPage));
+      fillRequiredAuthFields();
+
+      fireEvent.click(screen.getByRole("button", { name: "Sign In" }));
+
+      await waitFor(() =>
+        expect(screen.getByText("Invalid login credentials")).toBeTruthy()
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("shows the friendly network message on account creation failure", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    mockCreateClient.mockReturnValue({
+      auth: {
+        signUp: jest
+          .fn()
+          .mockRejectedValue(new TypeError("Network request failed")),
+      },
+    });
+
+    try {
+      render(React.createElement(SignupPage));
+
+      fireEvent.change(screen.getByLabelText("Full Name"), {
+        target: { value: "Dog Parent" },
+      });
+      fillRequiredAuthFields();
+
+      fireEvent.click(screen.getByRole("button", { name: "Start Free Trial" }));
+
+      await waitFor(() =>
+        expect(
+          screen.getByText(
+            "We couldn't reach account setup right now. Please try again in a moment."
+          )
+        ).toBeTruthy()
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("shows the friendly network message on password reset failure", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    mockCreateClient.mockReturnValue({
+      auth: {
+        resetPasswordForEmail: jest
+          .fn()
+          .mockRejectedValue(new TypeError("Load failed")),
+      },
+    });
+
+    try {
+      render(React.createElement(ForgotPasswordPage));
+
+      fireEvent.change(screen.getByLabelText("Email"), {
+        target: { value: "owner@example.com" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Send Reset Link" }));
+
+      await waitFor(() =>
+        expect(
+          screen.getByText(
+            "We couldn't reach password reset right now. Please try again in a moment."
+          )
+        ).toBeTruthy()
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});

--- a/tests/auth-routing.test.ts
+++ b/tests/auth-routing.test.ts
@@ -4,6 +4,7 @@ import {
   buildRecoveryRedirectPath,
   buildRedirectTarget,
   buildLoginPath,
+  getAuthActionErrorMessage,
   isProtectedPath,
   resolvePostAuthRedirect,
   sanitizeRedirectTarget,
@@ -77,5 +78,32 @@ describe("VET-1215 auth routing helpers", () => {
     expect(buildRedirectTarget("/notifications", "?tab=unread")).toBe(
       "/notifications?tab=unread"
     );
+  });
+
+  it("sanitizes raw network failures for auth actions", () => {
+    expect(
+      getAuthActionErrorMessage(
+        new TypeError("Failed to fetch"),
+        "login",
+        "Fallback"
+      )
+    ).toBe("We couldn't reach secure sign-in right now. Please try again in a moment.");
+    expect(
+      getAuthActionErrorMessage(
+        new TypeError("Network request failed"),
+        "signup",
+        "Fallback"
+      )
+    ).toBe("We couldn't reach account setup right now. Please try again in a moment.");
+  });
+
+  it("preserves explicit auth provider errors", () => {
+    expect(
+      getAuthActionErrorMessage(
+        new Error("Invalid login credentials"),
+        "login",
+        "Fallback"
+      )
+    ).toBe("Invalid login credentials");
   });
 });


### PR DESCRIPTION
## Summary
- replace raw browser network exceptions on login, signup, and password reset with user-friendly auth connectivity messages
- keep explicit auth-provider messages like invalid credentials visible to the user
- add auth helper and auth-page regressions for unreachable backend failures

## Validation
- 
px jest tests/auth-routing.test.ts tests/auth-pages.network-error.test.tsx --runInBand --verbose
- 
pm run build
- 
pm test

## Notes
This resolves the visible \Failed to fetch\ banner reported on the auth forms.

The separate production auth outage is still a Vercel/Supabase environment incident: current production is shipping a dead \NEXT_PUBLIC_SUPABASE_URL\ host, so real sign-in will remain blocked until that env is corrected and redeployed.