### PR TITLE
VET-1388: honor profile-based admin auth for tester access

### DIFF
--- a/src/lib/admin-auth.ts
+++ b/src/lib/admin-auth.ts
@@ -80,23 +80,25 @@ function isAdminViaAuthMetadata(user: {
   );
 }
 
-async function isAdminViaUsersTable(
+function isAdminFromRoleRow(value: unknown) {
+  const row = asObject(value);
+
+  return hasAdminRole(row?.role) || isTruthyAdminFlag(row?.is_admin);
+}
+
+async function isAdminViaRoleTable(
   supabase: Awaited<ReturnType<typeof createServerSupabaseClient>>,
+  table: "profiles" | "users",
   userId: string
 ) {
   try {
     const { data } = await supabase
-      .from("users")
+      .from(table)
       .select("role, is_admin")
       .eq("id", userId)
       .maybeSingle();
 
-    if (!data || typeof data !== "object") {
-      return false;
-    }
-
-    const row = data as Record<string, unknown>;
-    return row.role === "admin" || row.is_admin === true;
+    return isAdminFromRoleRow(data);
   } catch {
     return false;
   }
@@ -130,7 +132,11 @@ export async function getAdminRequestContext(): Promise<AdminRequestContext | nu
       return { email, isDemo: false, userId: user.id };
     }
 
-    if (await isAdminViaUsersTable(supabase, user.id)) {
+    if (await isAdminViaRoleTable(supabase, "users", user.id)) {
+      return { email, isDemo: false, userId: user.id };
+    }
+
+    if (await isAdminViaRoleTable(supabase, "profiles", user.id)) {
       return { email, isDemo: false, userId: user.id };
     }
   } catch (error) {

--- a/tests/admin-auth.test.ts
+++ b/tests/admin-auth.test.ts
@@ -5,12 +5,19 @@ jest.mock("@/lib/supabase-server", () => ({
 }));
 
 function buildSupabaseClient({
+  profilesRow = null,
   user = null,
   usersRow = null,
 }: {
+  profilesRow?: Record<string, unknown> | null;
   user?: Record<string, unknown> | null;
   usersRow?: Record<string, unknown> | null;
 } = {}) {
+  const rowsByTable: Record<string, Record<string, unknown> | null> = {
+    profiles: profilesRow,
+    users: usersRow,
+  };
+
   return {
     auth: {
       getUser: jest.fn().mockResolvedValue({
@@ -18,16 +25,16 @@ function buildSupabaseClient({
         error: null,
       }),
     },
-    from: jest.fn().mockReturnValue({
+    from: jest.fn((table: string) => ({
       select: jest.fn().mockReturnValue({
         eq: jest.fn().mockReturnValue({
           maybeSingle: jest.fn().mockResolvedValue({
-            data: usersRow,
+            data: rowsByTable[table] ?? null,
             error: null,
           }),
         }),
       }),
-    }),
+    })),
   };
 }
 
@@ -115,10 +122,67 @@ describe("admin auth override hardening", () => {
     });
   });
 
+  it("accepts founder/admin users from the ADMIN_EMAILS allowlist", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.ADMIN_EMAILS = " founder@pawvital.ai , backup@pawvital.ai ";
+    mockCreateServerSupabaseClient.mockResolvedValue(
+      buildSupabaseClient({
+        user: {
+          app_metadata: {
+            provider: "email",
+          },
+          email: "Founder@PawVital.ai",
+          id: "founder-admin-id",
+          role: "authenticated",
+          user_metadata: {},
+        },
+      })
+    );
+
+    const { getAdminRequestContext } = await import("@/lib/admin-auth");
+    await expect(getAdminRequestContext()).resolves.toEqual({
+      email: "founder@pawvital.ai",
+      isDemo: false,
+      userId: "founder-admin-id",
+    });
+  });
+
+  it("accepts admins flagged in the profiles row when auth metadata is absent", async () => {
+    process.env.NODE_ENV = "production";
+    mockCreateServerSupabaseClient.mockResolvedValue(
+      buildSupabaseClient({
+        profilesRow: {
+          is_admin: true,
+          role: "admin",
+        },
+        user: {
+          app_metadata: {
+            provider: "email",
+          },
+          email: "Founder@PawVital.ai",
+          id: "founder-admin-id",
+          role: "authenticated",
+          user_metadata: {},
+        },
+      })
+    );
+
+    const { getAdminRequestContext } = await import("@/lib/admin-auth");
+    await expect(getAdminRequestContext()).resolves.toEqual({
+      email: "founder@pawvital.ai",
+      isDemo: false,
+      userId: "founder-admin-id",
+    });
+  });
+
   it("blocks signed-in non-admin users without admin auth metadata or table role", async () => {
     process.env.NODE_ENV = "production";
     mockCreateServerSupabaseClient.mockResolvedValue(
       buildSupabaseClient({
+        profilesRow: {
+          is_admin: false,
+          role: "tester",
+        },
         user: {
           app_metadata: {
             provider: "email",

--- a/tests/admin-tester-access.page.test.ts
+++ b/tests/admin-tester-access.page.test.ts
@@ -1,0 +1,137 @@
+import { renderToStaticMarkup } from "react-dom/server";
+
+const mockGetAdminRequestContext = jest.fn();
+const mockBuildPrivateTesterDashboardFallback = jest.fn();
+const mockListPrivateTesterSummaries = jest.fn();
+const mockTesterAccessDashboardClient = jest.fn();
+
+jest.mock("next/link", () => {
+  const React = jest.requireActual("react") as typeof import("react");
+
+  return {
+    __esModule: true,
+    default: ({
+      children,
+      href,
+      ...props
+    }: {
+      children: React.ReactNode;
+      href: string;
+    }) => React.createElement("a", { href, ...props }, children),
+  };
+});
+
+jest.mock("@/lib/admin-auth", () => ({
+  getAdminRequestContext: (...args: unknown[]) =>
+    mockGetAdminRequestContext(...args),
+}));
+
+jest.mock("@/lib/private-tester-admin", () => ({
+  buildPrivateTesterDashboardFallback: (...args: unknown[]) =>
+    mockBuildPrivateTesterDashboardFallback(...args),
+  listPrivateTesterSummaries: (...args: unknown[]) =>
+    mockListPrivateTesterSummaries(...args),
+}));
+
+jest.mock(
+  "@/app/(dashboard)/admin/tester-access/TesterAccessDashboardClient",
+  () => ({
+    __esModule: true,
+    default: (props: { initialData: unknown }) => {
+      mockTesterAccessDashboardClient(props);
+      return "tester-access-dashboard-client";
+    },
+  })
+);
+
+async function renderPage() {
+  const { default: AdminTesterAccessPage } = await import(
+    "@/app/(dashboard)/admin/tester-access/page"
+  );
+
+  return renderToStaticMarkup(await AdminTesterAccessPage());
+}
+
+describe("AdminTesterAccessPage", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    mockBuildPrivateTesterDashboardFallback.mockReturnValue({
+      config: { allowedEmailCount: 0 },
+      summary: { total: 0 },
+      testers: [],
+    });
+  });
+
+  it("blocks unauthorized callers before any tester access data is loaded", async () => {
+    mockGetAdminRequestContext.mockResolvedValue(null);
+
+    const html = await renderPage();
+
+    expect(html).toContain("Admin access required");
+    expect(html).toContain(
+      "Tester access controls are only available to signed-in admins."
+    );
+    expect(mockListPrivateTesterSummaries).not.toHaveBeenCalled();
+    expect(mockTesterAccessDashboardClient).not.toHaveBeenCalled();
+  });
+
+  it("renders the tester access dashboard for admins with the sanitized dataset", async () => {
+    mockGetAdminRequestContext.mockResolvedValue({
+      email: "founder@pawvital.ai",
+      isDemo: false,
+      userId: "admin-1",
+    });
+    mockListPrivateTesterSummaries.mockResolvedValue({
+      config: {
+        allowedEmailCount: 1,
+        allowedEmails: ["tester@example.com"],
+        blockedEmailCount: 0,
+        blockedEmails: [],
+        freeAccess: true,
+        guestSymptomChecker: false,
+        inviteOnly: true,
+        modeEnabled: true,
+      },
+      summary: {
+        active: 1,
+        authAccessDisabled: 0,
+        blocked: 0,
+        deletionRequested: 0,
+        negativeFeedbackEntries: 0,
+        symptomChecks: 1,
+        total: 1,
+      },
+      testers: [],
+    });
+
+    const html = await renderPage();
+
+    expect(html).toContain("tester-access-dashboard-client");
+    expect(mockListPrivateTesterSummaries).toHaveBeenCalledTimes(1);
+    expect(mockTesterAccessDashboardClient).toHaveBeenCalledWith({
+      initialData: {
+        config: {
+          allowedEmailCount: 1,
+          allowedEmails: ["tester@example.com"],
+          blockedEmailCount: 0,
+          blockedEmails: [],
+          freeAccess: true,
+          guestSymptomChecker: false,
+          inviteOnly: true,
+          modeEnabled: true,
+        },
+        summary: {
+          active: 1,
+          authAccessDisabled: 0,
+          blocked: 0,
+          deletionRequested: 0,
+          negativeFeedbackEntries: 0,
+          symptomChecks: 1,
+          total: 1,
+        },
+        testers: [],
+      },
+    });
+  });
+});


### PR DESCRIPTION
## What changed
- extended the admin request guard to recognize founder/admin access from the signed-in user's `profiles` row in addition to auth metadata, `ADMIN_EMAILS`, and the `users` table
- added admin-auth regression coverage for allowlist and profile-based admin resolution while keeping non-admin users blocked
- added a focused `/admin/tester-access` page test so unauthorized callers still get a clear admin-only message before any tester data loads

## Why
The remaining VET-1388 auth gap was that `/api/admin/private-tester` could still deny a real founder/admin if production stored the admin signal on `profiles` instead of Supabase auth metadata or the `users` table.

## Impact
Authorized admins can resolve through the extra profile-based auth source without widening access for testers or unauthenticated callers, and the tester-access lane keeps its safe-metadata-only behavior.

## Root cause
`getAdminRequestContext()` did not check the signed-in user's `profiles` row for `role` / `is_admin`, even though that was called out as a possible production admin source.

## Validation
- `npx jest tests/admin-auth.test.ts tests/private-tester-admin.route.test.ts tests/private-tester-admin.data.test.ts tests/tester-access-dashboard-client.test.ts tests/admin-tester-access.page.test.ts --runInBand --verbose`
- `npm run smoke:private-tester:access`
- `npm test`
- `npm run build`
