### PR TITLE
fix(VET-1386): harden production feedback persistence failures

### DIFF
--- a/src/app/api/ai/outcome-feedback/route.ts
+++ b/src/app/api/ai/outcome-feedback/route.ts
@@ -44,6 +44,12 @@ type OutcomeFeedbackRequestBody = z.infer<
   typeof OutcomeFeedbackRequestBodySchema
 >;
 
+function getTesterFeedbackFailureStatus(
+  errorCode?: "not_found" | "server_unavailable"
+) {
+  return errorCode === "not_found" ? 404 : 503;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -205,16 +211,12 @@ export async function POST(request: Request) {
   const saved = await saveTesterFeedback(parsedTesterFeedback.data, auth.user.id);
 
   if (!saved.ok || !saved.caseSummary) {
-    const status =
-      saved.warnings.some((warning) => warning.toLowerCase().includes("not found"))
-        ? 404
-        : 503;
     return NextResponse.json(
       {
         ok: false,
         error: "Unable to save outcome feedback",
       },
-      { status }
+      { status: getTesterFeedbackFailureStatus(saved.errorCode) }
     );
   }
 
@@ -252,9 +254,9 @@ export async function GET(request: Request) {
     return NextResponse.json(
       {
         ok: false,
-        error: listed.warnings[0] ?? "Unable to load outcome feedback cases",
+        error: "Unable to load outcome feedback cases",
       },
-      { status: 503 }
+      { status: getTesterFeedbackFailureStatus(listed.errorCode) }
     );
   }
 

--- a/src/components/tester-feedback/widget.tsx
+++ b/src/components/tester-feedback/widget.tsx
@@ -43,6 +43,7 @@ function getSafeFeedbackErrorMessage(status: number) {
       return "Please review your feedback and try again.";
     case 401:
       return "Please sign in again to submit feedback.";
+    case 403:
     case 404:
       return "We could not link this feedback to a saved report.";
     case 429:

--- a/src/lib/tester-feedback-storage.ts
+++ b/src/lib/tester-feedback-storage.ts
@@ -23,12 +23,14 @@ interface SymptomCheckRow {
 }
 
 export interface TesterFeedbackSaveResult {
+  errorCode?: "not_found" | "server_unavailable";
   ok: boolean;
   caseSummary: TesterFeedbackCaseSummary | null;
   warnings: string[];
 }
 
 export interface TesterFeedbackListResult {
+  errorCode?: "not_found" | "server_unavailable";
   ok: boolean;
   cases: TesterFeedbackCaseSummary[];
   warnings: string[];
@@ -46,6 +48,7 @@ async function loadOwnedSymptomChecks(
   userId: string,
   symptomCheckId?: string
 ): Promise<{
+  errorCode?: "server_unavailable";
   ok: boolean;
   rows: SymptomCheckRow[];
   warnings: string[];
@@ -53,6 +56,7 @@ async function loadOwnedSymptomChecks(
   const supabase = getServiceSupabase();
   if (!supabase) {
     return {
+      errorCode: "server_unavailable",
       ok: false,
       rows: [],
       warnings: ["Supabase is not configured"],
@@ -67,6 +71,7 @@ async function loadOwnedSymptomChecks(
   if (petError) {
     console.error("[TesterFeedback] Failed to load owned pets:", petError);
     return {
+      errorCode: "server_unavailable",
       ok: false,
       rows: [],
       warnings: ["Failed to load owned pets"],
@@ -102,6 +107,7 @@ async function loadOwnedSymptomChecks(
   if (error) {
     console.error("[TesterFeedback] Failed to load symptom checks:", error);
     return {
+      errorCode: "server_unavailable",
       ok: false,
       rows: [],
       warnings: ["Failed to load symptom checks"],
@@ -192,6 +198,7 @@ export async function saveTesterFeedbackToDB(input: {
 
   if (!ownedChecks.ok) {
     return {
+      errorCode: ownedChecks.errorCode,
       ok: false,
       caseSummary: null,
       warnings: ownedChecks.warnings,
@@ -201,6 +208,7 @@ export async function saveTesterFeedbackToDB(input: {
   const row = ownedChecks.rows[0];
   if (!row) {
     return {
+      errorCode: "not_found",
       ok: false,
       caseSummary: null,
       warnings: ["Symptom check not found or access denied"],
@@ -210,6 +218,7 @@ export async function saveTesterFeedbackToDB(input: {
   const supabase = getServiceSupabase();
   if (!supabase) {
     return {
+      errorCode: "server_unavailable",
       ok: false,
       caseSummary: null,
       warnings: ["Supabase is not configured"],
@@ -236,6 +245,7 @@ export async function saveTesterFeedbackToDB(input: {
   if (error) {
     console.error("[TesterFeedback] Failed to save tester feedback:", error);
     return {
+      errorCode: "server_unavailable",
       ok: false,
       caseSummary: null,
       warnings: ["Unable to save tester feedback"],
@@ -264,6 +274,7 @@ export async function listTesterFeedbackCases(input: {
 
   if (!ownedChecks.ok) {
     return {
+      errorCode: ownedChecks.errorCode,
       ok: false,
       cases: [],
       warnings: ownedChecks.warnings,

--- a/tests/outcome-feedback.route.test.ts
+++ b/tests/outcome-feedback.route.test.ts
@@ -281,6 +281,58 @@ describe("outcome-feedback route", () => {
     expect(payload.warnings).toBeUndefined();
   });
 
+  it("sanitizes tester feedback save failures without parsing warning text", async () => {
+    mockSaveTesterFeedbackToDB.mockResolvedValue({
+      ok: false,
+      errorCode: "not_found",
+      caseSummary: null,
+      warnings: [
+        "Owner notes: Piper needed sedation after the emergency visit",
+      ],
+    });
+
+    const { POST } = await import("@/app/api/ai/outcome-feedback/route");
+    const response = await POST(
+      makePostRequest({
+        symptomCheckId: "11111111-1111-1111-1111-111111111111",
+        helpfulness: "no",
+        confusingAreas: ["report"],
+        trustLevel: "no",
+        notes: "Piper needed sedation after the emergency visit",
+      })
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(payload).toEqual({
+      ok: false,
+      error: "Unable to save outcome feedback",
+    });
+    expect(JSON.stringify(payload)).not.toContain("Piper");
+  });
+
+  it("sanitizes tester feedback list failures without exposing storage warnings", async () => {
+    mockListTesterFeedbackCases.mockResolvedValue({
+      ok: false,
+      errorCode: "server_unavailable",
+      cases: [],
+      warnings: [
+        "Owner notes: Piper needed sedation after the emergency visit",
+      ],
+    });
+
+    const { GET } = await import("@/app/api/ai/outcome-feedback/route");
+    const response = await GET(makeGetRequest("?flaggedOnly=true"));
+    const payload = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(payload).toEqual({
+      ok: false,
+      error: "Unable to load outcome feedback cases",
+    });
+    expect(JSON.stringify(payload)).not.toContain("Piper");
+  });
+
   it("blocks repeated abuse when the route limiter trips", async () => {
     mockCheckRateLimit.mockResolvedValue({
       success: false,

--- a/tests/outcome-feedback.section.test.ts
+++ b/tests/outcome-feedback.section.test.ts
@@ -119,4 +119,37 @@ describe("OutcomeFeedbackSection", () => {
     );
     expect(screen.queryByText(/Piper needed sedation/i)).toBeNull();
   });
+
+  it("treats forbidden saves like missing-report failures without echoing server text", async () => {
+    const fetchSpy = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({
+        ok: false,
+        error: "Owner notes: Piper needed sedation after the emergency visit.",
+      }),
+    });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      writable: true,
+      value: fetchSpy,
+    });
+
+    render(
+      React.createElement(OutcomeFeedbackSection, {
+        report: buildReport(),
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Send feedback" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "We could not link this feedback to a saved report.",
+        ),
+      ).toBeTruthy(),
+    );
+    expect(screen.queryByText(/Piper needed sedation/i)).toBeNull();
+  });
 });

--- a/tests/tester-feedback-storage.test.ts
+++ b/tests/tester-feedback-storage.test.ts
@@ -172,4 +172,44 @@ describe("tester feedback storage", () => {
       }),
     );
   });
+
+  it("returns a structured not_found error when feedback cannot be linked to an owned report", async () => {
+    const row: MutableSymptomCheckRow = {
+      id: "11111111-1111-1111-1111-111111111111",
+      pet_id: null,
+      symptoms: "Repeated vomiting with pale gums",
+      ai_response: JSON.stringify({
+        recommendation: "emergency_vet",
+        title: "Emergency vomiting case",
+      }),
+      severity: "emergency",
+      recommendation: "emergency_vet",
+      created_at: "2026-04-20T12:00:00.000Z",
+    };
+
+    mockGetServiceSupabase.mockReturnValue(createSupabaseMock(row));
+
+    const { saveTesterFeedbackToDB } = await import(
+      "@/lib/tester-feedback-storage"
+    );
+
+    const result = await saveTesterFeedbackToDB({
+      userId: "owner-1",
+      feedback: {
+        symptomCheckId: row.id,
+        helpfulness: "no",
+        confusingAreas: ["report"],
+        trustLevel: "not_sure",
+        notes: "Piper needed sedation after the emergency visit.",
+        surface: "result_page",
+      },
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      errorCode: "not_found",
+      caseSummary: null,
+      warnings: ["Symptom check not found or access denied"],
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Tightens the real tester feedback persistence path so production failures stay sanitized and machine-readable instead of relying on warning-string parsing.

## What changed

- adds structured error codes for tester feedback save/list failures
- sanitizes API failure responses so client-visible errors never echo storage warnings or owner notes
- treats forbidden missing-link failures the same as missing report linkage in the tester widget
- adds regression coverage for structured not-found failures, sanitized list failures, and persisted flagged feedback review data

## Validation

- `npx jest tests/outcome-feedback.route.test.ts tests/outcome-feedback.section.test.ts tests/tester-feedback-storage.test.ts --runInBand --verbose`
- `npm test`
- `npm run build`
- `npm run smoke:private-tester`

## Scope

Targets `codex/vet-1385-cohort1-production-blockers` only.