### PR TITLE
fix(auth): complete PKCE recovery in browser

### DIFF
--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -8,7 +8,7 @@ import Button, { buttonClassName } from "@/components/ui/button";
 import Input from "@/components/ui/input";
 import {
   appendRedirectParam,
-  buildCallbackUrl,
+  buildBrowserCallbackUrl,
   buildRecoveryRedirectPath,
   getAuthFeedbackMessage,
   getAuthActionErrorMessage,
@@ -46,7 +46,7 @@ export default function ForgotPasswordPage() {
       }
       const supabase = createClient();
       const { error: resetError } = await supabase.auth.resetPasswordForEmail(email, {
-        redirectTo: buildCallbackUrl(
+        redirectTo: buildBrowserCallbackUrl(
           window.location.origin,
           buildRecoveryRedirectPath(redirectTarget)
         ),

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -8,7 +8,7 @@ import Button from "@/components/ui/button";
 import Input from "@/components/ui/input";
 import {
   appendRedirectParam,
-  buildCallbackUrl,
+  buildBrowserCallbackUrl,
   getAuthFeedbackMessage,
   getAuthActionErrorMessage,
   resolvePostAuthRedirect,
@@ -59,7 +59,7 @@ export default function SignupPage() {
         password,
         options: {
           data: { full_name: name },
-          emailRedirectTo: buildCallbackUrl(window.location.origin, redirectTarget),
+          emailRedirectTo: buildBrowserCallbackUrl(window.location.origin, redirectTarget),
         },
       });
 

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import {
+  buildLoginPath,
+  buildRecoveryRedirectPath,
+  DEFAULT_AUTH_REDIRECT,
+  RESET_PASSWORD_PATH,
+  resolvePostAuthRedirect,
+} from "@/lib/auth-routing";
+import { replaceWithBrowser } from "@/lib/browser-navigation";
+import { createClient, isSupabaseConfigured } from "@/lib/supabase";
+
+export default function AuthCallbackPage() {
+  const [error, setError] = useState<{
+    actionHref: string;
+    actionLabel: string;
+    message: string;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!isSupabaseConfigured) {
+      replaceWithBrowser(DEFAULT_AUTH_REDIRECT);
+      return;
+    }
+
+    const url = new URL(window.location.href);
+    const code = url.searchParams.get("code");
+    const rawNext = url.searchParams.get("next");
+    const nextTarget = resolvePostAuthRedirect(rawNext, {
+      allowedOrigin: window.location.origin,
+      fallback: DEFAULT_AUTH_REDIRECT,
+    });
+    const recoveryTarget = resolvePostAuthRedirect(rawNext, {
+      allowedOrigin: window.location.origin,
+      fallback: buildRecoveryRedirectPath(DEFAULT_AUTH_REDIRECT),
+      allowResetPassword: true,
+    });
+    const isRecoveryRedirect = recoveryTarget.startsWith(RESET_PASSWORD_PATH);
+
+    if (!code) {
+      replaceWithBrowser(
+        buildLoginPath(nextTarget, {
+          error: "auth_callback_failed",
+        })
+      );
+      return;
+    }
+    const authCode = code;
+
+    async function completeCallback() {
+      const supabase = createClient();
+      const { error: exchangeError } =
+        await supabase.auth.exchangeCodeForSession(authCode);
+
+      if (exchangeError) {
+        replaceWithBrowser(
+          buildLoginPath(nextTarget, {
+            error: isRecoveryRedirect ? "invalid_reset_link" : "auth_callback_failed",
+          })
+        );
+        return;
+      }
+
+      replaceWithBrowser(isRecoveryRedirect ? recoveryTarget : nextTarget);
+    }
+
+    void completeCallback().catch((err: unknown) => {
+      console.error("Failed to complete auth callback", err);
+      setError({
+        actionHref: isRecoveryRedirect
+          ? "/forgot-password"
+          : buildLoginPath(nextTarget, { error: "auth_callback_failed" }),
+        actionLabel: isRecoveryRedirect
+          ? "Request a new reset link"
+          : "Return to sign in",
+        message: isRecoveryRedirect
+          ? "We couldn't complete password reset from that link. Please try again."
+          : "We couldn't complete sign-in from that link. Please try again.",
+      });
+    });
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-amber-50 flex items-center justify-center p-4">
+      <div className="w-full max-w-md rounded-2xl border border-gray-200 bg-white p-8 text-center shadow-lg">
+        {error ? (
+          <>
+            <h1 className="text-xl font-bold text-gray-900">Link not completed</h1>
+            <p className="mt-3 text-sm text-gray-600">{error.message}</p>
+            <Link
+              href={error.actionHref}
+              target="_top"
+              prefetch={false}
+              className="mt-6 inline-flex rounded-xl bg-blue-600 px-5 py-3 text-sm font-semibold text-white hover:bg-blue-700"
+            >
+              {error.actionLabel}
+            </Link>
+          </>
+        ) : (
+          <>
+            <h1 className="text-xl font-bold text-gray-900">Completing your secure link</h1>
+            <p className="mt-3 text-sm text-gray-600">
+              One moment while PawVital verifies this browser session.
+            </p>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/auth-routing.ts
+++ b/src/lib/auth-routing.ts
@@ -153,6 +153,20 @@ export function buildCallbackUrl(origin: string, redirectTarget: string | null |
   return url.toString();
 }
 
+export function buildBrowserCallbackUrl(
+  origin: string,
+  redirectTarget: string | null | undefined
+) {
+  const url = new URL("/auth/callback", origin);
+  const safeTarget = sanitizeRedirectTarget(redirectTarget, origin);
+
+  if (safeTarget) {
+    url.searchParams.set("next", safeTarget);
+  }
+
+  return url.toString();
+}
+
 export function buildLoginPath(
   redirectTarget: string | null | undefined,
   options?: {

--- a/tests/auth-callback.page.test.tsx
+++ b/tests/auth-callback.page.test.tsx
@@ -1,0 +1,93 @@
+/** @jest-environment jsdom */
+
+import * as React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import AuthCallbackPage from "@/app/auth/callback/page";
+
+const mockExchangeCodeForSession = jest.fn();
+const mockReplaceWithBrowser = jest.fn();
+
+jest.mock("next/link", () => {
+  const ReactActual = jest.requireActual<typeof import("react")>("react");
+
+  return {
+    __esModule: true,
+    default: ({
+      children,
+      href,
+      ...props
+    }: {
+      children: React.ReactNode;
+      href: string;
+    }) => ReactActual.createElement("a", { href, ...props }, children),
+  };
+});
+
+jest.mock("@/lib/browser-navigation", () => ({
+  replaceWithBrowser: (...args: unknown[]) => mockReplaceWithBrowser(...args),
+}));
+
+jest.mock("@/lib/supabase", () => ({
+  createClient: () => ({
+    auth: {
+      exchangeCodeForSession: (...args: unknown[]) =>
+        mockExchangeCodeForSession(...args),
+    },
+  }),
+  isSupabaseConfigured: true,
+}));
+
+function setCallbackUrl(next: string) {
+  window.history.pushState(
+    {},
+    "",
+    `/auth/callback?code=test-code&next=${encodeURIComponent(next)}`
+  );
+}
+
+describe("auth browser callback page", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("shows a reset-link fallback when recovery callback completion throws", async () => {
+    mockExchangeCodeForSession.mockRejectedValue(new Error("PKCE verifier missing"));
+    setCallbackUrl("/reset-password?redirect=%2Fsymptom-checker");
+
+    render(React.createElement(AuthCallbackPage));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "We couldn't complete password reset from that link. Please try again."
+        )
+      ).toBeTruthy()
+    );
+
+    expect(
+      screen.getByRole("link", { name: "Request a new reset link" }).getAttribute("href")
+    ).toBe("/forgot-password");
+  });
+
+  it("shows a sign-in fallback when non-recovery callback completion throws", async () => {
+    mockExchangeCodeForSession.mockRejectedValue(new Error("PKCE verifier missing"));
+    setCallbackUrl("/dashboard");
+
+    render(React.createElement(AuthCallbackPage));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("We couldn't complete sign-in from that link. Please try again.")
+      ).toBeTruthy()
+    );
+
+    expect(
+      screen.getByRole("link", { name: "Return to sign in" }).getAttribute("href")
+    ).toBe("/login?redirect=%2Fdashboard&error=auth_callback_failed");
+  });
+});

--- a/tests/auth-pages.network-error.test.tsx
+++ b/tests/auth-pages.network-error.test.tsx
@@ -167,4 +167,30 @@ describe("auth page network error handling", () => {
       errorSpy.mockRestore();
     }
   });
+
+  it("sends password reset emails through the browser callback for PKCE recovery", async () => {
+    const resetPasswordForEmail = jest.fn().mockResolvedValue({ error: null });
+    mockCreateClient.mockReturnValue({
+      auth: {
+        resetPasswordForEmail,
+      },
+    });
+
+    render(React.createElement(ForgotPasswordPage));
+
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "owner@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send Reset Link" }));
+
+    await waitFor(() =>
+      expect(resetPasswordForEmail).toHaveBeenCalledWith(
+        "owner@example.com",
+        {
+          redirectTo:
+            "http://localhost/auth/callback?next=%2Freset-password%3Fredirect%3D%252Fdashboard",
+        }
+      )
+    );
+  });
 });

