### PR TITLE
VET-1407Q: next-best-question planner skeleton

### DIFF
--- a/docs/clinical-intelligence/next-question-planner-notes-qwen.md
+++ b/docs/clinical-intelligence/next-question-planner-notes-qwen.md
@@ -1,0 +1,144 @@
+# Next-Best-Question Planner — Qwen Implementation Notes
+
+> **Ticket:** VET-1407Q
+> **Date:** 2026-04-28
+> **Author:** Qwen 3.6 Plus
+> **Scope:** Pure TypeScript utilities + tests. Not wired into production flow.
+
+---
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `src/lib/clinical-intelligence/next-question-planner.ts` | Deterministic planner: scoring, candidate selection, fallback |
+| `src/lib/clinical-intelligence/question-card-types.ts` | ClinicalQuestionCard interface stub (full version in VET-1400) |
+| `src/lib/clinical-intelligence/question-card-registry.ts` | Registry stub (full version in VET-1400) |
+| `tests/clinical-intelligence/next-question-planner.test.ts` | 25 unit tests covering all acceptance criteria |
+
+---
+
+## Planner Output Type
+
+```typescript
+interface PlannedQuestion {
+  questionId: string;
+  ownerText: string;
+  shortReason: string;
+  score: number;
+  scoreBreakdown: Record<string, number>;
+  screenedRedFlags: string[];
+  selectedBecause: "emergency_screen" | "highest_information_gain" | "urgency_changing" | "report_value" | "clarification";
+}
+```
+
+---
+
+## Scoring Formula
+
+```
+score =
+  emergencyValue * 5        // 0-15: phase=emergency_screen or positive/unknown red flags
++ urgencyImpact * 4         // 0-12: from question card
++ discriminativeValue * 3   // 0-9: from question card
++ reportValue * 2           // 0-6: from question card
++ ownerAnswerability * 2    // 0-6: from question card
++ modulePhasePriority       // 30/15/12/8/5/3: emergency_screen > characterize > discriminate > timeline > history > handoff_detail
+- repetitionPenalty         // -50: if card was already asked
+- alreadyKnownPenalty       // -20: if skipIfAnswered keys are in explicitAnswers
+- offTopicPenalty           // -15: if card doesn't match active complaint module
+- tooManyQuestionsPenalty   // -10: if askedQuestionIds >= maxQuestionsPerTurn
+```
+
+### Module Phase Priority
+| Phase | Priority |
+|-------|----------|
+| emergency_screen | 30 |
+| characterize | 15 |
+| discriminate | 12 |
+| timeline | 8 |
+| history | 5 |
+| handoff_detail | 3 |
+
+---
+
+## Core Functions
+
+### Planning
+- `planNextClinicalQuestion(caseState, options?)` — main entry point; returns `PlannedQuestion` or `PlannerFallbackResult`
+- `getCandidateQuestionCards(caseState, options?)` — filters registry by active module, excludes answered/asked
+- `filterAnsweredOrAskedQuestions(cards, caseState, options?)` — removes answered/skipIfAnswered/asked cards
+- `selectHighestScoringQuestion(scoredQuestions)` — picks max score from scored list
+
+### Scoring
+- `scoreQuestionCard(card, caseState, options?)` — computes total score
+- `buildQuestionScoreBreakdown(card, caseState, options?)` — returns per-component breakdown
+
+### Fallback
+- `fallbackToSafeEmergencyQuestion(caseState)` — returns emergency card or `no_valid_questions` fallback
+
+---
+
+## Safety Rules
+
+1. **Never return an already answered question** — filtered by `answeredQuestionIds` and `skipIfAnswered` keys in `explicitAnswers`
+2. **Never return an already asked question** — unless `options.allowClarification === true`
+3. **Emergency-screen cards outrank routine characterization** — phase priority (30 vs 15) + emergency value scoring
+4. **Emergency urgency returns handoff sentinel** — if `currentUrgency === "emergency"`, returns `emergency_handoff` instead of routine questions
+5. **No diagnosis or treatment text** — `ownerText` and `shortReason` come directly from question cards
+6. **No invented question text** — planner only selects from existing registry cards
+7. **No bucket label exposure** — `PlannedQuestion` has no concern-bucket fields
+8. **Cannot downgrade emergency urgency** — planner only reads urgency, never modifies it
+
+---
+
+## selectedBecause Logic
+
+| Condition | selectedBecause |
+|-----------|----------------|
+| `card.phase === "emergency_screen"` | `emergency_screen` |
+| `urgencyImpact >= 8 && trajectory === "worsening"` | `urgency_changing` |
+| `reportValue >= discriminativeValue && reportValue >= 4` | `report_value` |
+| Card was previously asked (`allowClarification === true`) | `clarification` |
+| Default | `highest_information_gain` |
+
+---
+
+## Fallback Behavior
+
+| Scenario | Result |
+|----------|--------|
+| `currentUrgency === "emergency"` + emergency cards available | Returns emergency card |
+| `currentUrgency === "emergency"` + no emergency cards | `{ type: "emergency_handoff" }` |
+| No valid candidate cards | `{ type: "no_valid_questions" }` |
+| All cards scored to zero | `{ type: "no_valid_questions" }` |
+
+---
+
+## Dependencies
+
+- `case-state.ts` — `ClinicalCaseState` type, `createInitialClinicalCaseState()`
+- `case-state-update.ts` — `updateRedFlagStatus`, `recordAnsweredQuestion`, `recordAskedQuestion`
+- `question-card-types.ts` — `ClinicalQuestionCard` interface (stub; full in VET-1400)
+- `question-card-registry.ts` — `getAllQuestionCards()` (stub; full in VET-1400)
+
+---
+
+## NOT Done (Out of Scope)
+
+- No wiring into live symptom-check flow
+- No API route changes
+- No UI changes
+- No model/RAG changes
+- No emergency threshold changes
+- No new question text generation
+
+---
+
+## Next Steps (Separate Ticket Required — Codex GPT-5.4)
+
+1. Wire planner into symptom-check session loop after VET-1399, VET-1400, VET-1401Q, VET-1406Q are merged
+2. Replace stub registry with VET-1400's full question-card registry
+3. Integrate concern bucket scores into `modulePhasePriority` or as a separate scoring component
+4. Build admin UI for planner inspection
+5. Add clarification loop support with `allowClarification` option

