### PR TITLE
VET-1406Q: concern-bucket engine skeleton

### DIFF
--- a/docs/clinical-intelligence/concern-bucket-engine-notes-qwen.md
+++ b/docs/clinical-intelligence/concern-bucket-engine-notes-qwen.md
@@ -1,0 +1,122 @@
+# Concern Bucket Engine — Qwen Implementation Notes
+
+> **Ticket:** VET-1406Q
+> **Date:** 2026-04-28
+> **Author:** Qwen 3.6 Plus
+> **Scope:** Pure TypeScript utilities + tests. Not wired into production flow.
+
+---
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `src/lib/clinical-intelligence/concern-buckets.ts` | Bucket definitions, types, and lookup helpers |
+| `src/lib/clinical-intelligence/concern-bucket-scoring.ts` | Scoring engine, top-N, must-not-miss detection, merge into case state |
+| `tests/clinical-intelligence/concern-buckets.test.ts` | Unit tests for all exported functions |
+
+---
+
+## Bucket Definitions (13 total)
+
+### Must-not-miss buckets (8)
+| ID | Label | Key Red Flags |
+|----|-------|---------------|
+| `emergency_airway_breathing` | Emergency — Airway / Breathing | blue_gums, pale_gums, breathing_difficulty, breathing_onset_sudden, stridor_present |
+| `emergency_circulation_shock` | Emergency — Circulation / Shock | collapse, unresponsive, pale_gums, large_blood_volume, wound_deep_bleeding |
+| `bloat_gdv_pattern` | Emergency — Bloat / GDV Pattern | unproductive_retching, rapid_onset_distension, bloat_with_restlessness, distended_abdomen_painful |
+| `toxin_exposure_pattern` | Emergency — Toxin Exposure Pattern | toxin_confirmed, rat_poison_confirmed, toxin_with_symptoms |
+| `urinary_obstruction_pattern` | Emergency — Urinary Obstruction Pattern | urinary_blockage, no_urine_24h |
+| `seizure_neuro_pattern` | Emergency — Seizure / Neuro Pattern | seizure_activity, seizure_prolonged, post_ictal_prolonged, sudden_paralysis |
+| `trauma_severe_pain` | Emergency — Trauma / Severe Pain | wound_deep_bleeding, wound_bone_visible |
+| `skin_allergy_emergency` | Emergency — Skin Allergy Emergency | face_swelling, hives_widespread, allergic_with_breathing |
+
+### Non-critical buckets (5)
+| ID | Label |
+|----|-------|
+| `gi_dehydration_or_blood` | Concern — GI Dehydration or Blood |
+| `skin_irritation_or_parasite` | Concern — Skin Irritation or Parasite |
+| `routine_mild_skin` | Routine — Mild Skin Issue |
+| `routine_mild_limp` | Routine — Mild Limp |
+| `unclear_needs_more_info` | Unclear — Needs More Information |
+
+---
+
+## Scoring Rules
+
+| Evidence Type | Score | Notes |
+|---------------|-------|-------|
+| Positive matching red flag | +35 | Strong score increase |
+| Matching clinical signal | +20 | Medium score increase |
+| Matching explicit answer | +15 | Medium score increase |
+| Unknown emergency slot (must-not-miss) | +5 | Keeps bucket present at low score |
+| Emergency urgency + positive flag | min(score, 80) | Floor for emergency buckets |
+
+Scores are clamped to 0–100.
+
+---
+
+## Pure Functions
+
+### Bucket Definitions
+- `getConcernBucketDefinitions()` — returns all 13 bucket definitions
+- `getConcernBucketDefinitionById(id)` — lookup by ID
+- `getAllMustNotMissBucketIds()` — returns IDs of 8 must-not-miss buckets
+
+### Scoring
+- `scoreConcernBuckets(caseState)` — scores all buckets against case state
+- `scoreConcernBucket(caseState, definition)` — scores a single bucket
+- `getTopConcernBuckets(caseState, limit?)` — returns top N scored buckets sorted descending
+- `hasMustNotMissConcern(caseState)` — true if any must-not-miss bucket has score > 0
+- `mergeConcernBucketsIntoCaseState(caseState)` — writes scored buckets into `caseState.concernBuckets`
+
+---
+
+## Safety Rules
+
+1. **Buckets are internal only** — `labelForLogs` is for logging/debugging, not owner-facing
+2. **No diagnosis/treatment language** — bucket IDs and labels contain no diagnosis, treatment, cure, medication, prescription, antibiotic, steroid, or surgery terms
+3. **Buckets cannot downgrade emergency urgency** — `mergeConcernBucketsIntoCaseState` only writes `concernBuckets`, never touches `currentUrgency`
+4. **User-facing text must not use bucket labels** — bucket IDs are internal identifiers
+5. **No treatment advice** — buckets only suggest question-card IDs for further information gathering
+6. **Negative answer cannot override positive red flag** — scoring only adds for positive matches; negative flags are ignored
+
+---
+
+## Suggested Question Mappings
+
+Each bucket maps to question-card IDs for follow-up:
+- `emergency_airway_breathing` → `breathing_difficulty_check`, `gum_color_check`
+- `emergency_circulation_shock` → `collapse_weakness_check`, `gum_color_check`
+- `bloat_gdv_pattern` → `bloat_retching_abdomen_check`
+- `toxin_exposure_pattern` → `toxin_exposure_check`
+- `urinary_obstruction_pattern` → `urinary_blockage_check`, `urinary_straining_output`
+- `seizure_neuro_pattern` → `seizure_neuro_check`, `neuro_seizure_duration`
+- `trauma_severe_pain` → `limping_trauma_onset`
+- `skin_allergy_emergency` → `skin_emergency_allergy_screen`
+- `skin_irritation_or_parasite` → `skin_location_distribution`, `skin_changes_check`, `skin_exposure_check`
+- `routine_mild_skin` → `skin_location_distribution`
+- `routine_mild_limp` → `limping_weight_bearing`
+- `unclear_needs_more_info` → `emergency_global_screen`
+
+---
+
+## NOT Done (Out of Scope)
+
+- No wiring into live symptom-check flow
+- No API route changes
+- No UI changes
+- No planner cutover
+- No model/RAG changes
+- No emergency threshold changes
+- No owner-facing exposure of bucket labels
+
+---
+
+## Next Steps (Separate Ticket Required — Codex GPT-5.4)
+
+1. Wire concern bucket scoring into the symptom-check session loop
+2. Use `getTopConcernBuckets()` to drive next-question selection
+3. Use `hasMustNotMissConcern()` as a safety gate before handoff
+4. Build admin UI for bucket inspection
+5. Integrate with the planner for question prioritization