--- a/tests/auth-routing.test.ts
+++ b/tests/auth-routing.test.ts
@@ -1,5 +1,6 @@
 import {
   appendRedirectParam,
+  buildBrowserCallbackUrl,
   buildCallbackUrl,
   buildRecoveryRedirectPath,
   buildRedirectTarget,
@@ -59,6 +60,9 @@ describe("VET-1215 auth routing helpers", () => {
     ).toBe("/login?redirect=%2Fnotifications%3Ftab%3Dunread&reason=session_expired");
     expect(buildCallbackUrl("https://pawvital.ai", "/pets/1")).toBe(
       "https://pawvital.ai/api/auth/callback?next=%2Fpets%2F1"
+    );
+    expect(buildBrowserCallbackUrl("https://pawvital.ai", "/pets/1")).toBe(
+      "https://pawvital.ai/auth/callback?next=%2Fpets%2F1"
     );
   });
 


### PR DESCRIPTION
## Summary
- add a browser-side /auth/callback route for Supabase PKCE email links
- send password reset and signup confirmation emails through the browser callback
- add regression coverage for reset emails using /auth/callback

## Test plan
- npm test -- --runTestsByPath tests/auth-routing.test.ts tests/auth-pages.network-error.test.tsx tests/auth-callback.route.test.ts --verbose
- npm run build

## Notes
- This fixes reset links that currently return to /api/auth/callback and fail with auth_callback_failed because the server cannot complete the browser-held PKCE verifier flow.