--- a/src/lib/clinical-intelligence/next-question-planner.ts
+++ b/src/lib/clinical-intelligence/next-question-planner.ts
@@ -66,6 +66,9 @@ function shouldSkipDueToAnsweredDependencies(
   caseState: ClinicalCaseState
 ): boolean {
   for (const depKey of card.skipIfAnswered) {
+    if (caseState.answeredQuestionIds.includes(depKey)) {
+      return true;
+    }
     if (depKey in caseState.explicitAnswers) {
       return true;
     }

--- a/src/lib/clinical-intelligence/next-question-planner.ts
+++ b/src/lib/clinical-intelligence/next-question-planner.ts
@@ -119,7 +119,7 @@ export function getCandidateQuestionCards(
   caseState: ClinicalCaseState,
   options?: PlannerOptions
 ): ClinicalQuestionCard[] {
-  let cards = getAllQuestionCards();
+  let cards = [...getAllQuestionCards()];
 
   if (caseState.activeComplaintModule || options?.activeComplaintModule) {
     const activeModule = options?.activeComplaintModule ?? caseState.activeComplaintModule;

--- a/src/lib/clinical-intelligence/next-question-planner.ts
+++ b/src/lib/clinical-intelligence/next-question-planner.ts
@@ -1,0 +1,347 @@
+import type { ClinicalCaseState } from "./case-state";
+import type { ClinicalQuestionCard } from "./question-card-types";
+import { getAllQuestionCards } from "./question-card-registry";
+
+export type SelectedBecause =
+  | "emergency_screen"
+  | "highest_information_gain"
+  | "urgency_changing"
+  | "report_value"
+  | "clarification";
+
+export interface PlannedQuestion {
+  questionId: string;
+  ownerText: string;
+  shortReason: string;
+  score: number;
+  scoreBreakdown: Record<string, number>;
+  screenedRedFlags: string[];
+  selectedBecause: SelectedBecause;
+}
+
+export interface PlannerOptions {
+  allowClarification?: boolean;
+  activeComplaintModule?: string | null;
+  maxQuestionsPerTurn?: number;
+}
+
+export interface PlannerFallbackResult {
+  type: "emergency_handoff" | "no_valid_questions" | "clarification_needed";
+  reason: string;
+}
+
+const MODULE_PHASE_PRIORITY: Record<ClinicalQuestionCard["phase"], number> = {
+  emergency_screen: 30,
+  characterize: 15,
+  discriminate: 12,
+  timeline: 8,
+  history: 5,
+  handoff_detail: 3,
+};
+
+const REPETITION_PENALTY = 50;
+const ALREADY_KNOWN_PENALTY = 20;
+const OFF_TOPIC_PENALTY = 15;
+const TOO_MANY_QUESTIONS_PENALTY = 10;
+
+function isQuestionAlreadyAnswered(
+  card: ClinicalQuestionCard,
+  caseState: ClinicalCaseState
+): boolean {
+  if (caseState.answeredQuestionIds.includes(card.id)) {
+    return true;
+  }
+
+  for (const depKey of card.skipIfAnswered) {
+    if (depKey in caseState.explicitAnswers) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function shouldSkipDueToAnsweredDependencies(
+  card: ClinicalQuestionCard,
+  caseState: ClinicalCaseState
+): boolean {
+  for (const depKey of card.skipIfAnswered) {
+    if (depKey in caseState.explicitAnswers) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function getUnknownRedFlagsForCard(
+  card: ClinicalQuestionCard,
+  caseState: ClinicalCaseState
+): string[] {
+  return card.screensRedFlags.filter(
+    (flagId) =>
+      !caseState.redFlagStatus[flagId] ||
+      caseState.redFlagStatus[flagId].status === "unknown"
+  );
+}
+
+function hasPositiveRedFlagsForCard(
+  card: ClinicalQuestionCard,
+  caseState: ClinicalCaseState
+): boolean {
+  return card.screensRedFlags.some(
+    (flagId) => caseState.redFlagStatus[flagId]?.status === "positive"
+  );
+}
+
+export function filterAnsweredOrAskedQuestions(
+  cards: readonly ClinicalQuestionCard[],
+  caseState: ClinicalCaseState,
+  options?: { allowClarification?: boolean }
+): ClinicalQuestionCard[] {
+  return cards.filter((card) => {
+    const isAnswered = isQuestionAlreadyAnswered(card, caseState);
+    const isAsked = caseState.askedQuestionIds.includes(card.id);
+    const isSkipped = shouldSkipDueToAnsweredDependencies(card, caseState);
+
+    if (isAnswered || isSkipped) {
+      return false;
+    }
+
+    if (isAsked && !options?.allowClarification) {
+      return false;
+    }
+
+    return true;
+  });
+}
+
+export function getCandidateQuestionCards(
+  caseState: ClinicalCaseState,
+  options?: PlannerOptions
+): ClinicalQuestionCard[] {
+  let cards = getAllQuestionCards();
+
+  if (caseState.activeComplaintModule || options?.activeComplaintModule) {
+    const activeModule = options?.activeComplaintModule ?? caseState.activeComplaintModule;
+    if (activeModule) {
+      const moduleCards = cards.filter((c) =>
+        c.complaintFamilies.includes(activeModule)
+      );
+      const emergencyCards = cards.filter((c) =>
+        c.complaintFamilies.includes("emergency")
+      );
+      cards = [...emergencyCards, ...moduleCards.filter(
+        (c) => !c.complaintFamilies.includes("emergency")
+      )];
+    }
+  }
+
+  cards = filterAnsweredOrAskedQuestions(cards, caseState, {
+    allowClarification: options?.allowClarification,
+  });
+
+  return cards;
+}
+
+export function buildQuestionScoreBreakdown(
+  card: ClinicalQuestionCard,
+  caseState: ClinicalCaseState,
+  options?: PlannerOptions
+): Record<string, number> {
+  const breakdown: Record<string, number> = {};
+
+  const emergencyValue =
+    card.phase === "emergency_screen" ||
+    hasPositiveRedFlagsForCard(card, caseState)
+      ? 3
+      : card.screensRedFlags.length > 0 &&
+        getUnknownRedFlagsForCard(card, caseState).length > 0
+      ? 2
+      : 0;
+  breakdown["emergencyValue"] = emergencyValue * 5;
+
+  breakdown["urgencyImpact"] = card.urgencyImpact * 4;
+
+  breakdown["discriminativeValue"] = card.discriminativeValue * 3;
+
+  breakdown["reportValue"] = card.reportValue * 2;
+
+  breakdown["ownerAnswerability"] = card.ownerAnswerability * 2;
+
+  breakdown["modulePhasePriority"] = MODULE_PHASE_PRIORITY[card.phase] ?? 0;
+
+  const isAsked = caseState.askedQuestionIds.includes(card.id);
+  if (isAsked) {
+    breakdown["repetitionPenalty"] = -REPETITION_PENALTY;
+  } else {
+    breakdown["repetitionPenalty"] = 0;
+  }
+
+  if (shouldSkipDueToAnsweredDependencies(card, caseState)) {
+    breakdown["alreadyKnownPenalty"] = -ALREADY_KNOWN_PENALTY;
+  } else {
+    breakdown["alreadyKnownPenalty"] = 0;
+  }
+
+  const activeModule = options?.activeComplaintModule ?? caseState.activeComplaintModule;
+  if (
+    activeModule &&
+    !card.complaintFamilies.includes("emergency") &&
+    !card.complaintFamilies.includes(activeModule)
+  ) {
+    breakdown["offTopicPenalty"] = -OFF_TOPIC_PENALTY;
+  } else {
+    breakdown["offTopicPenalty"] = 0;
+  }
+
+  if (caseState.askedQuestionIds.length >= (options?.maxQuestionsPerTurn ?? 10)) {
+    breakdown["tooManyQuestionsPenalty"] = -TOO_MANY_QUESTIONS_PENALTY;
+  } else {
+    breakdown["tooManyQuestionsPenalty"] = 0;
+  }
+
+  return breakdown;
+}
+
+export function scoreQuestionCard(
+  card: ClinicalQuestionCard,
+  caseState: ClinicalCaseState,
+  options?: PlannerOptions
+): number {
+  const breakdown = buildQuestionScoreBreakdown(card, caseState, options);
+  return Object.values(breakdown).reduce((sum, val) => sum + val, 0);
+}
+
+function determineSelectedBecause(
+  card: ClinicalQuestionCard,
+  caseState: ClinicalCaseState,
+  breakdown: Record<string, number>
+): SelectedBecause {
+  if (card.phase === "emergency_screen") {
+    return "emergency_screen";
+  }
+
+  if (breakdown["urgencyImpact"] >= 8 && caseState.urgencyTrajectory === "worsening") {
+    return "urgency_changing";
+  }
+
+  if (breakdown["reportValue"] >= breakdown["discriminativeValue"] && breakdown["reportValue"] >= 4) {
+    return "report_value";
+  }
+
+  if (caseState.askedQuestionIds.includes(card.id)) {
+    return "clarification";
+  }
+
+  return "highest_information_gain";
+}
+
+export function selectHighestScoringQuestion(
+  scoredQuestions: Array<{
+    card: ClinicalQuestionCard;
+    score: number;
+    breakdown: Record<string, number>;
+  }>
+): {
+  card: ClinicalQuestionCard;
+  score: number;
+  breakdown: Record<string, number>;
+} | null {
+  if (scoredQuestions.length === 0) {
+    return null;
+  }
+
+  return scoredQuestions.reduce((best, current) =>
+    current.score > best.score ? current : best
+  );
+}
+
+export function fallbackToSafeEmergencyQuestion(
+  caseState: ClinicalCaseState
+): PlannedQuestion | PlannerFallbackResult {
+  const emergencyCards = getAllQuestionCards().filter(
+    (c) => c.phase === "emergency_screen"
+  );
+
+  const available = filterAnsweredOrAskedQuestions(emergencyCards, caseState, {
+    allowClarification: false,
+  });
+
+  if (available.length > 0) {
+    const card = available[0];
+    const breakdown = buildQuestionScoreBreakdown(card, caseState);
+    const score = Object.values(breakdown).reduce((sum, val) => sum + val, 0);
+
+    return {
+      questionId: card.id,
+      ownerText: card.ownerText,
+      shortReason: card.shortReason,
+      score,
+      scoreBreakdown: breakdown,
+      screenedRedFlags: card.screensRedFlags,
+      selectedBecause: "emergency_screen",
+    };
+  }
+
+  return {
+    type: "no_valid_questions",
+    reason: "No valid emergency questions available for triage",
+  };
+}
+
+export function planNextClinicalQuestion(
+  caseState: ClinicalCaseState,
+  options?: PlannerOptions
+): PlannedQuestion | PlannerFallbackResult {
+  if (caseState.currentUrgency === "emergency") {
+    const emergencyResult = fallbackToSafeEmergencyQuestion(caseState);
+    if ("type" in emergencyResult) {
+      return {
+        type: "emergency_handoff",
+        reason: "Current urgency is emergency — handoff to vet recommended",
+      };
+    }
+    return emergencyResult;
+  }
+
+  const candidates = getCandidateQuestionCards(caseState, options);
+
+  if (candidates.length === 0) {
+    return {
+      type: "no_valid_questions",
+      reason: "No valid candidate questions remaining",
+    };
+  }
+
+  const scored = candidates.map((card) => ({
+    card,
+    score: scoreQuestionCard(card, caseState, options),
+    breakdown: buildQuestionScoreBreakdown(card, caseState, options),
+  }));
+
+  const best = selectHighestScoringQuestion(scored);
+
+  if (!best) {
+    return {
+      type: "no_valid_questions",
+      reason: "No valid candidate questions remaining after scoring",
+    };
+  }
+
+  const unknownFlags = getUnknownRedFlagsForCard(best.card, caseState);
+  const selectedBecause = determineSelectedBecause(
+    best.card,
+    caseState,
+    best.breakdown
+  );
+
+  return {
+    questionId: best.card.id,
+    ownerText: best.card.ownerText,
+    shortReason: best.card.shortReason,
+    score: best.score,
+    scoreBreakdown: best.breakdown,
+    screenedRedFlags: unknownFlags,
+    selectedBecause,
+  };
+}

--- a/src/lib/clinical-intelligence/next-question-planner.ts
+++ b/src/lib/clinical-intelligence/next-question-planner.ts
@@ -53,6 +53,9 @@ function isQuestionAlreadyAnswered(
   }
 
   for (const depKey of card.skipIfAnswered) {
+    if (caseState.answeredQuestionIds.includes(depKey)) {
+      return true;
+    }
     if (depKey in caseState.explicitAnswers) {
       return true;
     }
@@ -81,9 +84,10 @@ function getUnknownRedFlagsForCard(
   caseState: ClinicalCaseState
 ): string[] {
   return card.screensRedFlags.filter(
-    (flagId) =>
-      !caseState.redFlagStatus[flagId] ||
-      caseState.redFlagStatus[flagId].status === "unknown"
+    (flagId) => {
+      const entry = caseState.redFlagStatus[flagId];
+      return !entry || entry.status === "unknown" || entry.status === "not_sure";
+    }
   );
 }
 
@@ -104,9 +108,10 @@ export function filterAnsweredOrAskedQuestions(
   return cards.filter((card) => {
     const isAnswered = isQuestionAlreadyAnswered(card, caseState);
     const isAsked = caseState.askedQuestionIds.includes(card.id);
-    const isSkipped = shouldSkipDueToAnsweredDependencies(card, caseState);
+    const isSkipped = caseState.skippedQuestionIds.includes(card.id);
+    const isSkippedDueToDeps = shouldSkipDueToAnsweredDependencies(card, caseState);
 
-    if (isAnswered || isSkipped) {
+    if (isAnswered || isSkipped || isSkippedDueToDeps) {
       return false;
     }
 
@@ -297,14 +302,10 @@ export function planNextClinicalQuestion(
   options?: PlannerOptions
 ): PlannedQuestion | PlannerFallbackResult {
   if (caseState.currentUrgency === "emergency") {
-    const emergencyResult = fallbackToSafeEmergencyQuestion(caseState);
-    if ("type" in emergencyResult) {
-      return {
-        type: "emergency_handoff",
-        reason: "Current urgency is emergency — handoff to vet recommended",
-      };
-    }
-    return emergencyResult;
+    return {
+      type: "emergency_handoff",
+      reason: "Current urgency is emergency — handoff to vet recommended",
+    };
   }
 
   const candidates = getCandidateQuestionCards(caseState, options);

--- a/src/lib/clinical-intelligence/next-question-planner.ts
+++ b/src/lib/clinical-intelligence/next-question-planner.ts
@@ -127,28 +127,11 @@ export function getCandidateQuestionCards(
   caseState: ClinicalCaseState,
   options?: PlannerOptions
 ): ClinicalQuestionCard[] {
-  let cards = [...getAllQuestionCards()];
+  const cards = [...getAllQuestionCards()];
 
-  if (caseState.activeComplaintModule || options?.activeComplaintModule) {
-    const activeModule = options?.activeComplaintModule ?? caseState.activeComplaintModule;
-    if (activeModule) {
-      const moduleCards = cards.filter((c) =>
-        c.complaintFamilies.includes(activeModule)
-      );
-      const emergencyCards = cards.filter((c) =>
-        c.complaintFamilies.includes("emergency")
-      );
-      cards = [...emergencyCards, ...moduleCards.filter(
-        (c) => !c.complaintFamilies.includes("emergency")
-      )];
-    }
-  }
-
-  cards = filterAnsweredOrAskedQuestions(cards, caseState, {
+  return filterAnsweredOrAskedQuestions(cards, caseState, {
     allowClarification: options?.allowClarification,
   });
-
-  return cards;
 }
 
 export function buildQuestionScoreBreakdown(

--- a/src/lib/clinical-intelligence/next-question-planner.ts
+++ b/src/lib/clinical-intelligence/next-question-planner.ts
@@ -267,6 +267,13 @@ export function selectHighestScoringQuestion(
 export function fallbackToSafeEmergencyQuestion(
   caseState: ClinicalCaseState
 ): PlannedQuestion | PlannerFallbackResult {
+  if (caseState.currentUrgency === "emergency") {
+    return {
+      type: "emergency_handoff",
+      reason: "Current urgency is emergency — handoff to vet recommended",
+    };
+  }
+
   const emergencyCards = getAllQuestionCards().filter(
     (c) => c.phase === "emergency_screen"
   );

--- a/src/lib/clinical-intelligence/next-question-planner.ts
+++ b/src/lib/clinical-intelligence/next-question-planner.ts
@@ -276,7 +276,7 @@ export function fallbackToSafeEmergencyQuestion(
       shortReason: card.shortReason,
       score,
       scoreBreakdown: breakdown,
-      screenedRedFlags: card.screensRedFlags,
+      screenedRedFlags: getUnknownRedFlagsForCard(card, caseState),
       selectedBecause: "emergency_screen",
     };
   }
@@ -315,10 +315,10 @@ export function planNextClinicalQuestion(
 
   const best = selectHighestScoringQuestion(scored);
 
-  if (!best) {
+  if (!best || best.score <= 0) {
     return {
       type: "no_valid_questions",
-      reason: "No valid candidate questions remaining after scoring",
+      reason: "No positive-value candidate questions remaining after scoring",
     };
   }
 

--- a/src/lib/clinical-intelligence/red-flag-status.ts
+++ b/src/lib/clinical-intelligence/red-flag-status.ts
@@ -58,12 +58,12 @@ export function resolveUnknownRedFlags(
 
   for (const id of redFlagIds) {
     const existing = newState.redFlagStatus[id];
-    if (existing && existing.status === "unknown") {
+    if (!existing || existing.status === "unknown") {
       newState.redFlagStatus[id] = {
-        ...existing,
         status,
         source: "explicit_answer",
         updatedAtTurn: turn,
+        evidenceText: existing?.evidenceText,
       };
     }
   }

--- a/tests/clinical-intelligence/next-question-planner.test.ts
+++ b/tests/clinical-intelligence/next-question-planner.test.ts
@@ -7,6 +7,7 @@ import {
   updateRedFlagStatus,
   recordAnsweredQuestion,
   recordAskedQuestion,
+  recordSkippedQuestion,
 } from "@/lib/clinical-intelligence/case-state-update";
 
 import {
@@ -251,6 +252,21 @@ describe("Already-known skipIfAnswered values reduce score", () => {
 
     expect(breakdown["alreadyKnownPenalty"]).toBeLessThan(0);
   });
+
+  it("penalizes cards where skipIfAnswered is an answered question ID", () => {
+    let state = makeState();
+    state = recordAnsweredQuestion(state, "emergency_global_screen", "breathing_difficulty", "no");
+
+    const dependentCard: ClinicalQuestionCard = {
+      ...MOCK_SKIN_CARD,
+      id: "skin_followup_after_emergency",
+      skipIfAnswered: ["emergency_global_screen"],
+    };
+
+    const breakdown = buildQuestionScoreBreakdown(dependentCard, state);
+
+    expect(breakdown["alreadyKnownPenalty"]).toBeLessThan(0);
+  });
 });
 
 describe("Highest scoring question is selected", () => {
@@ -453,11 +469,38 @@ describe("filterAnsweredOrAskedQuestions", () => {
     expect(filtered.some((c) => c.id === "emergency_global_screen")).toBe(false);
   });
 
+  it("filters out cards whose skipIfAnswered dependency is an answered question ID", () => {
+    let state = makeState();
+    state = recordAnsweredQuestion(state, "emergency_global_screen", "breathing_difficulty", "no");
+
+    const dependentCard: ClinicalQuestionCard = {
+      ...MOCK_SKIN_CARD,
+      id: "skin_followup_after_emergency",
+      skipIfAnswered: ["emergency_global_screen"],
+    };
+
+    const filtered = filterAnsweredOrAskedQuestions([dependentCard], state);
+
+    expect(filtered).toHaveLength(0);
+  });
+
   it("filters out asked cards by default", () => {
     let state = makeState();
     state = recordAskedQuestion(state, "emergency_global_screen");
 
     const filtered = filterAnsweredOrAskedQuestions(MOCK_CARDS, state);
+
+    expect(filtered.some((c) => c.id === "emergency_global_screen")).toBe(false);
+  });
+
+  it("filters out skipped cards even when clarification repeats are allowed", () => {
+    let state = makeState();
+    state = recordSkippedQuestion(state, "emergency_global_screen");
+    state = recordAskedQuestion(state, "emergency_global_screen");
+
+    const filtered = filterAnsweredOrAskedQuestions(MOCK_CARDS, state, {
+      allowClarification: true,
+    });
 
     expect(filtered.some((c) => c.id === "emergency_global_screen")).toBe(false);
   });
@@ -471,6 +514,28 @@ describe("filterAnsweredOrAskedQuestions", () => {
     });
 
     expect(filtered.some((c) => c.id === "emergency_global_screen")).toBe(true);
+  });
+});
+
+describe("Question score red-flag uncertainty", () => {
+  it("treats not_sure red flags as unresolved for emergency value", () => {
+    let state = makeState();
+    state = updateRedFlagStatus(state, "blue_gums", {
+      status: "not_sure",
+      source: "explicit_answer",
+      turn: 1,
+    });
+
+    const redFlagCard: ClinicalQuestionCard = {
+      ...MOCK_SKIN_CARD,
+      id: "blue_gums_followup",
+      phase: "characterize",
+      screensRedFlags: ["blue_gums"],
+    };
+
+    const breakdown = buildQuestionScoreBreakdown(redFlagCard, state);
+
+    expect(breakdown["emergencyValue"]).toBeGreaterThan(0);
   });
 });
 

--- a/tests/clinical-intelligence/next-question-planner.test.ts
+++ b/tests/clinical-intelligence/next-question-planner.test.ts
@@ -404,6 +404,51 @@ describe("Fallback works when no candidate cards are valid", () => {
       expect(card?.phase).toBe("emergency_screen");
     }
   });
+
+  it("fallbackToSafeEmergencyQuestion returns only unresolved screened red flags", () => {
+    let state = makeState();
+    state = updateRedFlagStatus(state, "blue_gums", {
+      status: "negative",
+      source: "explicit_answer",
+      turn: 1,
+    });
+
+    const result = fallbackToSafeEmergencyQuestion(state);
+
+    expect("type" in result).toBe(false);
+    const planned = result as PlannedQuestion;
+    expect(planned.screenedRedFlags).not.toContain("blue_gums");
+    expect(planned.screenedRedFlags).toEqual(
+      expect.arrayContaining(["breathing_difficulty", "stridor_present"])
+    );
+  });
+});
+
+describe("Planner rejects non-positive candidates", () => {
+  it("returns no_valid_questions when penalties leave no positive-value candidate", () => {
+    const lowValueCard: ClinicalQuestionCard = {
+      ...MOCK_REPORT_CARD,
+      id: "low_value_general_followup",
+      complaintFamilies: ["general"],
+      phase: "handoff_detail",
+      ownerAnswerability: 0,
+      urgencyImpact: 0,
+      discriminativeValue: 0,
+      reportValue: 0,
+      skipIfAnswered: [],
+    };
+    jest.spyOn(registry, "getAllQuestionCards").mockReturnValueOnce([lowValueCard]);
+
+    const state = createInitialClinicalCaseState("skin");
+
+    const result = planNextClinicalQuestion(state, { maxQuestionsPerTurn: 0 });
+
+    expect(result).toHaveProperty("type", "no_valid_questions");
+    expect(result).toHaveProperty(
+      "reason",
+      "No positive-value candidate questions remaining after scoring"
+    );
+  });
 });
 
 describe("Does not generate new question text", () => {

--- a/tests/clinical-intelligence/next-question-planner.test.ts
+++ b/tests/clinical-intelligence/next-question-planner.test.ts
@@ -553,15 +553,13 @@ describe("Question score red-flag uncertainty", () => {
 });
 
 describe("getCandidateQuestionCards", () => {
-  it("returns cards filtered by active complaint module", () => {
+  it("returns all valid cards, not only module-matching ones", () => {
     const state = createInitialClinicalCaseState("gi");
 
     const candidates = getCandidateQuestionCards(state);
 
-    const hasEmergency = candidates.some((c) => c.complaintFamilies.includes("emergency"));
-    const hasGi = candidates.some((c) => c.complaintFamilies.includes("gi"));
-
-    expect(hasEmergency || hasGi).toBe(true);
+    const hasSkin = candidates.some((c) => c.complaintFamilies.includes("skin"));
+    expect(hasSkin).toBe(true);
   });
 
   it("excludes answered and asked cards", () => {
@@ -573,5 +571,36 @@ describe("getCandidateQuestionCards", () => {
 
     expect(candidates.some((c) => c.id === "emergency_global_screen")).toBe(false);
     expect(candidates.some((c) => c.id === "gum_color_check")).toBe(false);
+  });
+});
+
+describe("Off-topic fallback when module cards exhausted", () => {
+  it("returns a non-module card when all module cards are answered", () => {
+    let state = createInitialClinicalCaseState("skin");
+
+    state = recordAnsweredQuestion(state, "skin_location_distribution", "skin_location", "abdomen");
+
+    const result = planNextClinicalQuestion(state);
+
+    expect("type" in result).toBe(false);
+    const planned = result as PlannedQuestion;
+    expect(planned.questionId).not.toBe("skin_location_distribution");
+  });
+
+  it("includes offTopicPenalty in scoreBreakdown for non-module cards", () => {
+    const state = createInitialClinicalCaseState("gi");
+
+    const breakdown = buildQuestionScoreBreakdown(MOCK_SKIN_CARD, state);
+
+    expect(breakdown["offTopicPenalty"]).toBeLessThan(0);
+  });
+
+  it("module cards outrank off-topic cards when both are available", () => {
+    const state = createInitialClinicalCaseState("gi");
+
+    const giScore = scoreQuestionCard(MOCK_GI_CARD, state);
+    const skinScore = scoreQuestionCard(MOCK_SKIN_CARD, state);
+
+    expect(giScore).toBeGreaterThan(skinScore);
   });
 });

--- a/tests/clinical-intelligence/next-question-planner.test.ts
+++ b/tests/clinical-intelligence/next-question-planner.test.ts
@@ -575,24 +575,57 @@ describe("getCandidateQuestionCards", () => {
 });
 
 describe("Off-topic fallback when module cards exhausted", () => {
-  it("returns a non-module card when all module cards are answered", () => {
+  it("returns a non-module fallback card when all module cards are answered (not no_valid_questions)", () => {
     let state = createInitialClinicalCaseState("skin");
 
-    state = recordAnsweredQuestion(state, "skin_location_distribution", "skin_location", "abdomen");
+    for (const card of MOCK_CARDS) {
+      if (card.complaintFamilies.includes("skin")) {
+        state = recordAnsweredQuestion(state, card.id, card.skipIfAnswered[0] || "answered", "yes");
+      }
+    }
 
     const result = planNextClinicalQuestion(state);
 
     expect("type" in result).toBe(false);
     const planned = result as PlannedQuestion;
-    expect(planned.questionId).not.toBe("skin_location_distribution");
+    const selectedCard = MOCK_CARDS.find((c) => c.id === planned.questionId);
+    expect(selectedCard).toBeDefined();
+    expect(selectedCard!.complaintFamilies.includes("skin")).toBe(false);
   });
 
-  it("includes offTopicPenalty in scoreBreakdown for non-module cards", () => {
-    const state = createInitialClinicalCaseState("gi");
+  it("returns a valid fallback even when module AND emergency cards are exhausted", () => {
+    let state = createInitialClinicalCaseState("skin");
 
-    const breakdown = buildQuestionScoreBreakdown(MOCK_SKIN_CARD, state);
+    for (const card of MOCK_CARDS) {
+      if (card.complaintFamilies.includes("skin") || card.complaintFamilies.includes("emergency")) {
+        state = recordAnsweredQuestion(state, card.id, card.skipIfAnswered[0] || "answered", "yes");
+      }
+    }
 
-    expect(breakdown["offTopicPenalty"]).toBeLessThan(0);
+    const result = planNextClinicalQuestion(state);
+
+    expect("type" in result).toBe(false);
+    const planned = result as PlannedQuestion;
+    const selectedCard = MOCK_CARDS.find((c) => c.id === planned.questionId);
+    expect(selectedCard).toBeDefined();
+    expect(selectedCard!.complaintFamilies.includes("skin")).toBe(false);
+    expect(selectedCard!.complaintFamilies.includes("emergency")).toBe(false);
+  });
+
+  it("includes offTopicPenalty in scoreBreakdown for non-module fallback cards", () => {
+    let state = createInitialClinicalCaseState("skin");
+
+    for (const card of MOCK_CARDS) {
+      if (card.complaintFamilies.includes("skin") || card.complaintFamilies.includes("emergency")) {
+        state = recordAnsweredQuestion(state, card.id, card.skipIfAnswered[0] || "answered", "yes");
+      }
+    }
+
+    const result = planNextClinicalQuestion(state);
+
+    expect("type" in result).toBe(false);
+    const planned = result as PlannedQuestion;
+    expect(planned.scoreBreakdown["offTopicPenalty"]).toBeLessThan(0);
   });
 
   it("module cards outrank off-topic cards when both are available", () => {
@@ -602,5 +635,25 @@ describe("Off-topic fallback when module cards exhausted", () => {
     const skinScore = scoreQuestionCard(MOCK_SKIN_CARD, state);
 
     expect(giScore).toBeGreaterThan(skinScore);
+  });
+
+  it("emergency-screen cards still outrank module-matching cards", () => {
+    const state = createInitialClinicalCaseState("gi");
+
+    const emergencyScore = scoreQuestionCard(MOCK_EMERGENCY_CARD, state);
+    const giScore = scoreQuestionCard(MOCK_GI_CARD, state);
+
+    expect(emergencyScore).toBeGreaterThan(giScore);
+  });
+
+  it("planner selects emergency card over module card when both are candidates", () => {
+    const state = createInitialClinicalCaseState("skin");
+
+    const result = planNextClinicalQuestion(state);
+
+    expect("type" in result).toBe(false);
+    const planned = result as PlannedQuestion;
+    const selectedCard = MOCK_CARDS.find((c) => c.id === planned.questionId);
+    expect(selectedCard!.phase).toBe("emergency_screen");
   });
 });

--- a/tests/clinical-intelligence/next-question-planner.test.ts
+++ b/tests/clinical-intelligence/next-question-planner.test.ts
@@ -363,6 +363,19 @@ describe("Current emergency urgency does not produce routine questions", () => {
       expect(card?.phase).toBe("emergency_screen");
     }
   });
+
+  it("fallback helper returns emergency_handoff when urgency is already emergency", () => {
+    let state = makeState();
+    state = updateRedFlagStatus(state, "blue_gums", {
+      status: "positive",
+      source: "explicit_answer",
+      turn: 1,
+    });
+
+    const result = fallbackToSafeEmergencyQuestion(state);
+
+    expect(result).toHaveProperty("type", "emergency_handoff");
+  });
 });
 
 describe("Fallback works when no candidate cards are valid", () => {

--- a/tests/clinical-intelligence/next-question-planner.test.ts
+++ b/tests/clinical-intelligence/next-question-planner.test.ts
@@ -1,0 +1,499 @@
+import {
+  createInitialClinicalCaseState,
+  type ClinicalCaseState,
+} from "@/lib/clinical-intelligence/case-state";
+import type { ClinicalQuestionCard } from "@/lib/clinical-intelligence/question-card-types";
+import {
+  updateRedFlagStatus,
+  recordAnsweredQuestion,
+  recordAskedQuestion,
+} from "@/lib/clinical-intelligence/case-state-update";
+
+import {
+  planNextClinicalQuestion,
+  scoreQuestionCard,
+  getCandidateQuestionCards,
+  filterAnsweredOrAskedQuestions,
+  buildQuestionScoreBreakdown,
+  selectHighestScoringQuestion,
+  fallbackToSafeEmergencyQuestion,
+  type PlannedQuestion,
+} from "@/lib/clinical-intelligence/next-question-planner";
+
+import * as registry from "@/lib/clinical-intelligence/question-card-registry";
+
+const MOCK_EMERGENCY_CARD: ClinicalQuestionCard = {
+  id: "emergency_global_screen",
+  ownerText: "Is your dog having any difficulty breathing right now?",
+  shortReason: "Screen for airway emergency",
+  complaintFamilies: ["emergency"],
+  bodySystems: ["respiratory"],
+  phase: "emergency_screen",
+  ownerAnswerability: 2,
+  urgencyImpact: 3,
+  discriminativeValue: 3,
+  reportValue: 2,
+  screensRedFlags: ["blue_gums", "breathing_difficulty", "stridor_present"],
+  changesUrgencyIf: {},
+  answerType: "boolean",
+  skipIfAnswered: ["breathing_difficulty"],
+  sourceIds: ["merck_vet_manual"],
+};
+
+const MOCK_GUM_CARD: ClinicalQuestionCard = {
+  id: "gum_color_check",
+  ownerText: "What color are your dog's gums?",
+  shortReason: "Assess circulation via gum color",
+  complaintFamilies: ["emergency"],
+  bodySystems: ["circulatory"],
+  phase: "emergency_screen",
+  ownerAnswerability: 3,
+  urgencyImpact: 3,
+  discriminativeValue: 2,
+  reportValue: 2,
+  screensRedFlags: ["blue_gums", "pale_gums"],
+  changesUrgencyIf: {},
+  answerType: "choice",
+  allowedAnswers: ["pink", "blue", "pale_white", "yellow"],
+  skipIfAnswered: ["gum_color"],
+  sourceIds: ["merck_vet_manual"],
+};
+
+const MOCK_SKIN_CARD: ClinicalQuestionCard = {
+  id: "skin_location_distribution",
+  ownerText: "Where on your dog's body do you notice the skin issue?",
+  shortReason: "Characterize skin problem location",
+  complaintFamilies: ["skin"],
+  bodySystems: ["integumentary"],
+  phase: "characterize",
+  ownerAnswerability: 3,
+  urgencyImpact: 0,
+  discriminativeValue: 2,
+  reportValue: 1,
+  screensRedFlags: [],
+  changesUrgencyIf: {},
+  answerType: "choice",
+  skipIfAnswered: ["skin_location"],
+  sourceIds: ["dermatology_guide"],
+};
+
+const MOCK_GI_CARD: ClinicalQuestionCard = {
+  id: "gi_vomiting_frequency",
+  ownerText: "How many times has your dog vomited today?",
+  shortReason: "Assess GI severity via vomiting frequency",
+  complaintFamilies: ["gi"],
+  bodySystems: ["gastrointestinal"],
+  phase: "characterize",
+  ownerAnswerability: 3,
+  urgencyImpact: 1,
+  discriminativeValue: 2,
+  reportValue: 2,
+  screensRedFlags: [],
+  changesUrgencyIf: {},
+  answerType: "number",
+  skipIfAnswered: ["vomiting_frequency"],
+  sourceIds: ["gi_triage_guide"],
+};
+
+const MOCK_BLOAT_CARD: ClinicalQuestionCard = {
+  id: "bloat_retching_abdomen_check",
+  ownerText: "Has your dog been trying to vomit but nothing comes up?",
+  shortReason: "Screen for GDV/bloat emergency",
+  complaintFamilies: ["emergency", "gi"],
+  bodySystems: ["gastrointestinal"],
+  phase: "emergency_screen",
+  ownerAnswerability: 2,
+  urgencyImpact: 3,
+  discriminativeValue: 3,
+  reportValue: 3,
+  screensRedFlags: ["unproductive_retching", "rapid_onset_distension"],
+  changesUrgencyIf: {},
+  answerType: "boolean",
+  skipIfAnswered: ["unproductive_retching"],
+  sourceIds: ["merck_vet_manual"],
+};
+
+const MOCK_REPORT_CARD: ClinicalQuestionCard = {
+  id: "timeline_onset",
+  ownerText: "When did you first notice these symptoms?",
+  shortReason: "Establish symptom timeline for report",
+  complaintFamilies: ["general"],
+  bodySystems: ["general"],
+  phase: "timeline",
+  ownerAnswerability: 3,
+  urgencyImpact: 0,
+  discriminativeValue: 1,
+  reportValue: 3,
+  screensRedFlags: [],
+  changesUrgencyIf: {},
+  answerType: "choice",
+  skipIfAnswered: ["symptom_onset"],
+  sourceIds: ["triage_protocol"],
+};
+
+const MOCK_CARDS: ClinicalQuestionCard[] = [
+  MOCK_EMERGENCY_CARD,
+  MOCK_GUM_CARD,
+  MOCK_SKIN_CARD,
+  MOCK_GI_CARD,
+  MOCK_BLOAT_CARD,
+  MOCK_REPORT_CARD,
+];
+
+jest.spyOn(registry, "getAllQuestionCards").mockReturnValue(MOCK_CARDS);
+jest.spyOn(registry, "getQuestionCardById").mockImplementation((id) =>
+  MOCK_CARDS.find((c) => c.id === id)
+);
+jest.spyOn(registry, "getQuestionCardsByComplaintFamily").mockImplementation((family) =>
+  MOCK_CARDS.filter((c) => c.complaintFamilies.includes(family))
+);
+jest.spyOn(registry, "getQuestionCardsByPhase").mockImplementation((phase) =>
+  MOCK_CARDS.filter((c) => c.phase === phase)
+);
+
+function makeState(): ClinicalCaseState {
+  return createInitialClinicalCaseState();
+}
+
+describe("Planner returns PlannedQuestion shape", () => {
+  it("returns a valid PlannedQuestion object", () => {
+    const state = makeState();
+
+    const result = planNextClinicalQuestion(state);
+
+    expect(result).not.toHaveProperty("type");
+    const planned = result as PlannedQuestion;
+    expect(planned.questionId).toBeDefined();
+    expect(planned.ownerText).toBeDefined();
+    expect(planned.shortReason).toBeDefined();
+    expect(typeof planned.score).toBe("number");
+    expect(planned.scoreBreakdown).toBeDefined();
+    expect(Array.isArray(planned.screenedRedFlags)).toBe(true);
+    expect(["emergency_screen", "highest_information_gain", "urgency_changing", "report_value", "clarification"]).toContain(planned.selectedBecause);
+  });
+});
+
+describe("Planner never repeats an answered question", () => {
+  it("does not return an already answered question", () => {
+    let state = makeState();
+    state = recordAnsweredQuestion(state, "emergency_global_screen", "breathing_difficulty", "no");
+
+    const result = planNextClinicalQuestion(state);
+
+    if ("type" in result) {
+      return;
+    }
+    expect(result.questionId).not.toBe("emergency_global_screen");
+  });
+});
+
+describe("Planner never repeats an asked question", () => {
+  it("does not return an already asked question", () => {
+    let state = makeState();
+    state = recordAskedQuestion(state, "emergency_global_screen");
+
+    const result = planNextClinicalQuestion(state);
+
+    if ("type" in result) {
+      return;
+    }
+    expect(result.questionId).not.toBe("emergency_global_screen");
+  });
+});
+
+describe("Emergency-screen cards outrank routine characterization", () => {
+  it("emergency cards score higher than routine cards", () => {
+    const state = makeState();
+
+    const emergencyScore = scoreQuestionCard(MOCK_EMERGENCY_CARD, state);
+    const skinScore = scoreQuestionCard(MOCK_SKIN_CARD, state);
+
+    expect(emergencyScore).toBeGreaterThan(skinScore);
+  });
+
+  it("planner selects emergency card over routine card", () => {
+    const state = makeState();
+
+    const result = planNextClinicalQuestion(state);
+
+    if ("type" in result) {
+      return;
+    }
+    const isEmergency = MOCK_CARDS.filter((c) => c.phase === "emergency_screen").some(
+      (c) => c.id === result.questionId
+    );
+    expect(isEmergency).toBe(true);
+  });
+});
+
+describe("Unknown emergency red flags increase emergency question score", () => {
+  it("unknown red flags boost emergency card score", () => {
+    let state = makeState();
+    state = updateRedFlagStatus(state, "blue_gums", {
+      status: "unknown",
+      source: "unset",
+      turn: 0,
+    });
+
+    const baseScore = scoreQuestionCard(MOCK_EMERGENCY_CARD, makeState());
+    const unknownScore = scoreQuestionCard(MOCK_EMERGENCY_CARD, state);
+
+    expect(unknownScore).toBeGreaterThanOrEqual(baseScore);
+  });
+});
+
+describe("Already-known skipIfAnswered values reduce score", () => {
+  it("penalizes cards where skipIfAnswered is in explicitAnswers", () => {
+    let state = makeState();
+    state = recordAnsweredQuestion(state, "q1", "breathing_difficulty", "no");
+
+    const breakdown = buildQuestionScoreBreakdown(MOCK_EMERGENCY_CARD, state);
+
+    expect(breakdown["alreadyKnownPenalty"]).toBeLessThan(0);
+  });
+});
+
+describe("Highest scoring question is selected", () => {
+  it("selectHighestScoringQuestion returns the highest score", () => {
+    const scored = [
+      { card: MOCK_SKIN_CARD, score: 20, breakdown: {} },
+      { card: MOCK_EMERGENCY_CARD, score: 50, breakdown: {} },
+      { card: MOCK_GI_CARD, score: 35, breakdown: {} },
+    ];
+
+    const best = selectHighestScoringQuestion(scored);
+
+    expect(best).toBeDefined();
+    expect(best!.card.id).toBe("emergency_global_screen");
+    expect(best!.score).toBe(50);
+  });
+
+  it("returns null for empty array", () => {
+    expect(selectHighestScoringQuestion([])).toBeNull();
+  });
+});
+
+describe("Score breakdown includes all formula parts", () => {
+  it("breakdown contains all expected keys", () => {
+    const state = makeState();
+    const breakdown = buildQuestionScoreBreakdown(MOCK_EMERGENCY_CARD, state);
+
+    expect(breakdown).toHaveProperty("emergencyValue");
+    expect(breakdown).toHaveProperty("urgencyImpact");
+    expect(breakdown).toHaveProperty("discriminativeValue");
+    expect(breakdown).toHaveProperty("reportValue");
+    expect(breakdown).toHaveProperty("ownerAnswerability");
+    expect(breakdown).toHaveProperty("modulePhasePriority");
+    expect(breakdown).toHaveProperty("repetitionPenalty");
+    expect(breakdown).toHaveProperty("alreadyKnownPenalty");
+    expect(breakdown).toHaveProperty("offTopicPenalty");
+    expect(breakdown).toHaveProperty("tooManyQuestionsPenalty");
+  });
+
+  it("score equals sum of breakdown values", () => {
+    const state = makeState();
+    const breakdown = buildQuestionScoreBreakdown(MOCK_EMERGENCY_CARD, state);
+    const score = scoreQuestionCard(MOCK_EMERGENCY_CARD, state);
+    const sum = Object.values(breakdown).reduce((s, v) => s + v, 0);
+
+    expect(score).toBe(sum);
+  });
+});
+
+describe("selectedBecause is emergency_screen for emergency cards", () => {
+  it("emergency cards get emergency_screen selectedBecause", () => {
+    const state = makeState();
+    const result = planNextClinicalQuestion(state);
+
+    if ("type" in result) {
+      return;
+    }
+    const emergencyCards = MOCK_CARDS.filter((c) => c.phase === "emergency_screen");
+    const isEmergency = emergencyCards.some((c) => c.id === result.questionId);
+
+    if (isEmergency) {
+      expect(result.selectedBecause).toBe("emergency_screen");
+    }
+  });
+});
+
+describe("selectedBecause is report_value when reportValue dominates", () => {
+  it("report_value selectedBecause when reportValue is highest", () => {
+    const state = makeState();
+    const breakdown = buildQuestionScoreBreakdown(MOCK_REPORT_CARD, state);
+
+    expect(breakdown["reportValue"]).toBe(6);
+    expect(breakdown["reportValue"]).toBeGreaterThanOrEqual(breakdown["discriminativeValue"]);
+  });
+});
+
+describe("Current emergency urgency does not produce routine questions", () => {
+  it("returns emergency_handoff when urgency is emergency", () => {
+    let state = makeState();
+    state = updateRedFlagStatus(state, "blue_gums", {
+      status: "positive",
+      source: "explicit_answer",
+      turn: 1,
+    });
+
+    expect(state.currentUrgency).toBe("emergency");
+
+    const result = planNextClinicalQuestion(state);
+
+    if ("type" in result) {
+      expect(result.type).toBe("emergency_handoff");
+    } else {
+      const card = MOCK_CARDS.find((c) => c.id === result.questionId);
+      expect(card?.phase).toBe("emergency_screen");
+    }
+  });
+});
+
+describe("Fallback works when no candidate cards are valid", () => {
+  it("returns fallback when all cards are answered", () => {
+    let state = makeState();
+    for (const card of MOCK_CARDS) {
+      state = recordAnsweredQuestion(state, card.id, card.skipIfAnswered[0] || "answered", "yes");
+    }
+
+    const result = planNextClinicalQuestion(state);
+
+    if ("type" in result) {
+      expect(result.type).toBe("no_valid_questions");
+    }
+  });
+
+  it("fallbackToSafeEmergencyQuestion returns emergency card or fallback", () => {
+    const state = makeState();
+
+    const result = fallbackToSafeEmergencyQuestion(state);
+
+    if ("type" in result) {
+      expect(result.type).toBeDefined();
+    } else {
+      const card = MOCK_CARDS.find((c) => c.id === result.questionId);
+      expect(card?.phase).toBe("emergency_screen");
+    }
+  });
+});
+
+describe("Does not generate new question text", () => {
+  it("ownerText comes from question card only", () => {
+    const state = makeState();
+    const result = planNextClinicalQuestion(state);
+
+    if ("type" in result) {
+      return;
+    }
+    const card = MOCK_CARDS.find((c) => c.id === result.questionId);
+    expect(result.ownerText).toBe(card?.ownerText);
+  });
+
+  it("shortReason comes from question card only", () => {
+    const state = makeState();
+    const result = planNextClinicalQuestion(state);
+
+    if ("type" in result) {
+      return;
+    }
+    const card = MOCK_CARDS.find((c) => c.id === result.questionId);
+    expect(result.shortReason).toBe(card?.shortReason);
+  });
+});
+
+describe("Does not expose bucket labels", () => {
+  it("PlannedQuestion has no bucket label fields", () => {
+    const state = makeState();
+    const result = planNextClinicalQuestion(state);
+
+    if ("type" in result) {
+      return;
+    }
+    expect(result).not.toHaveProperty("bucketId");
+    expect(result).not.toHaveProperty("bucketLabel");
+    expect(result).not.toHaveProperty("concernBucket");
+  });
+});
+
+describe("No diagnosis/treatment language in planned output", () => {
+  it("ownerText contains no diagnosis/treatment claims", () => {
+    const forbiddenWords = [
+      "diagnose",
+      "diagnosis",
+      "treat",
+      "treatment",
+      "cure",
+      "medication",
+      "prescription",
+      "antibiotic",
+      "steroid",
+      "surgery",
+    ];
+
+    const state = makeState();
+    const result = planNextClinicalQuestion(state);
+
+    if ("type" in result) {
+      return;
+    }
+    const combinedText = `${result.ownerText} ${result.shortReason}`.toLowerCase();
+    for (const word of forbiddenWords) {
+      expect(combinedText).not.toContain(word.toLowerCase());
+    }
+  });
+});
+
+describe("filterAnsweredOrAskedQuestions", () => {
+  it("filters out answered cards", () => {
+    let state = makeState();
+    state = recordAnsweredQuestion(state, "emergency_global_screen", "breathing_difficulty", "no");
+
+    const filtered = filterAnsweredOrAskedQuestions(MOCK_CARDS, state);
+
+    expect(filtered.some((c) => c.id === "emergency_global_screen")).toBe(false);
+  });
+
+  it("filters out asked cards by default", () => {
+    let state = makeState();
+    state = recordAskedQuestion(state, "emergency_global_screen");
+
+    const filtered = filterAnsweredOrAskedQuestions(MOCK_CARDS, state);
+
+    expect(filtered.some((c) => c.id === "emergency_global_screen")).toBe(false);
+  });
+
+  it("includes asked cards when allowClarification is true", () => {
+    let state = makeState();
+    state = recordAskedQuestion(state, "emergency_global_screen");
+
+    const filtered = filterAnsweredOrAskedQuestions(MOCK_CARDS, state, {
+      allowClarification: true,
+    });
+
+    expect(filtered.some((c) => c.id === "emergency_global_screen")).toBe(true);
+  });
+});
+
+describe("getCandidateQuestionCards", () => {
+  it("returns cards filtered by active complaint module", () => {
+    const state = createInitialClinicalCaseState("gi");
+
+    const candidates = getCandidateQuestionCards(state);
+
+    const hasEmergency = candidates.some((c) => c.complaintFamilies.includes("emergency"));
+    const hasGi = candidates.some((c) => c.complaintFamilies.includes("gi"));
+
+    expect(hasEmergency || hasGi).toBe(true);
+  });
+
+  it("excludes answered and asked cards", () => {
+    let state = makeState();
+    state = recordAnsweredQuestion(state, "emergency_global_screen", "breathing_difficulty", "no");
+    state = recordAskedQuestion(state, "gum_color_check");
+
+    const candidates = getCandidateQuestionCards(state);
+
+    expect(candidates.some((c) => c.id === "emergency_global_screen")).toBe(false);
+    expect(candidates.some((c) => c.id === "gum_color_check")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add deterministic next-best-question planner that selects from question-card registry using case state, concern buckets, emergency value, urgency impact, owner answerability, report value, and repetition penalties
- Scoring formula: emergencyValue*5 + urgencyImpact*4 + discriminativeValue*3 + reportValue*2 + ownerAnswerability*2 + modulePhasePriority - penalties
- Safety: never returns answered/asked questions, emergency urgency returns handoff sentinel, no diagnosis/treatment text, no bucket label exposure
- 25 passing unit tests

## Scope
- Pure TypeScript utilities + tests
- Not wired into production flow
- Depends on VET-1401Q (ClinicalCaseState), VET-1400 (question-card registry)

## Merge order
VET-1400 → VET-1401Q → VET-1406Q → **VET-1407Q** → VET-1403K → VET-1404K