--- a/src/lib/clinical-intelligence/concern-bucket-scoring.ts
+++ b/src/lib/clinical-intelligence/concern-bucket-scoring.ts
@@ -1,0 +1,125 @@
+import type { ClinicalCaseState } from "./case-state";
+import type { ConcernBucketDefinition, ScoredConcernBucket } from "./concern-buckets";
+import { getConcernBucketDefinitions } from "./concern-buckets";
+
+const SCORE_CLAMP_MIN = 0;
+const SCORE_CLAMP_MAX = 100;
+
+const POSITIVE_RED_FLAG_SCORE = 35;
+const CLINICAL_SIGNAL_SCORE = 20;
+const EXPLICIT_ANSWER_SCORE = 15;
+const UNKNOWN_EMERGENCY_SLOT_SCORE = 5;
+
+function clampScore(score: number): number {
+  return Math.max(SCORE_CLAMP_MIN, Math.min(SCORE_CLAMP_MAX, score));
+}
+
+export function scoreConcernBuckets(
+  caseState: ClinicalCaseState
+): ScoredConcernBucket[] {
+  const definitions = getConcernBucketDefinitions();
+  return definitions.map((def) => scoreConcernBucket(caseState, def));
+}
+
+export function scoreConcernBucket(
+  caseState: ClinicalCaseState,
+  definition: ConcernBucketDefinition
+): ScoredConcernBucket {
+  let score = 0;
+  const evidence: string[] = [];
+
+  for (const redFlagId of definition.redFlagIds) {
+    const entry = caseState.redFlagStatus[redFlagId];
+    if (entry?.status === "positive") {
+      score += POSITIVE_RED_FLAG_SCORE;
+      evidence.push(`Positive red flag: ${redFlagId}${entry.evidenceText ? ` — ${entry.evidenceText}` : ""}`);
+    }
+  }
+
+  for (const signalId of definition.signalIds) {
+    const matchingSignal = caseState.clinicalSignals.find(
+      (s) => s.id === signalId || s.type === signalId
+    );
+    if (matchingSignal) {
+      score += CLINICAL_SIGNAL_SCORE;
+      evidence.push(`Clinical signal: ${matchingSignal.type} — ${matchingSignal.evidenceText}`);
+    }
+  }
+
+  for (const answerKey of definition.answerKeys) {
+    if (answerKey in caseState.explicitAnswers) {
+      score += EXPLICIT_ANSWER_SCORE;
+      const value = caseState.explicitAnswers[answerKey];
+      evidence.push(`Explicit answer: ${answerKey} = ${String(value)}`);
+    }
+  }
+
+  const hasPositiveRedFlag = definition.redFlagIds.some(
+    (id) => caseState.redFlagStatus[id]?.status === "positive"
+  );
+
+  if (!hasPositiveRedFlag && definition.mustNotMiss) {
+    const allUnknown = definition.redFlagIds.every(
+      (id) => !caseState.redFlagStatus[id] || caseState.redFlagStatus[id].status === "unknown"
+    );
+    if (allUnknown && definition.redFlagIds.length > 0) {
+      score += UNKNOWN_EMERGENCY_SLOT_SCORE;
+      evidence.push(`Must-not-miss bucket with unknown red flags — kept at low score`);
+    }
+  }
+
+  score = clampScore(score);
+
+  if (caseState.currentUrgency === "emergency" && hasPositiveRedFlag) {
+    score = Math.max(score, 80);
+  }
+
+  return {
+    id: definition.id,
+    score,
+    evidence,
+    mustNotMiss: definition.mustNotMiss,
+    suggestedQuestionIds: definition.suggestedQuestionIds,
+  };
+}
+
+export function getTopConcernBuckets(
+  caseState: ClinicalCaseState,
+  limit: number = 5
+): ScoredConcernBucket[] {
+  const scored = scoreConcernBuckets(caseState);
+
+  return scored
+    .filter((bucket) => bucket.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+}
+
+export function hasMustNotMissConcern(
+  caseState: ClinicalCaseState
+): boolean {
+  const scored = scoreConcernBuckets(caseState);
+  return scored.some(
+    (bucket) => bucket.mustNotMiss && bucket.score > UNKNOWN_EMERGENCY_SLOT_SCORE
+  );
+}
+
+export function mergeConcernBucketsIntoCaseState(
+  caseState: ClinicalCaseState
+): ClinicalCaseState {
+  const scored = scoreConcernBuckets(caseState);
+
+  const concernBuckets = scored
+    .filter((bucket) => bucket.score > 0)
+    .map((bucket) => ({
+      id: bucket.id,
+      score: bucket.score,
+      evidence: bucket.evidence,
+      mustNotMiss: bucket.mustNotMiss,
+    }));
+
+  return {
+    ...caseState,
+    concernBuckets,
+  };
+}

--- a/src/lib/clinical-intelligence/concern-buckets.ts
+++ b/src/lib/clinical-intelligence/concern-buckets.ts
@@ -1,0 +1,191 @@
+export interface ConcernBucketDefinition {
+  id: string;
+  labelForLogs: string;
+  mustNotMiss: boolean;
+  redFlagIds: string[];
+  signalIds: string[];
+  answerKeys: string[];
+  suggestedQuestionIds: string[];
+}
+
+export interface ScoredConcernBucket {
+  id: string;
+  score: number;
+  evidence: string[];
+  mustNotMiss: boolean;
+  suggestedQuestionIds: string[];
+}
+
+const BUCKET_DEFINITIONS: readonly ConcernBucketDefinition[] = [
+  {
+    id: "emergency_airway_breathing",
+    labelForLogs: "Emergency — Airway / Breathing",
+    mustNotMiss: true,
+    redFlagIds: [
+      "blue_gums",
+      "pale_gums",
+      "breathing_difficulty",
+      "breathing_onset_sudden",
+      "stridor_present",
+    ],
+    signalIds: ["respiratory_distress_signal", "cyanosis_signal"],
+    answerKeys: ["gum_color", "difficulty_breathing", "breathing_onset", "breathing_rate"],
+    suggestedQuestionIds: ["breathing_difficulty_check", "gum_color_check"],
+  },
+  {
+    id: "emergency_circulation_shock",
+    labelForLogs: "Emergency — Circulation / Shock",
+    mustNotMiss: true,
+    redFlagIds: [
+      "collapse",
+      "unresponsive",
+      "pale_gums",
+      "large_blood_volume",
+      "wound_deep_bleeding",
+    ],
+    signalIds: ["shock_signal", "hemorrhage_signal"],
+    answerKeys: ["consciousness_level", "gum_color", "blood_amount", "wound_discharge"],
+    suggestedQuestionIds: ["collapse_weakness_check", "gum_color_check"],
+  },
+  {
+    id: "bloat_gdv_pattern",
+    labelForLogs: "Emergency — Bloat / GDV Pattern",
+    mustNotMiss: true,
+    redFlagIds: [
+      "unproductive_retching",
+      "rapid_onset_distension",
+      "bloat_with_restlessness",
+      "distended_abdomen_painful",
+    ],
+    signalIds: ["gdv_signal", "abdominal_distension_signal"],
+    answerKeys: ["unproductive_retching", "swollen_abdomen", "abdomen_onset", "restlessness", "abdomen_pain"],
+    suggestedQuestionIds: ["bloat_retching_abdomen_check"],
+  },
+  {
+    id: "toxin_exposure_pattern",
+    labelForLogs: "Emergency — Toxin Exposure Pattern",
+    mustNotMiss: true,
+    redFlagIds: [
+      "toxin_confirmed",
+      "rat_poison_confirmed",
+      "toxin_with_symptoms",
+    ],
+    signalIds: ["toxicosis_signal", "poison_exposure_signal"],
+    answerKeys: ["toxin_exposure", "rat_poison_access", "vomiting", "trembling"],
+    suggestedQuestionIds: ["toxin_exposure_check"],
+  },
+  {
+    id: "urinary_obstruction_pattern",
+    labelForLogs: "Emergency — Urinary Obstruction Pattern",
+    mustNotMiss: true,
+    redFlagIds: [
+      "urinary_blockage",
+      "no_urine_24h",
+    ],
+    signalIds: ["urinary_obstruction_signal"],
+    answerKeys: ["straining_to_urinate", "no_urine_output", "male_dog"],
+    suggestedQuestionIds: ["urinary_blockage_check", "urinary_straining_output"],
+  },
+  {
+    id: "seizure_neuro_pattern",
+    labelForLogs: "Emergency — Seizure / Neuro Pattern",
+    mustNotMiss: true,
+    redFlagIds: [
+      "seizure_activity",
+      "seizure_prolonged",
+      "post_ictal_prolonged",
+      "sudden_paralysis",
+    ],
+    signalIds: ["seizure_signal", "neurologic_deficit_signal"],
+    answerKeys: ["seizure_duration", "consciousness_level", "balance_issues", "head_tilt"],
+    suggestedQuestionIds: ["seizure_neuro_check", "neuro_seizure_duration"],
+  },
+  {
+    id: "trauma_severe_pain",
+    labelForLogs: "Emergency — Trauma / Severe Pain",
+    mustNotMiss: true,
+    redFlagIds: [
+      "wound_deep_bleeding",
+      "wound_bone_visible",
+    ],
+    signalIds: ["trauma_signal", "severe_pain_signal"],
+    answerKeys: ["trauma_onset", "wound_depth", "wound_discharge", "pain_level"],
+    suggestedQuestionIds: ["limping_trauma_onset"],
+  },
+  {
+    id: "gi_dehydration_or_blood",
+    labelForLogs: "Concern — GI Dehydration or Blood",
+    mustNotMiss: false,
+    redFlagIds: [
+      "vomit_blood",
+      "stool_blood_large",
+      "bloody_diarrhea_puppy",
+    ],
+    signalIds: ["gi_bleeding_signal", "dehydration_signal"],
+    answerKeys: ["vomiting_frequency", "blood_in_stool", "blood_amount", "water_intake", "keeping_water_down"],
+    suggestedQuestionIds: ["gi_vomiting_frequency", "gi_blood_check", "gi_keep_water_down_check"],
+  },
+  {
+    id: "skin_allergy_emergency",
+    labelForLogs: "Emergency — Skin Allergy Emergency",
+    mustNotMiss: true,
+    redFlagIds: [
+      "face_swelling",
+      "hives_widespread",
+      "allergic_with_breathing",
+    ],
+    signalIds: ["anaphylaxis_signal", "angioedema_signal"],
+    answerKeys: ["facial_swelling", "hives", "difficulty_breathing", "medication_reaction"],
+    suggestedQuestionIds: ["skin_emergency_allergy_screen"],
+  },
+  {
+    id: "skin_irritation_or_parasite",
+    labelForLogs: "Concern — Skin Irritation or Parasite",
+    mustNotMiss: false,
+    redFlagIds: [],
+    signalIds: ["skin_irritation_signal", "parasite_signal"],
+    answerKeys: ["excessive_scratching", "skin_changes", "skin_exposure", "wound_discharge"],
+    suggestedQuestionIds: ["skin_location_distribution", "skin_changes_check", "skin_exposure_check"],
+  },
+  {
+    id: "routine_mild_skin",
+    labelForLogs: "Routine — Mild Skin Issue",
+    mustNotMiss: false,
+    redFlagIds: [],
+    signalIds: ["mild_skin_signal"],
+    answerKeys: ["excessive_scratching", "skin_changes"],
+    suggestedQuestionIds: ["skin_location_distribution"],
+  },
+  {
+    id: "routine_mild_limp",
+    labelForLogs: "Routine — Mild Limp",
+    mustNotMiss: false,
+    redFlagIds: [],
+    signalIds: ["mild_limp_signal"],
+    answerKeys: ["limping", "weight_bearing", "abnormal_gait"],
+    suggestedQuestionIds: ["limping_weight_bearing"],
+  },
+  {
+    id: "unclear_needs_more_info",
+    labelForLogs: "Unclear — Needs More Information",
+    mustNotMiss: false,
+    redFlagIds: [],
+    signalIds: [],
+    answerKeys: [],
+    suggestedQuestionIds: ["emergency_global_screen"],
+  },
+];
+
+export function getConcernBucketDefinitions(): readonly ConcernBucketDefinition[] {
+  return BUCKET_DEFINITIONS;
+}
+
+export function getConcernBucketDefinitionById(
+  id: string
+): ConcernBucketDefinition | undefined {
+  return BUCKET_DEFINITIONS.find((def) => def.id === id);
+}
+
+export function getAllMustNotMissBucketIds(): string[] {
+  return BUCKET_DEFINITIONS.filter((def) => def.mustNotMiss).map((def) => def.id);
+}

--- a/tests/clinical-intelligence/concern-buckets.test.ts
+++ b/tests/clinical-intelligence/concern-buckets.test.ts
@@ -1,0 +1,564 @@
+import {
+  createInitialClinicalCaseState,
+  type ClinicalCaseState,
+  type ClinicalSignal,
+} from "@/lib/clinical-intelligence/case-state";
+
+import {
+  updateRedFlagStatus,
+  recordAnsweredQuestion,
+  addClinicalSignal,
+} from "@/lib/clinical-intelligence/case-state-update";
+
+import {
+  getConcernBucketDefinitions,
+  getConcernBucketDefinitionById,
+  getAllMustNotMissBucketIds,
+} from "@/lib/clinical-intelligence/concern-buckets";
+
+import {
+  scoreConcernBuckets,
+  getTopConcernBuckets,
+  hasMustNotMissConcern,
+  mergeConcernBucketsIntoCaseState,
+} from "@/lib/clinical-intelligence/concern-bucket-scoring";
+
+describe("Concern bucket definitions", () => {
+  it("initializes all expected bucket definitions", () => {
+    const definitions = getConcernBucketDefinitions();
+
+    expect(definitions.length).toBe(13);
+
+    const expectedIds = [
+      "emergency_airway_breathing",
+      "emergency_circulation_shock",
+      "bloat_gdv_pattern",
+      "toxin_exposure_pattern",
+      "urinary_obstruction_pattern",
+      "seizure_neuro_pattern",
+      "trauma_severe_pain",
+      "gi_dehydration_or_blood",
+      "skin_allergy_emergency",
+      "skin_irritation_or_parasite",
+      "routine_mild_skin",
+      "routine_mild_limp",
+      "unclear_needs_more_info",
+    ];
+
+    const actualIds = definitions.map((d) => d.id);
+    for (const expectedId of expectedIds) {
+      expect(actualIds).toContain(expectedId);
+    }
+  });
+
+  it("every bucket has labelForLogs without diagnosis/treatment language", () => {
+    const definitions = getConcernBucketDefinitions();
+    const forbiddenPatterns = [
+      /diagnos/i,
+      /treat/i,
+      /cure/i,
+      /medication/i,
+      /prescription/i,
+      /surgery/i,
+      /antibiotic/i,
+    ];
+
+    for (const def of definitions) {
+      for (const pattern of forbiddenPatterns) {
+        expect(def.labelForLogs).not.toMatch(pattern);
+      }
+    }
+  });
+
+  it("getConcernBucketDefinitionById returns correct definition", () => {
+    const def = getConcernBucketDefinitionById("bloat_gdv_pattern");
+
+    expect(def).toBeDefined();
+    expect(def?.id).toBe("bloat_gdv_pattern");
+    expect(def?.mustNotMiss).toBe(true);
+    expect(def?.redFlagIds).toContain("unproductive_retching");
+  });
+
+  it("getConcernBucketDefinitionById returns undefined for unknown id", () => {
+    expect(getConcernBucketDefinitionById("nonexistent_bucket")).toBeUndefined();
+  });
+
+  it("getAllMustNotMissBucketIds returns only must-not-miss buckets", () => {
+    const mustNotMissIds = getAllMustNotMissBucketIds();
+
+    expect(mustNotMissIds).toContain("emergency_airway_breathing");
+    expect(mustNotMissIds).toContain("emergency_circulation_shock");
+    expect(mustNotMissIds).toContain("bloat_gdv_pattern");
+    expect(mustNotMissIds).toContain("toxin_exposure_pattern");
+    expect(mustNotMissIds).toContain("urinary_obstruction_pattern");
+    expect(mustNotMissIds).toContain("seizure_neuro_pattern");
+    expect(mustNotMissIds).toContain("trauma_severe_pain");
+    expect(mustNotMissIds).toContain("skin_allergy_emergency");
+    expect(mustNotMissIds).not.toContain("routine_mild_skin");
+    expect(mustNotMissIds).not.toContain("routine_mild_limp");
+    expect(mustNotMissIds).not.toContain("unclear_needs_more_info");
+  });
+});
+
+describe("Scoring: breathing red flags", () => {
+  let state: ClinicalCaseState;
+
+  beforeEach(() => {
+    state = createInitialClinicalCaseState();
+  });
+
+  it("scores breathing red flags into emergency_airway_breathing", () => {
+    state = updateRedFlagStatus(state, "blue_gums", {
+      status: "positive",
+      source: "explicit_answer",
+      evidenceText: "Owner reports blue gums",
+      turn: 1,
+    });
+    state = updateRedFlagStatus(state, "breathing_difficulty", {
+      status: "positive",
+      source: "explicit_answer",
+      turn: 2,
+    });
+
+    const scored = scoreConcernBuckets(state);
+    const breathing = scored.find((b) => b.id === "emergency_airway_breathing");
+
+    expect(breathing).toBeDefined();
+    expect(breathing!.score).toBeGreaterThanOrEqual(70);
+    expect(breathing!.evidence.length).toBeGreaterThanOrEqual(2);
+    expect(breathing!.mustNotMiss).toBe(true);
+  });
+});
+
+describe("Scoring: collapse/shock", () => {
+  let state: ClinicalCaseState;
+
+  beforeEach(() => {
+    state = createInitialClinicalCaseState();
+  });
+
+  it("scores collapse/pale gums into emergency_circulation_shock", () => {
+    state = updateRedFlagStatus(state, "collapse", {
+      status: "positive",
+      source: "explicit_answer",
+      turn: 1,
+    });
+    state = updateRedFlagStatus(state, "pale_gums", {
+      status: "positive",
+      source: "explicit_answer",
+      turn: 2,
+    });
+
+    const scored = scoreConcernBuckets(state);
+    const shock = scored.find((b) => b.id === "emergency_circulation_shock");
+
+    expect(shock).toBeDefined();
+    expect(shock!.score).toBeGreaterThanOrEqual(70);
+    expect(shock!.mustNotMiss).toBe(true);
+  });
+});
+
+describe("Scoring: bloat/GDV", () => {
+  let state: ClinicalCaseState;
+
+  beforeEach(() => {
+    state = createInitialClinicalCaseState();
+  });
+
+  it("scores retching/swollen abdomen signals into bloat_gdv_pattern", () => {
+    state = updateRedFlagStatus(state, "unproductive_retching", {
+      status: "positive",
+      source: "explicit_answer",
+      evidenceText: "Unproductive retching confirmed",
+      turn: 1,
+    });
+
+    const scored = scoreConcernBuckets(state);
+    const bloat = scored.find((b) => b.id === "bloat_gdv_pattern");
+
+    expect(bloat).toBeDefined();
+    expect(bloat!.score).toBeGreaterThanOrEqual(35);
+    expect(bloat!.mustNotMiss).toBe(true);
+  });
+});
+
+describe("Scoring: toxin exposure", () => {
+  let state: ClinicalCaseState;
+
+  beforeEach(() => {
+    state = createInitialClinicalCaseState();
+  });
+
+  it("scores toxin exposure into toxin_exposure_pattern", () => {
+    state = updateRedFlagStatus(state, "toxin_confirmed", {
+      status: "positive",
+      source: "explicit_answer",
+      turn: 1,
+    });
+
+    const scored = scoreConcernBuckets(state);
+    const toxin = scored.find((b) => b.id === "toxin_exposure_pattern");
+
+    expect(toxin).toBeDefined();
+    expect(toxin!.score).toBeGreaterThanOrEqual(35);
+    expect(toxin!.mustNotMiss).toBe(true);
+  });
+});
+
+describe("Scoring: urinary obstruction", () => {
+  let state: ClinicalCaseState;
+
+  beforeEach(() => {
+    state = createInitialClinicalCaseState();
+  });
+
+  it("scores urinary straining/no output into urinary_obstruction_pattern", () => {
+    state = updateRedFlagStatus(state, "urinary_blockage", {
+      status: "positive",
+      source: "explicit_answer",
+      turn: 1,
+    });
+
+    const scored = scoreConcernBuckets(state);
+    const urinary = scored.find((b) => b.id === "urinary_obstruction_pattern");
+
+    expect(urinary).toBeDefined();
+    expect(urinary!.score).toBeGreaterThanOrEqual(35);
+    expect(urinary!.mustNotMiss).toBe(true);
+  });
+});
+
+describe("Scoring: seizure/neuro", () => {
+  let state: ClinicalCaseState;
+
+  beforeEach(() => {
+    state = createInitialClinicalCaseState();
+  });
+
+  it("scores seizure signals into seizure_neuro_pattern", () => {
+    state = updateRedFlagStatus(state, "seizure_activity", {
+      status: "positive",
+      source: "explicit_answer",
+      turn: 1,
+    });
+
+    const scored = scoreConcernBuckets(state);
+    const neuro = scored.find((b) => b.id === "seizure_neuro_pattern");
+
+    expect(neuro).toBeDefined();
+    expect(neuro!.score).toBeGreaterThanOrEqual(35);
+    expect(neuro!.mustNotMiss).toBe(true);
+  });
+});
+
+describe("Scoring: mild skin symptoms", () => {
+  let state: ClinicalCaseState;
+
+  beforeEach(() => {
+    state = createInitialClinicalCaseState();
+  });
+
+  it("scores mild skin symptoms into routine_mild_skin without emergency escalation", () => {
+    state = recordAnsweredQuestion(state, "q1", "excessive_scratching", "yes");
+    state = recordAnsweredQuestion(state, "q2", "skin_changes", "mild_redness");
+
+    const scored = scoreConcernBuckets(state);
+    const mildSkin = scored.find((b) => b.id === "routine_mild_skin");
+
+    expect(mildSkin).toBeDefined();
+    expect(mildSkin!.score).toBeGreaterThan(0);
+    expect(mildSkin!.mustNotMiss).toBe(false);
+
+    const emergencySkin = scored.find((b) => b.id === "skin_allergy_emergency");
+    expect(emergencySkin).toBeDefined();
+    expect(emergencySkin!.mustNotMiss).toBe(true);
+  });
+});
+
+describe("Scoring: mild limp", () => {
+  let state: ClinicalCaseState;
+
+  beforeEach(() => {
+    state = createInitialClinicalCaseState();
+  });
+
+  it("scores mild limp into routine_mild_limp without emergency escalation", () => {
+    state = recordAnsweredQuestion(state, "q1", "limping", "yes");
+    state = recordAnsweredQuestion(state, "q2", "weight_bearing", "partial");
+
+    const scored = scoreConcernBuckets(state);
+    const mildLimp = scored.find((b) => b.id === "routine_mild_limp");
+
+    expect(mildLimp).toBeDefined();
+    expect(mildLimp!.score).toBeGreaterThan(0);
+    expect(mildLimp!.mustNotMiss).toBe(false);
+  });
+});
+
+describe("Scoring: clinical signals", () => {
+  let state: ClinicalCaseState;
+
+  beforeEach(() => {
+    state = createInitialClinicalCaseState();
+  });
+
+  it("scores matching clinical signals into the correct bucket", () => {
+    const signal: ClinicalSignal = {
+      id: "respiratory_distress_signal",
+      type: "respiratory_distress_signal",
+      severity: "high",
+      evidenceText: "AI detected respiratory distress from owner description",
+      turnDetected: 1,
+    };
+
+    state = addClinicalSignal(state, signal);
+
+    const scored = scoreConcernBuckets(state);
+    const breathing = scored.find((b) => b.id === "emergency_airway_breathing");
+
+    expect(breathing).toBeDefined();
+    expect(breathing!.score).toBeGreaterThanOrEqual(20);
+    expect(breathing!.evidence.some((e) => e.includes("Clinical signal"))).toBe(true);
+  });
+});
+
+describe("Scoring: scores are clamped", () => {
+  it("scores are clamped to 0-100 range", () => {
+    let state = createInitialClinicalCaseState();
+
+    for (let i = 0; i < 10; i++) {
+      state = updateRedFlagStatus(state, `flag_${i}`, {
+        status: "positive",
+        source: "explicit_answer",
+        turn: i + 1,
+      });
+    }
+
+    const scored = scoreConcernBuckets(state);
+
+    for (const bucket of scored) {
+      expect(bucket.score).toBeGreaterThanOrEqual(0);
+      expect(bucket.score).toBeLessThanOrEqual(100);
+    }
+  });
+});
+
+describe("Urgency safety: emergency is never downgraded", () => {
+  it("positive emergency urgency is never downgraded after bucket merge", () => {
+    let state = createInitialClinicalCaseState();
+    state = updateRedFlagStatus(state, "blue_gums", {
+      status: "positive",
+      source: "explicit_answer",
+      turn: 1,
+    });
+
+    expect(state.currentUrgency).toBe("emergency");
+
+    const merged = mergeConcernBucketsIntoCaseState(state);
+
+    expect(merged.currentUrgency).toBe("emergency");
+  });
+});
+
+describe("Negative red flag does not override positive", () => {
+  it("negative red flag does not override a different positive red flag", () => {
+    let state = createInitialClinicalCaseState();
+    state = updateRedFlagStatus(state, "blue_gums", {
+      status: "positive",
+      source: "explicit_answer",
+      turn: 1,
+    });
+    state = updateRedFlagStatus(state, "breathing_difficulty", {
+      status: "negative",
+      source: "explicit_answer",
+      turn: 2,
+    });
+
+    const scored = scoreConcernBuckets(state);
+    const breathing = scored.find((b) => b.id === "emergency_airway_breathing");
+
+    expect(breathing).toBeDefined();
+    expect(breathing!.score).toBeGreaterThanOrEqual(35);
+  });
+});
+
+describe("Suggested question IDs", () => {
+  it("suggested question IDs are preserved in scored buckets", () => {
+    let state = createInitialClinicalCaseState();
+    state = updateRedFlagStatus(state, "blue_gums", {
+      status: "positive",
+      source: "explicit_answer",
+      turn: 1,
+    });
+
+    const scored = scoreConcernBuckets(state);
+    const breathing = scored.find((b) => b.id === "emergency_airway_breathing");
+
+    expect(breathing).toBeDefined();
+    expect(breathing!.suggestedQuestionIds).toHaveLength(2);
+    expect(breathing!.suggestedQuestionIds).toContain("breathing_difficulty_check");
+    expect(breathing!.suggestedQuestionIds).toContain("gum_color_check");
+  });
+});
+
+describe("No owner-facing diagnosis/treatment language", () => {
+  it("no bucket definition contains diagnosis/treatment claims", () => {
+    const definitions = getConcernBucketDefinitions();
+    const forbiddenWords = [
+      "diagnose",
+      "diagnosis",
+      "treat",
+      "treatment",
+      "cure",
+      "medication",
+      "prescription",
+      "antibiotic",
+      "steroid",
+      "surgery",
+    ];
+
+    for (const def of definitions) {
+      const combinedText = `${def.labelForLogs} ${def.id}`.toLowerCase();
+      for (const word of forbiddenWords) {
+        expect(combinedText).not.toContain(word.toLowerCase());
+      }
+    }
+  });
+});
+
+describe("getTopConcernBuckets", () => {
+  it("sorts by score descending", () => {
+    let state = createInitialClinicalCaseState();
+    state = updateRedFlagStatus(state, "blue_gums", {
+      status: "positive",
+      source: "explicit_answer",
+      turn: 1,
+    });
+    state = updateRedFlagStatus(state, "unproductive_retching", {
+      status: "positive",
+      source: "explicit_answer",
+      turn: 2,
+    });
+    state = recordAnsweredQuestion(state, "q1", "excessive_scratching", "yes");
+
+    const top = getTopConcernBuckets(state, 3);
+
+    expect(top.length).toBeLessThanOrEqual(3);
+    for (let i = 0; i < top.length - 1; i++) {
+      expect(top[i].score).toBeGreaterThanOrEqual(top[i + 1].score);
+    }
+  });
+
+  it("respects the limit parameter", () => {
+    let state = createInitialClinicalCaseState();
+
+    for (let i = 0; i < 10; i++) {
+      state = updateRedFlagStatus(state, `flag_${i}`, {
+        status: "positive",
+        source: "explicit_answer",
+        turn: i + 1,
+      });
+    }
+
+    const top = getTopConcernBuckets(state, 2);
+
+    expect(top.length).toBeLessThanOrEqual(2);
+  });
+
+  it("filters out zero-score buckets", () => {
+    const state = createInitialClinicalCaseState();
+
+    const top = getTopConcernBuckets(state);
+
+    for (const bucket of top) {
+      expect(bucket.score).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("hasMustNotMissConcern", () => {
+  it("detects high-risk buckets when must-not-miss bucket has score > 0", () => {
+    let state = createInitialClinicalCaseState();
+    state = updateRedFlagStatus(state, "blue_gums", {
+      status: "positive",
+      source: "explicit_answer",
+      turn: 1,
+    });
+
+    expect(hasMustNotMissConcern(state)).toBe(true);
+  });
+
+  it("returns false when no must-not-miss bucket has a score", () => {
+    const state = createInitialClinicalCaseState();
+
+    expect(hasMustNotMissConcern(state)).toBe(false);
+  });
+
+  it("returns false when only non-must-not-miss buckets have scores", () => {
+    let state = createInitialClinicalCaseState();
+    state = recordAnsweredQuestion(state, "q1", "excessive_scratching", "yes");
+
+    expect(hasMustNotMissConcern(state)).toBe(false);
+  });
+});
+
+describe("mergeConcernBucketsIntoCaseState", () => {
+  it("populates concernBuckets on the case state", () => {
+    let state = createInitialClinicalCaseState();
+    state = updateRedFlagStatus(state, "blue_gums", {
+      status: "positive",
+      source: "explicit_answer",
+      turn: 1,
+    });
+
+    const merged = mergeConcernBucketsIntoCaseState(state);
+
+    expect(merged.concernBuckets.length).toBeGreaterThan(0);
+    const breathing = merged.concernBuckets.find((b) => b.id === "emergency_airway_breathing");
+    expect(breathing).toBeDefined();
+    expect(breathing!.score).toBeGreaterThan(0);
+  });
+
+  it("does not include zero-score buckets in concernBuckets", () => {
+    const state = createInitialClinicalCaseState();
+
+    const merged = mergeConcernBucketsIntoCaseState(state);
+
+    for (const bucket of merged.concernBuckets) {
+      expect(bucket.score).toBeGreaterThan(0);
+    }
+  });
+
+  it("preserves all other case state fields", () => {
+    let state = createInitialClinicalCaseState("gi");
+    state = updateRedFlagStatus(state, "blue_gums", {
+      status: "positive",
+      source: "explicit_answer",
+      turn: 1,
+    });
+
+    const merged = mergeConcernBucketsIntoCaseState(state);
+
+    expect(merged.species).toBe("dog");
+    expect(merged.activeComplaintModule).toBe("gi");
+    expect(merged.currentUrgency).toBe("emergency");
+    expect(merged.explicitAnswers).toEqual({});
+  });
+});
+
+describe("Unknown emergency slots keep must-not-miss bucket present", () => {
+  it("must-not-miss bucket with unknown red flags stays at low score", () => {
+    let state = createInitialClinicalCaseState();
+    state = updateRedFlagStatus(state, "blue_gums", {
+      status: "unknown",
+      source: "unset",
+      turn: 0,
+    });
+
+    const scored = scoreConcernBuckets(state);
+    const breathing = scored.find((b) => b.id === "emergency_airway_breathing");
+
+    expect(breathing).toBeDefined();
+    expect(breathing!.score).toBeGreaterThanOrEqual(5);
+  });
+});


### PR DESCRIPTION
## Summary
- Add 13 concern bucket definitions (8 must-not-miss, 5 routine/unclear) covering airway/breathing, circulation/shock, bloat/GDV, toxin exposure, urinary obstruction, seizure/neuro, trauma, GI, skin allergy, skin irritation, mild skin, mild limp, unclear
- Implement pure scoring engine: scoreConcernBuckets, getTopConcernBuckets, hasMustNotMissConcern, mergeConcernBucketsIntoCaseState
- Scoring: positive red flag +35, clinical signal +20, explicit answer +15, unknown emergency slot +5, clamped 0-100
- Safety: internal-only labels, no diagnosis/treatment language, cannot downgrade emergency urgency
- 29 passing unit tests

## Scope
- Pure TypeScript utilities + tests
- Not wired into production flow
- Depends on VET-1401Q (ClinicalCaseState types)

## Merge order
VET-1400 → VET-1401Q → **VET-1406Q** → VET-1403K → VET-1404K