### PR TITLE
fix(VET-1390): harden private tester scope quarantine

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { SpeedInsights } from "@vercel/speed-insights/next";
+import {
+  isPrivateTesterModeEnabled,
+  PRIVATE_TESTER_MODE_RUNTIME_ATTRIBUTE,
+} from "@/lib/private-tester-access";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -54,12 +58,21 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const privateTesterModeEnabled = isPrivateTesterModeEnabled();
+
   return (
     <html
       lang="en"
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
-      <body className="min-h-full flex flex-col">
+      <body
+        className="min-h-full flex flex-col"
+        {...{
+          [PRIVATE_TESTER_MODE_RUNTIME_ATTRIBUTE]: privateTesterModeEnabled
+            ? "1"
+            : "0",
+        }}
+      >
         {children}
         <SpeedInsights />
       </body>

--- a/src/lib/private-tester-access.ts
+++ b/src/lib/private-tester-access.ts
@@ -38,6 +38,8 @@ type EnvLike = Record<string, string | undefined>;
 
 const PRIVATE_TESTER_ROUTE_PREFIX = "/symptom-checker";
 export const PRIVATE_TESTER_MODE_COOKIE = "pawvital_private_tester_mode";
+export const PRIVATE_TESTER_MODE_RUNTIME_ATTRIBUTE =
+  "data-private-tester-mode";
 
 function isTruthyEnvFlag(value: string | undefined) {
   return value === "true" || value === "1";
@@ -89,6 +91,28 @@ function readCsv(env: EnvLike, keys: string[]) {
   return [];
 }
 
+function readPrivateTesterModeRuntimeFlag() {
+  if (typeof document === "undefined") {
+    return null;
+  }
+
+  const bodyValue = document.body?.getAttribute(
+    PRIVATE_TESTER_MODE_RUNTIME_ATTRIBUTE
+  );
+  if (typeof bodyValue === "string" && bodyValue.length > 0) {
+    return isTruthyEnvFlag(bodyValue);
+  }
+
+  const htmlValue = document.documentElement?.getAttribute(
+    PRIVATE_TESTER_MODE_RUNTIME_ATTRIBUTE
+  );
+  if (typeof htmlValue === "string" && htmlValue.length > 0) {
+    return isTruthyEnvFlag(htmlValue);
+  }
+
+  return null;
+}
+
 export function normalizePrivateTesterEmail(value: string | null | undefined) {
   if (typeof value !== "string") {
     return null;
@@ -99,14 +123,23 @@ export function normalizePrivateTesterEmail(value: string | null | undefined) {
 }
 
 export function isPrivateTesterModeEnabled(env: EnvLike = process.env) {
-  const modeEnabled = readFlag(
-    env,
-    ["NEXT_PUBLIC_PRIVATE_TESTER_MODE", "PRIVATE_TESTER_MODE"],
-    false
-  );
-
-  if (modeEnabled) {
+  if (
+    readFlag(
+      env,
+      ["NEXT_PUBLIC_PRIVATE_TESTER_MODE", "PRIVATE_TESTER_MODE"],
+      false
+    )
+  ) {
     return true;
+  }
+
+  if (env !== process.env) {
+    return false;
+  }
+
+  const runtimeFlag = readPrivateTesterModeRuntimeFlag();
+  if (runtimeFlag !== null) {
+    return runtimeFlag;
   }
 
   return readBrowserCookieFlag(PRIVATE_TESTER_MODE_COOKIE) ?? false;

--- a/tests/admin-cohort-launch.page.test.ts
+++ b/tests/admin-cohort-launch.page.test.ts
@@ -207,6 +207,46 @@ describe("AdminCohortLaunchPage", () => {
     );
   });
 
+  it("keeps founder-only cohort controls available when private tester mode is enabled", async () => {
+    const originalPrivateTesterMode = process.env.PRIVATE_TESTER_MODE;
+
+    try {
+      process.env.PRIVATE_TESTER_MODE = "1";
+      mockGetAdminRequestContext.mockResolvedValue({
+        email: "founder@example.com",
+        isDemo: false,
+        userId: "admin-1",
+      });
+      mockHeaders.mockResolvedValue(new Headers({ host: "app.pawvital.ai" }));
+      mockCookies.mockResolvedValue({
+        toString: () => "sb-access-token=admin-session",
+      });
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce(
+          makeJsonResponse({
+            testers: [],
+          })
+        )
+        .mockResolvedValueOnce(
+          makeJsonResponse({
+            latestCases: [],
+          })
+        );
+
+      const html = await renderPage();
+
+      expect(html).toContain("Private Tester Cohort 1 Command Center");
+      expect(html).toContain("Founder triage queue");
+      expect(html).toContain("Tester access");
+    } finally {
+      if (originalPrivateTesterMode) {
+        process.env.PRIVATE_TESTER_MODE = originalPrivateTesterMode;
+      } else {
+        delete process.env.PRIVATE_TESTER_MODE;
+      }
+    }
+  });
+
   it("blocks unauthenticated access before any admin data is fetched", async () => {
     mockGetAdminRequestContext.mockResolvedValue(null);
 

--- a/tests/private-tester-scope-ui.test.ts
+++ b/tests/private-tester-scope-ui.test.ts
@@ -9,7 +9,10 @@ import JournalPage from "@/app/(dashboard)/journal/page";
 import RemindersPage from "@/app/(dashboard)/reminders/page";
 import SupplementsPage from "@/app/(dashboard)/supplements/page";
 import Sidebar from "@/components/dashboard/sidebar";
-import { PRIVATE_TESTER_MODE_COOKIE } from "@/lib/private-tester-access";
+import {
+  PRIVATE_TESTER_MODE_COOKIE,
+  PRIVATE_TESTER_MODE_RUNTIME_ATTRIBUTE,
+} from "@/lib/private-tester-access";
 import { useAppStore } from "@/store/app-store";
 import type { Pet, UserProfile } from "@/types";
 
@@ -90,6 +93,15 @@ function setPrivateTesterModeCookie(enabled: boolean) {
   }
 }
 
+function setPrivateTesterRuntimeMode(value?: "1" | "0") {
+  if (value) {
+    document.body.setAttribute(PRIVATE_TESTER_MODE_RUNTIME_ATTRIBUTE, value);
+    return;
+  }
+
+  document.body.removeAttribute(PRIVATE_TESTER_MODE_RUNTIME_ATTRIBUTE);
+}
+
 describe("private tester scope UI", () => {
   const originalPrivateTesterMode = process.env.NEXT_PUBLIC_PRIVATE_TESTER_MODE;
 
@@ -98,6 +110,7 @@ describe("private tester scope UI", () => {
     jest.clearAllMocks();
     setPrivateTesterMode(false);
     setPrivateTesterModeCookie(false);
+    setPrivateTesterRuntimeMode();
     mockUsePathname.mockReturnValue("/dashboard");
     Object.defineProperty(window, "matchMedia", {
       configurable: true,
@@ -116,6 +129,7 @@ describe("private tester scope UI", () => {
 
   afterAll(() => {
     setPrivateTesterModeCookie(false);
+    setPrivateTesterRuntimeMode();
     if (originalPrivateTesterMode) {
       process.env.NEXT_PUBLIC_PRIVATE_TESTER_MODE = originalPrivateTesterMode;
       return;
@@ -273,5 +287,40 @@ describe("private tester scope UI", () => {
     ).toBeTruthy();
     expect(screen.queryByText("View Supplements")).toBeNull();
     expect(screen.queryByText("Connect with fellow dog parents")).toBeNull();
+  });
+
+  it("VET-1390 tester scope UI: respects the server runtime flag when NEXT_PUBLIC mode is not present in the client bundle", () => {
+    setPrivateTesterMode(false);
+    setPrivateTesterRuntimeMode("1");
+
+    const sidebarView = render(React.createElement(Sidebar));
+
+    expect(screen.queryByText("Supplements")).toBeNull();
+    expect(screen.queryByText("Paw Circle")).toBeNull();
+
+    sidebarView.unmount();
+
+    const dashboardView = render(React.createElement(DashboardPage));
+
+    expect(screen.getByText("Private tester home")).toBeTruthy();
+    expect(screen.queryByText("View Supplements")).toBeNull();
+
+    dashboardView.unmount();
+
+    const communityView = render(React.createElement(CommunityPage));
+
+    expect(
+      screen.getByText("Paw Circle is disabled for private testers")
+    ).toBeTruthy();
+    expect(screen.queryByText("Connect with fellow dog parents")).toBeNull();
+
+    communityView.unmount();
+
+    render(React.createElement(SupplementsPage));
+
+    expect(
+      screen.getByText("Supplement plan is disabled for private testers")
+    ).toBeTruthy();
+    expect(screen.queryByText("Glucosamine & Chondroitin")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Hardens private-tester scope quarantine so the dashboard tree can see a server-rendered private-tester mode flag even when the client bundle does not carry `NEXT_PUBLIC_PRIVATE_TESTER_MODE`.

## What changed

- writes a safe runtime `data-private-tester-mode` attribute from the root layout
- teaches private tester mode detection to honor that runtime attribute before falling back to the proxy cookie
- adds regression coverage for the runtime flag path and confirms founder-only cohort controls still render when private tester mode is enabled

## Validation

- `npx jest tests/private-tester-scope-ui.test.ts tests/admin-cohort-launch.page.test.ts tests/proxy.auth.test.ts --runInBand --verbose`
- `npm test`
- `npm run build`
- `npm run smoke:private-tester`

## Scope

Targets `codex/vet-1385-cohort1-production-blockers` only.