### PR TITLE
fix(auth): keep recovery links on reset form

### DIFF
--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -8,8 +8,7 @@ import Button, { buttonClassName } from "@/components/ui/button";
 import Input from "@/components/ui/input";
 import {
   appendRedirectParam,
-  buildBrowserCallbackUrl,
-  buildRecoveryRedirectPath,
+  buildRecoveryCallbackUrl,
   getAuthFeedbackMessage,
   getAuthActionErrorMessage,
   resolvePostAuthRedirect,
@@ -46,10 +45,7 @@ export default function ForgotPasswordPage() {
       }
       const supabase = createClient();
       const { error: resetError } = await supabase.auth.resetPasswordForEmail(email, {
-        redirectTo: buildBrowserCallbackUrl(
-          window.location.origin,
-          buildRecoveryRedirectPath(redirectTarget)
-        ),
+        redirectTo: buildRecoveryCallbackUrl(window.location.origin, redirectTarget),
       });
       if (resetError) throw resetError;
       setSent(true);

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -64,6 +64,7 @@ export async function GET(request: NextRequest) {
   const code = searchParams.get("code");
   const tokenHash = searchParams.get("token_hash");
   const rawType = searchParams.get("type");
+  const rawFlow = searchParams.get("flow");
   const rawNext = searchParams.get("next");
   const nextTarget = resolvePostAuthRedirect(rawNext, {
     allowedOrigin: origin,
@@ -77,14 +78,22 @@ export async function GET(request: NextRequest) {
 
   try {
     if (code) {
-      const isRecoveryFlow = rawNext?.includes(RESET_PASSWORD_PATH);
-      const redirectTarget = isRecoveryFlow ? recoveryTarget : nextTarget;
+      const isRecoveryFlow =
+        rawFlow === "recovery" ||
+        rawType === "recovery" ||
+        Boolean(rawNext?.includes(RESET_PASSWORD_PATH));
+      const redirectTarget = isRecoveryFlow
+        ? recoveryTarget.startsWith(RESET_PASSWORD_PATH)
+          ? recoveryTarget
+          : buildRecoveryRedirectPath(nextTarget)
+        : nextTarget;
 
       if (isRecoveryFlow) {
         const browserCallbackUrl = new URL(
           buildBrowserCallbackUrl(origin, redirectTarget)
         );
         browserCallbackUrl.searchParams.set("code", code);
+        browserCallbackUrl.searchParams.set("flow", "recovery");
 
         return NextResponse.redirect(browserCallbackUrl);
       }

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -27,17 +27,22 @@ export default function AuthCallbackPage() {
 
     const url = new URL(window.location.href);
     const code = url.searchParams.get("code");
+    const flow = url.searchParams.get("flow") || url.searchParams.get("type");
     const rawNext = url.searchParams.get("next");
     const nextTarget = resolvePostAuthRedirect(rawNext, {
       allowedOrigin: window.location.origin,
       fallback: DEFAULT_AUTH_REDIRECT,
     });
-    const recoveryTarget = resolvePostAuthRedirect(rawNext, {
+    const isRecoveryFlow =
+      flow === "recovery" || Boolean(rawNext?.includes(RESET_PASSWORD_PATH));
+    const explicitRecoveryTarget = resolvePostAuthRedirect(rawNext, {
       allowedOrigin: window.location.origin,
       fallback: buildRecoveryRedirectPath(DEFAULT_AUTH_REDIRECT),
       allowResetPassword: true,
     });
-    const isRecoveryRedirect = recoveryTarget.startsWith(RESET_PASSWORD_PATH);
+    const recoveryTarget = explicitRecoveryTarget.startsWith(RESET_PASSWORD_PATH)
+      ? explicitRecoveryTarget
+      : buildRecoveryRedirectPath(nextTarget);
 
     if (!code) {
       replaceWithBrowser(
@@ -57,25 +62,25 @@ export default function AuthCallbackPage() {
       if (exchangeError) {
         replaceWithBrowser(
           buildLoginPath(nextTarget, {
-            error: isRecoveryRedirect ? "invalid_reset_link" : "auth_callback_failed",
+            error: isRecoveryFlow ? "invalid_reset_link" : "auth_callback_failed",
           })
         );
         return;
       }
 
-      replaceWithBrowser(isRecoveryRedirect ? recoveryTarget : nextTarget);
+      replaceWithBrowser(isRecoveryFlow ? recoveryTarget : nextTarget);
     }
 
     void completeCallback().catch((err: unknown) => {
       console.error("Failed to complete auth callback", err);
       setError({
-        actionHref: isRecoveryRedirect
+        actionHref: isRecoveryFlow
           ? "/forgot-password"
           : buildLoginPath(nextTarget, { error: "auth_callback_failed" }),
-        actionLabel: isRecoveryRedirect
+        actionLabel: isRecoveryFlow
           ? "Request a new reset link"
           : "Return to sign in",
-        message: isRecoveryRedirect
+        message: isRecoveryFlow
           ? "We couldn't complete password reset from that link. Please try again."
           : "We couldn't complete sign-in from that link. Please try again.",
       });

--- a/src/lib/auth-routing.ts
+++ b/src/lib/auth-routing.ts
@@ -167,6 +167,19 @@ export function buildBrowserCallbackUrl(
   return url.toString();
 }
 
+export function buildRecoveryCallbackUrl(
+  origin: string,
+  redirectTarget: string | null | undefined
+) {
+  const url = new URL("/auth/callback", origin);
+  const recoveryTarget = buildRecoveryRedirectPath(redirectTarget);
+
+  url.searchParams.set("flow", "recovery");
+  url.searchParams.set("next", recoveryTarget);
+
+  return url.toString();
+}
+
 export function buildLoginPath(
   redirectTarget: string | null | undefined,
   options?: {

--- a/tests/auth-callback.page.test.tsx
+++ b/tests/auth-callback.page.test.tsx
@@ -90,4 +90,21 @@ describe("auth browser callback page", () => {
       screen.getByRole("link", { name: "Return to sign in" }).getAttribute("href")
     ).toBe("/login?redirect=%2Fdashboard&error=auth_callback_failed");
   });
+
+  it("keeps recovery callbacks on the reset-password form before the app redirect", async () => {
+    mockExchangeCodeForSession.mockResolvedValue({ error: null });
+    window.history.pushState(
+      {},
+      "",
+      "/auth/callback?code=test-code&flow=recovery&next=%2Fsymptom-checker"
+    );
+
+    render(React.createElement(AuthCallbackPage));
+
+    await waitFor(() =>
+      expect(mockReplaceWithBrowser).toHaveBeenCalledWith(
+        "/reset-password?redirect=%2Fsymptom-checker"
+      )
+    );
+  });
 });

--- a/tests/auth-callback.route.test.ts
+++ b/tests/auth-callback.route.test.ts
@@ -110,6 +110,25 @@ describe("VET-1215 auth callback route", () => {
     expect(callbackUrl.origin).toBe("https://app.pawvital.ai");
     expect(callbackUrl.pathname).toBe("/auth/callback");
     expect(callbackUrl.searchParams.get("code")).toBe("recovery-code");
+    expect(callbackUrl.searchParams.get("flow")).toBe("recovery");
+    expect(callbackUrl.searchParams.get("next")).toBe(
+      "/reset-password?redirect=%2Fsymptom-checker"
+    );
+    expect(mockExchangeCodeForSession).not.toHaveBeenCalled();
+  });
+
+  it("wraps recovery PKCE codes with protected next targets into reset-password", async () => {
+    const { GET } = await import("@/app/api/auth/callback/route");
+    const response = await GET(
+      new NextRequest(
+        "https://app.pawvital.ai/api/auth/callback?code=recovery-code&type=recovery&next=%2Fsymptom-checker"
+      )
+    );
+
+    const callbackUrl = new URL(response.headers.get("location") || "");
+    expect(callbackUrl.pathname).toBe("/auth/callback");
+    expect(callbackUrl.searchParams.get("code")).toBe("recovery-code");
+    expect(callbackUrl.searchParams.get("flow")).toBe("recovery");
     expect(callbackUrl.searchParams.get("next")).toBe(
       "/reset-password?redirect=%2Fsymptom-checker"
     );

--- a/tests/auth-pages.network-error.test.tsx
+++ b/tests/auth-pages.network-error.test.tsx
@@ -188,7 +188,7 @@ describe("auth page network error handling", () => {
         "owner@example.com",
         {
           redirectTo:
-            "http://localhost/auth/callback?next=%2Freset-password%3Fredirect%3D%252Fdashboard",
+            "http://localhost/auth/callback?flow=recovery&next=%2Freset-password%3Fredirect%3D%252Fdashboard",
         }
       )
     );

--- a/tests/auth-routing.test.ts
+++ b/tests/auth-routing.test.ts
@@ -2,6 +2,7 @@ import {
   appendRedirectParam,
   buildBrowserCallbackUrl,
   buildCallbackUrl,
+  buildRecoveryCallbackUrl,
   buildRecoveryRedirectPath,
   buildRedirectTarget,
   buildLoginPath,
@@ -63,6 +64,9 @@ describe("VET-1215 auth routing helpers", () => {
     );
     expect(buildBrowserCallbackUrl("https://pawvital.ai", "/pets/1")).toBe(
       "https://pawvital.ai/auth/callback?next=%2Fpets%2F1"
+    );
+    expect(buildRecoveryCallbackUrl("https://pawvital.ai", "/pets/1")).toBe(
+      "https://pawvital.ai/auth/callback?flow=recovery&next=%2Freset-password%3Fredirect%3D%252Fpets%252F1"
     );
   });
 


### PR DESCRIPTION
## Summary
- mark password reset emails with an explicit recovery callback flow
- force recovery callbacks to land on /reset-password before any post-reset app redirect
- preserve compatibility for recovery PKCE codes that arrive through /api/auth/callback

## Verification
- npm test -- --runTestsByPath tests/auth-callback.route.test.ts tests/auth-callback.page.test.tsx tests/auth-routing.test.ts tests/auth-pages.network-error.test.tsx --runInBand
- npm run build

## Notes
- Build/test were run in the dependency-ready verification worktree because the primary checkout has a broken node_modules install on Windows.
