### PR TITLE
VET-1398: add auth suspense boundary

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,0 +1,9 @@
+import { Suspense } from "react";
+
+export default function AuthLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return <Suspense fallback={null}>{children}</Suspense>;
+}


### PR DESCRIPTION
## Summary\n- add a local Suspense boundary for the auth route group\n- prevent auth pages using useSearchParams() from falling through to the root loading spinner\n- keep the fix scoped to auth rendering only\n\n## Verification\n- npx eslint src/app/(auth)/layout.tsx\n- npm test -- --runTestsByPath tests/auth-routing.test.ts tests/auth-pages.network-error.test.tsx tests/auth-callback.route.test.ts\n- npm run build\n- local Playwright against built app: /login and /signup both render 3 inputs, headings visible, no root Loading... spinner\n\nCloses #376\nRefs #375