### PR TITLE
[codex] fix VET-1387 admin cohort launch route

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -41,6 +41,7 @@ function applyPrivateTesterModeCookie(response: NextResponse) {
 
 export async function proxy(request: NextRequest) {
   const { pathname, search } = request.nextUrl;
+  const isAdminRoute = pathname.startsWith("/admin");
 
   // Demo mode — no Supabase configured, allow everything through
   if (!isSupabaseConfigured) {
@@ -116,7 +117,7 @@ export async function proxy(request: NextRequest) {
     );
   }
 
-  if (isProtected && user) {
+  if (isProtected && user && !isAdminRoute) {
     const testerAccess = evaluatePrivateTesterAccess({
       email: typeof user.email === "string" ? user.email : null,
       pathname,

--- a/tests/admin-cohort-launch.production.test.ts
+++ b/tests/admin-cohort-launch.production.test.ts
@@ -1,0 +1,198 @@
+import fs from "node:fs";
+import path from "node:path";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const mockGetAdminRequestContext = jest.fn();
+const mockHeaders = jest.fn();
+const mockCookies = jest.fn();
+const mockBuildDemoAdminFeedbackLedgerDashboardData = jest.fn();
+const mockBuildPrivateTesterDashboardFallback = jest.fn();
+const mockBuildPrivateTesterCohortCommandCenter = jest.fn();
+
+jest.mock("next/headers", () => ({
+  cookies: (...args: unknown[]) => mockCookies(...args),
+  headers: (...args: unknown[]) => mockHeaders(...args),
+}));
+
+jest.mock("next/link", () => {
+  const ReactActual = jest.requireActual<typeof import("react")>("react");
+
+  return {
+    __esModule: true,
+    default: ({
+      children,
+      href,
+      ...props
+    }: {
+      children: React.ReactNode;
+      href: string;
+    }) => ReactActual.createElement("a", { href, ...props }, children),
+  };
+});
+
+jest.mock("@/lib/admin-auth", () => ({
+  getAdminRequestContext: (...args: unknown[]) =>
+    mockGetAdminRequestContext(...args),
+}));
+
+jest.mock("@/lib/admin-feedback-ledger", () => ({
+  buildDemoAdminFeedbackLedgerDashboardData: (...args: unknown[]) =>
+    mockBuildDemoAdminFeedbackLedgerDashboardData(...args),
+}));
+
+jest.mock("@/lib/private-tester-admin", () => ({
+  buildPrivateTesterDashboardFallback: (...args: unknown[]) =>
+    mockBuildPrivateTesterDashboardFallback(...args),
+}));
+
+jest.mock("@/lib/private-tester-cohort", () => ({
+  buildPrivateTesterCohortCommandCenter: (...args: unknown[]) =>
+    mockBuildPrivateTesterCohortCommandCenter(...args),
+}));
+
+const cohortLaunchSourcePath = path.join(
+  process.cwd(),
+  "src",
+  "app",
+  "(dashboard)",
+  "admin",
+  "cohort-launch",
+  "page.tsx"
+);
+const appPathsManifestPath = path.join(
+  process.cwd(),
+  ".next",
+  "server",
+  "app-paths-manifest.json"
+);
+
+function buildCommandCenterFixture() {
+  return {
+    filters: {
+      emergencySessions: [],
+      failedReportSessions: [],
+      failedSignInOrAccessSessions: [],
+      latestSessions: [{ symptomCheckId: "case-1" }],
+      negativeFeedbackSessions: [],
+      noFeedbackSessions: [],
+      repeatedQuestionSessions: [],
+    },
+    highRiskSessions: [],
+    notes: ["Founder-only command center stays available in private tester mode."],
+    summary: {
+      completedSymptomChecks: 1,
+      dataDeletionRequests: 0,
+      emergencyResults: 0,
+      feedbackSubmitted: 0,
+      negativeFeedback: 0,
+      repeatedQuestionFlags: 0,
+      reportFailures: 0,
+      reportsOpened: 0,
+      signInFailures: 0,
+      signedInTesters: 1,
+      testerAccessDisabled: 0,
+      testersInvited: 1,
+    },
+    triage: {
+      P0: [],
+      P1: [],
+      P2: [],
+      P3: [],
+    },
+  };
+}
+
+function makeJsonResponse(payload: unknown) {
+  return {
+    json: jest.fn().mockResolvedValue(payload),
+    ok: true,
+  } as unknown as Response;
+}
+
+async function renderPage() {
+  const { default: AdminCohortLaunchPage } = await import(
+    "@/app/(dashboard)/admin/cohort-launch/page"
+  );
+
+  return renderToStaticMarkup(await AdminCohortLaunchPage());
+}
+
+describe("VET-1387 cohort launch production regression", () => {
+  const originalEnv = process.env;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      PRIVATE_TESTER_MODE: "1",
+    };
+    global.fetch = jest.fn() as typeof global.fetch;
+    mockGetAdminRequestContext.mockResolvedValue({
+      email: "founder@example.com",
+      isDemo: false,
+      userId: "admin-1",
+    });
+    mockHeaders.mockResolvedValue(new Headers({ host: "app.pawvital.ai" }));
+    mockCookies.mockResolvedValue({
+      toString: () => "sb-access-token=admin-session",
+    });
+    mockBuildDemoAdminFeedbackLedgerDashboardData.mockReturnValue({
+      latestCases: [],
+      summary: {},
+    });
+    mockBuildPrivateTesterDashboardFallback.mockReturnValue({
+      config: { allowedEmailCount: 0 },
+      summary: {},
+      testers: [],
+      warning: "fallback",
+    });
+    mockBuildPrivateTesterCohortCommandCenter.mockReturnValue(
+      buildCommandCenterFixture()
+    );
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(makeJsonResponse({ testers: [] }))
+      .mockResolvedValueOnce(makeJsonResponse({ latestCases: [] }));
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+    global.fetch = originalFetch;
+  });
+
+  it("keeps the cohort launch page reachable for admins while private tester mode is enabled", async () => {
+    const html = await renderPage();
+
+    expect(html).toContain("Private Tester Cohort 1 Command Center");
+    expect(html).toContain("Founder triage queue");
+    expect(html).toContain("Tester access");
+    expect(html).not.toContain("Admin access required");
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      1,
+      "https://app.pawvital.ai/api/admin/private-tester",
+      { headers: { cookie: "sb-access-token=admin-session" } }
+    );
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      2,
+      "https://app.pawvital.ai/api/admin/tester-feedback",
+      { headers: { cookie: "sb-access-token=admin-session" } }
+    );
+  });
+
+  it("keeps the cohort launch route in build output when the app manifest exists", () => {
+    expect(fs.existsSync(cohortLaunchSourcePath)).toBe(true);
+
+    if (!fs.existsSync(appPathsManifestPath)) {
+      return;
+    }
+
+    const manifest = JSON.parse(
+      fs.readFileSync(appPathsManifestPath, "utf8")
+    ) as Record<string, string>;
+
+    expect(manifest["/(dashboard)/admin/cohort-launch/page"]).toBe(
+      "app/(dashboard)/admin/cohort-launch/page.js"
+    );
+  });
+});

--- a/tests/proxy.auth.test.ts
+++ b/tests/proxy.auth.test.ts
@@ -131,6 +131,29 @@ describe("VET-1215 proxy auth guard", () => {
     expect(response.headers.get("location")).toBe("https://app.pawvital.ai/");
   });
 
+  it("VET-1387 admin cohort launch smoke: keeps admin routes reachable even when the signed-in user is not on the tester allowlist", async () => {
+    process.env = {
+      ...originalEnv,
+      NEXT_PUBLIC_PRIVATE_TESTER_INVITE_ONLY: "1",
+      NEXT_PUBLIC_PRIVATE_TESTER_MODE: "1",
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: "anon-key",
+      NEXT_PUBLIC_SUPABASE_URL: "https://supabase.example.co",
+      PRIVATE_TESTER_ALLOWED_EMAILS: "tester@example.com",
+    };
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1", email: "founder@example.com" } },
+      error: null,
+    });
+
+    const { proxy } = await loadProxyModule();
+    const response = await proxy(
+      new NextRequest("https://app.pawvital.ai/admin/cohort-launch")
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+  });
+
   it("VET-1352 tester access smoke: allows invited authenticated users through protected routes in private tester mode", async () => {
     process.env = {
       ...originalEnv,


### PR DESCRIPTION
## Summary
- skip private-tester invite gating for `/admin` routes so `/admin/cohort-launch` can reach its own admin-only page guard
- add a focused proxy regression proving `/admin/cohort-launch` stays reachable for an authenticated admin even when private-tester invite mode is enabled
- keep the existing private-tester redirect behavior for non-admin protected routes unchanged

## Root cause
The global `proxy.ts` private-tester gate ran on every protected route, including `/admin/cohort-launch`. That meant founder/admin traffic could be intercepted by tester-invite rules before the cohort launch page had a chance to apply its own admin authorization logic.

## Validation
- `npm test`
- `npm run build`
- focused route tests: `npm test -- tests/proxy.auth.test.ts tests/admin-cohort-launch.page.test.ts tests/admin-cohort-launch.routing.test.ts --runInBand`
- local admin route smoke: `GET /admin/cohort-launch` on `next dev` with `ADMIN_OVERRIDE=true` returned `200` and rendered `Private Tester Cohort 1 Command Center`
- live-style unauthorized runtime smoke could not be confirmed truthfully without a real signed-out production/preview auth path; automated coverage for unauthenticated and unauthorized blocking remains in `tests/proxy.auth.test.ts` and `tests/admin-cohort-launch.page.test.ts`
