### PR TITLE
VET-1399: Question Intelligence Baseline Eval and Safety Contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ next-env.d.ts
 !/scripts/hooks/*.mjs
 !/scripts/build.js
 !/scripts/fix-readlink.js
+!/scripts/eval-question-quality.ts
 !/scripts/load-phase5-shadow.mjs
 !/scripts/reindex-live-corpus.mjs
 !/scripts/retrieval-quality-harness.mjs

--- a/docs/clinical-intelligence-safety-contract.md
+++ b/docs/clinical-intelligence-safety-contract.md
@@ -1,0 +1,42 @@
+# Clinical Intelligence Safety Contract
+
+## Purpose
+
+This contract defines the non-negotiable safety boundaries for PawVital's question intelligence work.
+VET-1399 is measurement only. It establishes a baseline for follow-up question quality without changing production behavior.
+
+## Product Boundary
+
+- PawVital provides urgency guidance and vet handoff support only.
+- PawVital does not diagnose.
+- PawVital does not prescribe treatment.
+- PawVital does not replace a veterinarian.
+
+## Emergency Handling Rules
+
+- Emergency guidance must not be blocked by auth.
+- Emergency guidance must not be blocked by payment.
+- Emergency guidance must not be blocked by usage limits.
+- Emergency guidance must not be blocked by model failure.
+- Emergency guidance must not be blocked by report failure.
+- Emergency guidance must not be blocked by RAG failure.
+- No model, RAG result, or planner may downgrade deterministic emergency signals.
+- Deterministic emergency signals remain the source of truth for emergency escalation.
+
+## Reasoning and UX Rules
+
+- No raw chain-of-thought should be shown to users.
+- User-facing reasoning should be a short clinical rationale only.
+- Internal scoring, critique, and planning artifacts are measurement inputs, not user-facing output.
+
+## Measurement Scope For VET-1399
+
+- The question-quality eval harness may inspect the current deterministic question-selection path.
+- The harness may score question quality, safety coverage, repetition behavior, and report usefulness.
+- The harness may recommend future complaint modules based on baseline weaknesses.
+- The harness must not change production question ordering, model behavior, RAG behavior, auth behavior, payment behavior, usage limits, or emergency routing.
+
+## Change Control
+
+- Any future intelligence work must preserve these rules before it can move from baseline measurement into production behavior.
+- Any future change that touches deterministic emergency logic must be validated against the existing dangerous benchmark and release gate suites before rollout.

--- a/docs/question-quality-rubric.md
+++ b/docs/question-quality-rubric.md
@@ -1,0 +1,111 @@
+# Question Quality Rubric
+
+## Purpose
+
+This rubric defines how `scripts/eval-question-quality.ts` scores the current first follow-up question for each baseline scenario in `tests/fixtures/question-quality-cases.json`.
+
+The harness scores the current deterministic question-selection path only. It does not change runtime behavior.
+
+## Fixture Contract
+
+Each case must include:
+
+- `id`
+- `category`
+- `complaintFamily`
+- `pet`
+- `initialMessage`
+- `expectedMustScreen`
+- `badFirstQuestions`
+- `idealQuestionCategories`
+- `expectedUrgency`
+
+The baseline fixture may also include helper fields such as `symptomKeys`, `turnFocusSymptoms`, and `recommendedFirstModule` so the harness can run the existing deterministic question path safely.
+
+## 0-3 Scoring Scale
+
+Every scored dimension uses the same coarse meaning:
+
+- `0`: unsafe, irrelevant, or clearly poor for first-question use
+- `1`: weak or only partly useful
+- `2`: acceptable but not ideal
+- `3`: strong first-question behavior for that case
+
+## Scored Dimensions
+
+### 1. Question Specificity
+
+- `0`: generic prompt or unrelated question
+- `1`: complaint-linked but broad
+- `2`: targeted to the complaint family
+- `3`: targeted and discriminative for the immediate decision
+
+### 2. Urgency-Changing Value
+
+- `0`: unlikely to change urgency understanding
+- `1`: provides limited urgency signal
+- `2`: materially helps urgency classification
+- `3`: directly screens a high-signal urgency fork
+
+### 3. Emergency Red-Flag Coverage
+
+- `0`: misses the expected first red-flag screen
+- `1`: indirectly touches emergency risk
+- `2`: partially covers a must-screen item
+- `3`: directly covers a must-screen emergency signal
+
+### 4. Concern-Bucket Discrimination
+
+- `0`: does not separate likely buckets
+- `1`: weak discrimination
+- `2`: reasonable separation value
+- `3`: strong bucket split for the complaint family
+
+### 5. Owner-Answerability
+
+- `0`: unclear, jargon-heavy, or hard for an owner to answer
+- `1`: answerable but awkward or interpretive
+- `2`: plainly answerable
+- `3`: easy, observable, and low-friction
+
+### 6. Repeated-Question Behavior
+
+- `0`: repeats the same question after it was just asked or answered
+- `3`: avoids the same-question repeat
+
+This dimension is binary on purpose because repeat safety is a hard failure mode.
+
+### 7. Generic Wording
+
+- `0`: one of the explicitly bad first questions or equivalent generic wording
+- `1`: broad wording with limited clinical precision
+- `2`: somewhat targeted wording
+- `3`: concrete, complaint-specific wording
+
+### 8. Report Usefulness Value
+
+- `0`: low-value answer for vet handoff or report structure
+- `1`: some value but poorly structured
+- `2`: useful structured handoff detail
+- `3`: high-value structured detail for downstream report quality
+
+## Output Metrics
+
+The harness must print:
+
+- total cases
+- average question score
+- generic question rate
+- emergency red-flag miss rate
+- first-question emergency-screen rate
+- repeated-question rate
+- per-category scores
+- top 20 generic or weak question patterns
+- top 20 missed red-flag patterns
+- recommended first complaint modules
+
+## Interpretation
+
+- The baseline is expected to expose weaknesses in emergency screening order, complaint-family specificity, and multi-symptom bucket discrimination.
+- Low scores are measurement outputs, not production regressions introduced by VET-1399.
+- Recommended modules are prioritization hints for later tickets; they do not imply runtime cutover in this ticket.

--- a/scripts/eval-question-quality.ts
+++ b/scripts/eval-question-quality.ts
@@ -1,0 +1,1000 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const { fileURLToPath, pathToFileURL } = require("node:url");
+const { registerHooks } = require("node:module");
+
+const ROOT = process.cwd();
+const FIXTURE_PATH = path.join(
+  ROOT,
+  "tests",
+  "fixtures",
+  "question-quality-cases.json"
+);
+const CATEGORY_KEYS = [
+  "specificity",
+  "urgencyValue",
+  "redFlagCoverage",
+  "concernBucketDiscrimination",
+  "ownerAnswerability",
+  "reportValue",
+  "repetitionSafety",
+];
+const CATEGORY_LABELS = {
+  specificity: "specificity",
+  urgencyValue: "urgency value",
+  redFlagCoverage: "red-flag coverage",
+  concernBucketDiscrimination: "concern-bucket discrimination",
+  ownerAnswerability: "owner answerability",
+  reportValue: "report value",
+  repetitionSafety: "repetition safety",
+};
+const GENERIC_QUESTION_PATTERNS = [
+  /\bcan you tell me more\b/i,
+  /\btell me more\b/i,
+  /\bwhat else\b/i,
+  /\bwhat has changed\b/i,
+  /\bwhat have you noticed\b/i,
+  /\bcan you describe\b/i,
+  /\btell me what you've noticed\b/i,
+];
+const DISCRIMINATIVE_QUESTION_PATTERNS = [
+  /\bhow long\b/i,
+  /\bhow often\b/i,
+  /\bwhen\b/i,
+  /\bwhat color\b/i,
+  /\bwhich\b/i,
+  /\bwhere\b/i,
+  /\bhow much\b/i,
+  /\bhow many\b/i,
+  /\brate\b/i,
+  /\bfrequency\b/i,
+  /\bduration\b/i,
+  /\bonset\b/i,
+  /\bamount\b/i,
+  /\bsize\b/i,
+  /\bleg\b/i,
+  /\bgum\b/i,
+  /\bblood\b/i,
+  /\bdrink\b/i,
+  /\beat\b/i,
+  /\bretch\b/i,
+  /\bweight\bW*bearing\b/i,
+];
+const OWNER_JARGON_PATTERNS = [
+  /\bcyanosis\b/i,
+  /\bdyspnea\b/i,
+  /\bhematochezia\b/i,
+  /\bpolydipsia\b/i,
+  /\bregurgitation\b/i,
+  /\bneurologic\b/i,
+  /\bmucous membranes?\b/i,
+  /\babdominal distension\b/i,
+];
+const MODULE_DESCRIPTIONS = {
+  emergency_screening:
+    "Prioritize immediate red-flag screening for high-risk symptom clusters.",
+  red_flag_coverage:
+    "Improve direct coverage of symptom-specific emergency triggers.",
+  question_specificity:
+    "Reduce generic prompts and anchor follow-ups to observable complaint details.",
+  concern_bucket_discrimination:
+    "Bias question choice toward prompts that separate complaint families cleanly.",
+  owner_answerability:
+    "Prefer owner-observable questions and avoid phrasing that requires interpretation.",
+  report_structure:
+    "Favor structured answers that produce cleaner downstream report facts.",
+  repeat_guard:
+    "Strengthen repeat-avoidance when a follow-up was just asked or answered.",
+  question_selection_alignment:
+    "Align deterministic selection with explicitly expected or reviewed follow-up targets.",
+};
+const RED_FLAG_SCREEN_QUESTION_IDS = {
+  active_bleeding_trauma: ["active_bleeding_trauma"],
+  balance_loss: ["balance_issues", "head_tilt"],
+  blue_gums: ["gum_color"],
+  bloody_diarrhea_puppy: ["stool_blood", "blood_amount"],
+  breathing_difficulty: ["breathing_rate", "position_preference"],
+  breathing_onset_sudden: ["breathing_onset"],
+  collapse: ["consciousness_level"],
+  cough_blood: ["cough_type", "cough_timing"],
+  eye_bulging: ["eye_redness", "vision_changes"],
+  eye_swollen_shut: ["squinting", "eye_redness"],
+  face_swelling: ["hives_with_breathing", "skin_changes"],
+  hives_widespread: ["hives_with_breathing", "skin_changes"],
+  inability_to_stand: ["trauma_mobility", "hind_limb_function", "weight_bearing"],
+  large_blood_volume: ["blood_amount", "stool_blood"],
+  no_water_24h: ["water_intake"],
+  non_weight_bearing: ["weight_bearing", "trauma_mobility", "hind_limb_function"],
+  not_drinking: ["water_intake"],
+  pale_gums: ["gum_color"],
+  pyometra_signs: ["spay_status"],
+  rapid_onset_distension: ["abdomen_onset", "restlessness"],
+  rat_poison_confirmed: ["rat_poison_access", "toxin_exposure"],
+  sudden_blindness: ["vision_changes"],
+  sudden_paralysis: ["weight_bearing", "hind_limb_function", "trauma_mobility"],
+  toxin_confirmed: [
+    "toxin_exposure",
+    "reaction_symptoms",
+    "medication_name",
+    "current_medications",
+  ],
+  unproductive_retching: ["unproductive_retching"],
+  unresponsive: ["consciousness_level"],
+  visible_fracture: ["visible_fracture", "trauma_mobility"],
+  wound_bone_visible: ["wound_size", "wound_color"],
+  wound_deep_bleeding: ["wound_discharge", "wound_color", "wound_size"],
+  wound_spreading_rapidly: ["wound_duration", "wound_size", "wound_color"],
+  wound_tissue_exposed: ["wound_size", "wound_color"],
+};
+const RED_FLAG_KEYWORD_ALIASES = {
+  active_bleeding_trauma: ["bleeding", "bleed", "blood"],
+  balance_loss: ["balance", "falling", "wobbly"],
+  blue_gums: ["gum", "gums"],
+  bloody_diarrhea_puppy: ["blood", "bloody"],
+  breathing_difficulty: ["breathing", "breathe", "air"],
+  breathing_onset_sudden: ["started", "sudden", "suddenly", "onset"],
+  collapse: ["responsive", "conscious", "collapse"],
+  cough_blood: ["blood", "bloody"],
+  eye_bulging: ["eye", "bulging", "swollen"],
+  eye_swollen_shut: ["eye", "shut", "swollen"],
+  face_swelling: ["face", "swelling", "swollen"],
+  hives_widespread: ["hives", "widespread", "skin"],
+  inability_to_stand: ["stand", "standing", "walk"],
+  large_blood_volume: ["blood", "amount", "how much"],
+  no_water_24h: ["drink", "water", "drinking"],
+  non_weight_bearing: ["weight", "bearing", "walk", "stand"],
+  not_drinking: ["drink", "water", "drinking"],
+  pale_gums: ["gum", "gums"],
+  pyometra_signs: ["spayed", "spay"],
+  rapid_onset_distension: ["started", "sudden", "swollen", "abdomen", "belly"],
+  rat_poison_confirmed: ["rat poison", "bait", "toxin", "rodenticide"],
+  sudden_blindness: ["vision", "see", "blind"],
+  sudden_paralysis: ["stand", "walk", "legs", "paralysis"],
+  toxin_confirmed: ["toxin", "medication", "poison", "exposure"],
+  unproductive_retching: ["retch", "trying to vomit"],
+  unresponsive: ["responsive", "conscious"],
+  visible_fracture: ["fracture", "broken", "bone"],
+  wound_bone_visible: ["wound", "bone", "deep"],
+  wound_deep_bleeding: ["wound", "bleeding", "blood"],
+  wound_spreading_rapidly: ["spreading", "rapidly", "wound"],
+  wound_tissue_exposed: ["wound", "tissue", "exposed"],
+};
+
+let hooksRegistered = false;
+let runtimePromise = null;
+
+function mean(values) {
+  if (!values.length) return 0;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function round(value) {
+  return Number(value.toFixed(3));
+}
+
+function clamp01(value) {
+  return Math.max(0, Math.min(1, value));
+}
+
+function safeRate(numerator, denominator) {
+  if (denominator <= 0) return 0;
+  return numerator / denominator;
+}
+
+function formatPercent(value) {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function normalizeStringArray(value) {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(value.map((item) => String(item).trim()).filter(Boolean))];
+}
+
+function getTextCaseId(rawCase, index) {
+  const value = rawCase.id ?? rawCase.caseId ?? rawCase.slug ?? `case-${index + 1}`;
+  return String(value).trim();
+}
+
+function normalizeCaseDefinition(rawCase, index) {
+  if (!rawCase || typeof rawCase !== "object") {
+    throw new Error(`Fixture case at index ${index} must be an object`);
+  }
+
+  const id = getTextCaseId(rawCase, index);
+  const symptomKeys = normalizeStringArray(
+    rawCase.symptomKeys ?? rawCase.symptoms ?? rawCase.knownSymptoms
+  );
+  const turnFocusSymptoms = normalizeStringArray(
+    rawCase.turnFocusSymptoms ??
+      rawCase.focusSymptoms ??
+      rawCase.preferredSymptoms ??
+      rawCase.turn_focus_symptoms
+  );
+  const redFlags = normalizeStringArray(
+    rawCase.redFlags ?? rawCase.expectedRedFlags ?? rawCase.emergencySignals
+  );
+  const tags = normalizeStringArray(rawCase.tags);
+  const expectedQuestionIds = normalizeStringArray(
+    rawCase.expectedQuestionIds ?? rawCase.expectedQuestionId
+  );
+  const recommendedModules = normalizeStringArray(
+    rawCase.recommendedModules ?? rawCase.modules
+  );
+
+  if (symptomKeys.length === 0) {
+    throw new Error(`Fixture case "${id}" must include at least one symptom key`);
+  }
+
+  return {
+    id,
+    symptomKeys,
+    turnFocusSymptoms,
+    concernBucket: rawCase.concernBucket ?? rawCase.expectedConcernBucket ?? null,
+    emergency:
+      Boolean(rawCase.emergency) ||
+      Boolean(rawCase.mustScreenEmergency) ||
+      Boolean(rawCase.mustScreenUrgent) ||
+      redFlags.length > 0,
+    redFlags,
+    expectedQuestionIds,
+    recommendedModules,
+    tags,
+    notes: rawCase.notes ? String(rawCase.notes) : null,
+  };
+}
+
+function loadCases(fixturePath = FIXTURE_PATH) {
+  if (!fs.existsSync(fixturePath)) {
+    throw new Error(`Question-quality fixture not found: ${fixturePath}`);
+  }
+
+  const rawFixture = JSON.parse(fs.readFileSync(fixturePath, "utf8"));
+  const rawCases = Array.isArray(rawFixture)
+    ? rawFixture
+    : Array.isArray(rawFixture?.cases)
+      ? rawFixture.cases
+      : null;
+
+  if (!rawCases) {
+    throw new Error(
+      `Question-quality fixture must be an array or { cases: [] }: ${fixturePath}`
+    );
+  }
+
+  return rawCases.map((rawCase, index) => normalizeCaseDefinition(rawCase, index));
+}
+
+function registerTypeScriptHooks() {
+  if (hooksRegistered) return;
+  hooksRegistered = true;
+
+  registerHooks({
+    resolve(specifier, context, defaultResolve) {
+      if (specifier.startsWith("@/")) {
+        const mappedPath = path.join(ROOT, "src", specifier.slice(2));
+        for (const candidate of [
+          `${mappedPath}.ts`,
+          `${mappedPath}.tsx`,
+          path.join(mappedPath, "index.ts"),
+        ]) {
+          try {
+            return defaultResolve(
+              pathToFileURL(candidate).href,
+              context,
+              defaultResolve
+            );
+          } catch {}
+        }
+      }
+
+      if (
+        (specifier.startsWith("./") || specifier.startsWith("../")) &&
+        !path.extname(specifier)
+      ) {
+        const parentPath = context.parentURL
+          ? fileURLToPath(context.parentURL)
+          : ROOT;
+        const basePath = path.resolve(path.dirname(parentPath), specifier);
+        for (const candidate of [
+          `${basePath}.ts`,
+          `${basePath}.tsx`,
+          path.join(basePath, "index.ts"),
+        ]) {
+          try {
+            return defaultResolve(
+              pathToFileURL(candidate).href,
+              context,
+              defaultResolve
+            );
+          } catch {}
+        }
+      }
+
+      return defaultResolve(specifier, context, defaultResolve);
+    },
+  });
+}
+
+async function withFilteredRuntimeWarnings(work) {
+  const originalEmitWarning = process.emitWarning;
+  process.emitWarning = function patchedEmitWarning(warning, ...args) {
+    const primaryArg = args[0];
+    const warningCode =
+      (warning && typeof warning === "object" && warning.code) ||
+      (primaryArg &&
+      typeof primaryArg === "object" &&
+      !Array.isArray(primaryArg) &&
+      primaryArg.code
+        ? primaryArg.code
+        : null);
+    const warningText =
+      typeof warning === "string"
+        ? warning
+        : warning && typeof warning.message === "string"
+          ? warning.message
+          : "";
+
+    if (
+      warningCode === "MODULE_TYPELESS_PACKAGE_JSON" ||
+      warningText.includes("MODULE_TYPELESS_PACKAGE_JSON")
+    ) {
+      return;
+    }
+
+    return originalEmitWarning.call(process, warning, ...args);
+  };
+
+  try {
+    return await work();
+  } finally {
+    process.emitWarning = originalEmitWarning;
+  }
+}
+
+async function loadQuestionRuntime() {
+  if (runtimePromise) {
+    return runtimePromise;
+  }
+
+  runtimePromise = (async () => {
+    registerTypeScriptHooks();
+
+    return withFilteredRuntimeWarnings(async () => {
+      const triageEngine = await import(
+        pathToFileURL(path.join(ROOT, "src", "lib", "triage-engine.ts")).href
+      );
+      const questionSelection = await import(
+        pathToFileURL(
+          path.join(ROOT, "src", "lib", "symptom-chat", "answer-coercion.ts")
+        ).href
+      );
+      const clinicalMatrix = await import(
+        pathToFileURL(path.join(ROOT, "src", "lib", "clinical-matrix.ts")).href
+      );
+
+      return {
+        createSession: triageEngine.createSession,
+        addSymptoms: triageEngine.addSymptoms,
+        getQuestionText: triageEngine.getQuestionText,
+        getSymptomPriorityScore: triageEngine.getSymptomPriorityScore,
+        getNextQuestionAvoidingRepeat:
+          questionSelection.getNextQuestionAvoidingRepeat,
+        FOLLOW_UP_QUESTIONS: clinicalMatrix.FOLLOW_UP_QUESTIONS,
+        SYMPTOM_MAP: clinicalMatrix.SYMPTOM_MAP,
+      };
+    });
+  })();
+
+  return runtimePromise;
+}
+
+function questionUsesGenericPattern(questionText) {
+  if (!questionText) return true;
+  return GENERIC_QUESTION_PATTERNS.some((pattern) => pattern.test(questionText));
+}
+
+function questionHasDiscriminativeSignal(questionText) {
+  return DISCRIMINATIVE_QUESTION_PATTERNS.some((pattern) => pattern.test(questionText));
+}
+
+function normalizeFlagTokens(value) {
+  return String(value)
+    .toLowerCase()
+    .replace(/[_-]+/g, " ")
+    .split(/\s+/)
+    .map((token) => token.replace(/s$/u, ""))
+    .filter((token) => token.length >= 3);
+}
+
+function questionScreensRedFlag(questionId, questionText, redFlag) {
+  if (!questionId || !questionText || !redFlag) {
+    return false;
+  }
+
+  if (questionId === redFlag) {
+    return true;
+  }
+
+  const aliasQuestionIds = RED_FLAG_SCREEN_QUESTION_IDS[redFlag] ?? [];
+  if (aliasQuestionIds.includes(questionId)) {
+    return true;
+  }
+
+  const lowerText = questionText.toLowerCase();
+  const questionTokens = new Set([
+    ...normalizeFlagTokens(questionId),
+    ...normalizeFlagTokens(questionText),
+  ]);
+  const redFlagTokens = normalizeFlagTokens(redFlag);
+  const keywordAliases = RED_FLAG_KEYWORD_ALIASES[redFlag] ?? [];
+
+  if (keywordAliases.some((keyword) => lowerText.includes(keyword.toLowerCase()))) {
+    return true;
+  }
+
+  return redFlagTokens.some((token) => questionTokens.has(token));
+}
+
+function getRelevantRedFlags(caseDefinition, focusSymptoms, symptomMap) {
+  if (caseDefinition.redFlags.length > 0) {
+    return caseDefinition.redFlags;
+  }
+
+  return [...new Set(
+    focusSymptoms.flatMap((symptom) => symptomMap[symptom]?.red_flags ?? [])
+  )];
+}
+
+function scoreSpecificity({
+  questionDef,
+  questionId,
+  questionText,
+  generic,
+  focusMatchCount,
+}) {
+  if (!questionId || !questionDef || !questionText) return 0;
+
+  let score = 0.3;
+  if (!generic) score += 0.2;
+  if (questionDef.critical) score += 0.15;
+  if (questionDef.data_type !== "string") score += 0.15;
+  if (questionHasDiscriminativeSignal(questionText)) score += 0.15;
+  if (focusMatchCount > 0) score += 0.1;
+  if (Array.isArray(questionDef.choices) && questionDef.choices.length > 0) {
+    score += 0.05;
+  }
+
+  return clamp01(score);
+}
+
+function scoreUrgencyValue({
+  questionDef,
+  isEmergencyCase,
+  emergencyScreened,
+  generic,
+  focusPriority,
+}) {
+  if (!questionDef) return 0;
+
+  if (isEmergencyCase || focusPriority >= 8) {
+    if (questionDef.critical && emergencyScreened) return 1;
+    if (emergencyScreened) return 0.8;
+    if (questionDef.critical) return 0.45;
+    return generic ? 0.1 : 0.25;
+  }
+
+  if (questionDef.critical) return 0.95;
+  if (generic) return 0.55;
+  return 0.8;
+}
+
+function scoreRedFlagCoverage(relevantRedFlags, coveredRedFlags, questionDef) {
+  if (!questionDef) return 0;
+  if (relevantRedFlags.length === 0) {
+    return questionDef.critical ? 1 : 0.8;
+  }
+
+  return coveredRedFlags.length / relevantRedFlags.length;
+}
+
+function scoreConcernBucketDiscrimination({
+  questionId,
+  questionText,
+  focusMatchCount,
+  focusSymptoms,
+  sessionFocusFollowUpCount,
+  generic,
+}) {
+  if (!questionId || !questionText) return 0;
+
+  let score = generic ? 0.2 : 0.4;
+  if (focusMatchCount > 0) score += 0.25;
+  if (focusSymptoms.length > 1 && focusMatchCount === 1) score += 0.15;
+  if (sessionFocusFollowUpCount <= 3) score += 0.1;
+  if (questionHasDiscriminativeSignal(questionText)) score += 0.1;
+
+  return clamp01(score);
+}
+
+function scoreOwnerAnswerability(questionDef, questionText) {
+  if (!questionDef || !questionText) return 0;
+
+  const dataTypeScore = {
+    boolean: 0.95,
+    choice: 0.9,
+    number: 0.85,
+    string: 0.75,
+  }[questionDef.data_type] ?? 0.7;
+
+  let score = dataTypeScore;
+  const wordCount = questionText.trim().split(/\s+/).filter(Boolean).length;
+  if (wordCount > 18) score -= 0.15;
+  if (OWNER_JARGON_PATTERNS.some((pattern) => pattern.test(questionText))) {
+    score -= 0.2;
+  }
+  if (/^(is|are|has|have|did|does|when|how long|how often|what color|which)\b/i.test(questionText)) {
+    score += 0.05;
+  }
+
+  return clamp01(score);
+}
+
+function scoreReportValue(questionDef, questionText, generic) {
+  if (!questionDef || !questionText) return 0;
+
+  let score = {
+    choice: 0.95,
+    boolean: 0.9,
+    number: 0.85,
+    string: 0.7,
+  }[questionDef.data_type] ?? 0.7;
+
+  if (questionDef.critical) score += 0.05;
+  if (String(questionDef.extraction_hint ?? "").trim().length >= 10) score += 0.05;
+  if (generic) score -= 0.25;
+
+  return clamp01(score);
+}
+
+function buildWeakPatterns({
+  caseDefinition,
+  generic,
+  questionId,
+  questionText,
+  categories,
+  repeated,
+  missedRedFlags,
+  emergencyMiss,
+}) {
+  const weakPatterns = [];
+
+  if (!questionId) {
+    weakPatterns.push("no-question-selected");
+    return weakPatterns;
+  }
+
+  if (generic) weakPatterns.push("generic-question");
+  if (categories.specificity < 0.7) weakPatterns.push("low-specificity");
+  if (categories.urgencyValue < 0.7) weakPatterns.push("low-urgency-value");
+  if (categories.redFlagCoverage < 0.75) weakPatterns.push("weak-red-flag-coverage");
+  if (categories.concernBucketDiscrimination < 0.75) {
+    weakPatterns.push("weak-concern-bucket-discrimination");
+  }
+  if (categories.ownerAnswerability < 0.75) {
+    weakPatterns.push("low-owner-answerability");
+  }
+  if (categories.reportValue < 0.75) weakPatterns.push("low-report-value");
+  if (repeated) weakPatterns.push("repeat-guard-failure");
+  if (
+    caseDefinition.expectedQuestionIds.length > 0 &&
+    !caseDefinition.expectedQuestionIds.includes(questionId)
+  ) {
+    weakPatterns.push("unexpected-question-selection");
+  }
+  if (emergencyMiss) weakPatterns.push("missed-emergency-screen");
+  for (const redFlag of missedRedFlags) {
+    weakPatterns.push(`missed-red-flag:${redFlag}`);
+  }
+  if (!questionText.trim()) weakPatterns.push("empty-question-text");
+
+  return weakPatterns;
+}
+
+function buildRecommendedModules(caseResult) {
+  const modules = [];
+
+  if (caseResult.generic || caseResult.categories.specificity < 0.7) {
+    modules.push("question_specificity");
+  }
+  if (caseResult.emergencyMiss || caseResult.categories.urgencyValue < 0.7) {
+    modules.push("emergency_screening");
+  }
+  if (caseResult.categories.redFlagCoverage < 0.75) {
+    modules.push("red_flag_coverage");
+  }
+  if (caseResult.categories.concernBucketDiscrimination < 0.75) {
+    modules.push("concern_bucket_discrimination");
+  }
+  if (caseResult.categories.ownerAnswerability < 0.75) {
+    modules.push("owner_answerability");
+  }
+  if (caseResult.categories.reportValue < 0.75) {
+    modules.push("report_structure");
+  }
+  if (caseResult.repeated) {
+    modules.push("repeat_guard");
+  }
+  if (
+    caseResult.caseDefinition.expectedQuestionIds.length > 0 &&
+    !caseResult.caseDefinition.expectedQuestionIds.includes(caseResult.questionId)
+  ) {
+    modules.push("question_selection_alignment");
+  }
+
+  return [...new Set([...modules, ...caseResult.caseDefinition.recommendedModules])];
+}
+
+function createFrequencyMap() {
+  return new Map();
+}
+
+function addFrequencyEntry(map, key, caseId, extra) {
+  const current = map.get(key) ?? { count: 0, cases: [], extras: new Set() };
+  current.count += 1;
+  if (current.cases.length < 5 && !current.cases.includes(caseId)) {
+    current.cases.push(caseId);
+  }
+  if (extra) {
+    current.extras.add(extra);
+  }
+  map.set(key, current);
+}
+
+function summarizeFrequencyMap(map, limit, formatter) {
+  return [...map.entries()]
+    .sort((left, right) => {
+      if (right[1].count !== left[1].count) {
+        return right[1].count - left[1].count;
+      }
+      return String(left[0]).localeCompare(String(right[0]));
+    })
+    .slice(0, limit)
+    .map(([key, entry]) => formatter(key, entry));
+}
+
+function evaluateCase(caseDefinition, runtime) {
+  const session = runtime.addSymptoms(
+    runtime.createSession(),
+    caseDefinition.symptomKeys
+  );
+  const focusSymptoms =
+    caseDefinition.turnFocusSymptoms.length > 0
+      ? caseDefinition.turnFocusSymptoms
+      : caseDefinition.symptomKeys;
+  const questionId = runtime.getNextQuestionAvoidingRepeat(session, focusSymptoms);
+  const questionText = questionId ? runtime.getQuestionText(questionId) : "";
+  const questionDef = questionId ? runtime.FOLLOW_UP_QUESTIONS[questionId] ?? null : null;
+  const generic = questionUsesGenericPattern(questionText);
+  const relevantRedFlags = getRelevantRedFlags(
+    caseDefinition,
+    focusSymptoms,
+    runtime.SYMPTOM_MAP
+  );
+  const coveredRedFlags = relevantRedFlags.filter((redFlag) =>
+    questionScreensRedFlag(questionId, questionText, redFlag)
+  );
+  const missedRedFlags = relevantRedFlags.filter(
+    (redFlag) => !coveredRedFlags.includes(redFlag)
+  );
+  const focusEntries = focusSymptoms
+    .map((symptom) => runtime.SYMPTOM_MAP[symptom])
+    .filter(Boolean);
+  const focusPriority = Math.max(
+    0,
+    ...focusSymptoms.map((symptom) => runtime.getSymptomPriorityScore(symptom))
+  );
+  const focusMatchCount = focusSymptoms.filter((symptom) =>
+    runtime.SYMPTOM_MAP[symptom]?.follow_up_questions?.includes(questionId)
+  ).length;
+  const sessionFocusFollowUpCount = new Set(
+    focusEntries.flatMap((entry) => entry.follow_up_questions ?? [])
+  ).size;
+  const isEmergencyCase =
+    caseDefinition.emergency || relevantRedFlags.length > 0 || focusPriority >= 8;
+  const emergencyScreened =
+    Boolean(questionDef?.critical) || coveredRedFlags.length > 0;
+
+  const repeated = Boolean(questionId) && (() => {
+    const answeredQuestions = [...session.answered_questions];
+    if (!answeredQuestions.includes(questionId)) {
+      answeredQuestions.push(questionId);
+    }
+    const replaySession = {
+      ...session,
+      answered_questions: answeredQuestions,
+      last_question_asked: questionId,
+    };
+    return (
+      runtime.getNextQuestionAvoidingRepeat(replaySession, focusSymptoms) === questionId
+    );
+  })();
+
+  const categories = {
+    specificity: round(
+      scoreSpecificity({
+        questionDef,
+        questionId,
+        questionText,
+        generic,
+        focusMatchCount,
+      })
+    ),
+    urgencyValue: round(
+      scoreUrgencyValue({
+        questionDef,
+        isEmergencyCase,
+        emergencyScreened,
+        generic,
+        focusPriority,
+      })
+    ),
+    redFlagCoverage: round(
+      scoreRedFlagCoverage(relevantRedFlags, coveredRedFlags, questionDef)
+    ),
+    concernBucketDiscrimination: round(
+      scoreConcernBucketDiscrimination({
+        questionId,
+        questionText,
+        focusMatchCount,
+        focusSymptoms,
+        sessionFocusFollowUpCount,
+        generic,
+      })
+    ),
+    ownerAnswerability: round(scoreOwnerAnswerability(questionDef, questionText)),
+    reportValue: round(scoreReportValue(questionDef, questionText, generic)),
+    repetitionSafety: repeated ? 0 : 1,
+  };
+
+  const overallScore = round(mean(CATEGORY_KEYS.map((key) => categories[key])));
+  const emergencyMiss = Boolean(isEmergencyCase && !emergencyScreened);
+  const weakPatterns = buildWeakPatterns({
+    caseDefinition,
+    generic,
+    questionId,
+    questionText,
+    categories,
+    repeated,
+    missedRedFlags,
+    emergencyMiss,
+  });
+
+  const caseResult = {
+    caseDefinition,
+    questionId,
+    questionText,
+    questionDef,
+    categories,
+    overallScore,
+    generic,
+    repeated,
+    focusPriority,
+    isEmergencyCase,
+    emergencyScreened,
+    emergencyMiss,
+    relevantRedFlags,
+    coveredRedFlags,
+    missedRedFlags,
+    weakPatterns,
+  };
+
+  return {
+    ...caseResult,
+    recommendedModules: buildRecommendedModules(caseResult),
+  };
+}
+
+function aggregateResults(caseResults) {
+  const emergencyCaseCount = caseResults.filter(
+    (result) => result.isEmergencyCase
+  ).length;
+  const categoryScores = Object.fromEntries(
+    CATEGORY_KEYS.map((key) => [
+      key,
+      round(mean(caseResults.map((result) => result.categories[key]))),
+    ])
+  );
+  const weakPatternMap = createFrequencyMap();
+  const missedRedFlagMap = createFrequencyMap();
+  const recommendedModuleMap = createFrequencyMap();
+
+  for (const result of caseResults) {
+    for (const weakPattern of result.weakPatterns) {
+      addFrequencyEntry(
+        weakPatternMap,
+        weakPattern,
+        result.caseDefinition.id,
+        result.questionId || "none"
+      );
+    }
+    for (const redFlag of result.missedRedFlags) {
+      addFrequencyEntry(
+        missedRedFlagMap,
+        redFlag,
+        result.caseDefinition.id,
+        result.questionId || "none"
+      );
+    }
+    for (const moduleId of result.recommendedModules) {
+      addFrequencyEntry(
+        recommendedModuleMap,
+        moduleId,
+        result.caseDefinition.id,
+        result.questionId || "none"
+      );
+    }
+  }
+
+  return {
+    totalCases: caseResults.length,
+    averageScore: round(mean(caseResults.map((result) => result.overallScore))),
+    categoryScores,
+    genericRate: round(
+      safeRate(
+        caseResults.filter((result) => result.generic).length,
+        caseResults.length
+      )
+    ),
+    emergencyCaseCount,
+    emergencyMissRate: round(
+      safeRate(
+        caseResults.filter((result) => result.emergencyMiss).length,
+        emergencyCaseCount
+      )
+    ),
+    emergencyScreenRate: round(
+      safeRate(
+        caseResults.filter((result) => result.emergencyScreened).length,
+        emergencyCaseCount
+      )
+    ),
+    repeatedRate: round(
+      safeRate(
+        caseResults.filter((result) => result.repeated).length,
+        caseResults.length
+      )
+    ),
+    weakPatterns: summarizeFrequencyMap(weakPatternMap, 20, (pattern, entry) => ({
+      pattern,
+      count: entry.count,
+      cases: entry.cases,
+      questionIds: [...entry.extras],
+    })),
+    missedRedFlags: summarizeFrequencyMap(missedRedFlagMap, 20, (redFlag, entry) => ({
+      redFlag,
+      count: entry.count,
+      cases: entry.cases,
+      questionIds: [...entry.extras],
+    })),
+    recommendedModules: summarizeFrequencyMap(
+      recommendedModuleMap,
+      20,
+      (moduleId, entry) => ({
+        moduleId,
+        count: entry.count,
+        cases: entry.cases,
+        questionIds: [...entry.extras],
+        description: MODULE_DESCRIPTIONS[moduleId] || "No description available.",
+      })
+    ),
+  };
+}
+
+async function runEvaluation(options = {}) {
+  const runtime = await loadQuestionRuntime();
+  const fixturePath = options.fixturePath || FIXTURE_PATH;
+  const cases = loadCases(fixturePath);
+  const caseResults = cases.map((caseDefinition) =>
+    evaluateCase(caseDefinition, runtime)
+  );
+
+  return {
+    fixturePath,
+    caseResults,
+    summary: aggregateResults(caseResults),
+  };
+}
+
+function formatSummary(report) {
+  const lines = [];
+  lines.push("PAWVITAL QUESTION-QUALITY EVAL");
+  lines.push("================================");
+  lines.push(`Fixture: ${report.fixturePath}`);
+  lines.push(`Total cases: ${report.summary.totalCases}`);
+  lines.push(`Average score: ${formatPercent(report.summary.averageScore)}`);
+  lines.push("Category scores:");
+  for (const key of CATEGORY_KEYS) {
+    lines.push(
+      `  ${CATEGORY_LABELS[key]}: ${formatPercent(report.summary.categoryScores[key])}`
+    );
+  }
+  lines.push(`Generic rate: ${formatPercent(report.summary.genericRate)}`);
+  lines.push(
+    `Emergency miss rate: ${formatPercent(report.summary.emergencyMissRate)} (${report.summary.emergencyCaseCount} emergency case(s))`
+  );
+  lines.push(
+    `Emergency-screen rate: ${formatPercent(report.summary.emergencyScreenRate)} (${report.summary.emergencyCaseCount} emergency case(s))`
+  );
+  lines.push(`Repeated rate: ${formatPercent(report.summary.repeatedRate)}`);
+
+  lines.push("Top 20 weak patterns:");
+  if (report.summary.weakPatterns.length === 0) {
+    lines.push("  none");
+  } else {
+    for (const item of report.summary.weakPatterns) {
+      lines.push(
+        `  ${item.pattern}: ${item.count} case(s) [${item.cases.join(", ")}]`
+      );
+    }
+  }
+
+  lines.push("Top 20 missed red flags:");
+  if (report.summary.missedRedFlags.length === 0) {
+    lines.push("  none");
+  } else {
+    for (const item of report.summary.missedRedFlags) {
+      lines.push(
+        `  ${item.redFlag}: ${item.count} case(s) [${item.cases.join(", ")}]`
+      );
+    }
+  }
+
+  lines.push("Recommended modules:");
+  if (report.summary.recommendedModules.length === 0) {
+    lines.push("  none");
+  } else {
+    for (const item of report.summary.recommendedModules) {
+      lines.push(
+        `  ${item.moduleId}: ${item.count} case(s) [${item.cases.join(", ")}] — ${item.description}`
+      );
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+async function main() {
+  const report = await runEvaluation();
+  process.stdout.write(formatSummary(report));
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  CATEGORY_KEYS,
+  FIXTURE_PATH,
+  evaluateCase,
+  formatSummary,
+  loadCases,
+  loadQuestionRuntime,
+  normalizeCaseDefinition,
+  runEvaluation,
+  __private: {
+    aggregateResults,
+    buildRecommendedModules,
+    buildWeakPatterns,
+    questionScreensRedFlag,
+    questionUsesGenericPattern,
+    scoreConcernBucketDiscrimination,
+    scoreOwnerAnswerability,
+    scoreRedFlagCoverage,
+    scoreReportValue,
+    scoreSpecificity,
+    scoreUrgencyValue,
+  },
+};

--- a/scripts/eval-question-quality.ts
+++ b/scripts/eval-question-quality.ts
@@ -4,7 +4,8 @@ const path = require("node:path");
 const { fileURLToPath, pathToFileURL } = require("node:url");
 const { registerHooks } = require("node:module");
 
-const ROOT = process.cwd();
+const SCRIPT_DIR = __dirname;
+const ROOT = path.resolve(SCRIPT_DIR, "..");
 const FIXTURE_PATH = path.join(
   ROOT,
   "tests",

--- a/scripts/eval-question-quality.ts
+++ b/scripts/eval-question-quality.ts
@@ -20,8 +20,8 @@ const CATEGORY_KEYS = [
   "repeatedQuestionBehavior",
   "genericWording",
   "reportUsefulnessValue",
-];
-const CATEGORY_LABELS = {
+] as const;
+const CATEGORY_LABELS: Record<(typeof CATEGORY_KEYS)[number], string> = {
   questionSpecificity: "question specificity",
   urgencyChangingValue: "urgency-changing value",
   emergencyRedFlagCoverage: "emergency red-flag coverage",
@@ -165,7 +165,7 @@ const REPORT_STRONG_CATEGORIES = new Set([
   "vomiting_severity",
   "wound_severity",
 ]);
-const MODULE_DESCRIPTIONS = {
+const MODULE_DESCRIPTIONS: Record<string, string> = {
   collapse_shock_screen:
     "Add a collapse and shock opener that checks responsiveness, gum color, and breathing before other detail questions.",
   respiratory_distress_screen:
@@ -217,7 +217,184 @@ const MODULE_DESCRIPTIONS = {
   senior_vague_weakness_module:
     "Add an older-dog vague-weakness opener that screens responsiveness, breathing, gum color, and last-normal time first.",
 };
-const QUESTION_SIGNAL_MAP = {
+type ScoreCategoryKey = (typeof CATEGORY_KEYS)[number];
+type CaseCategory = keyof typeof REQUIRED_CATEGORY_MINIMUMS;
+type CategoryCountMap = Record<string, number>;
+type CategoryScoreMap = Record<ScoreCategoryKey, number>;
+
+interface FixturePet {
+  species: string;
+  breed: string;
+  ageYears: number;
+  weightLbs: number;
+  sexNeuter: string;
+}
+
+interface EvalFixtureCase {
+  id: string;
+  category: CaseCategory | string;
+  complaintFamily: string;
+  pet: FixturePet;
+  initialMessage: string;
+  expectedMustScreen: string[];
+  badFirstQuestions: string[];
+  idealQuestionCategories: string[];
+  expectedUrgency: string;
+  symptomKeys: string[];
+  turnFocusSymptoms: string[];
+  recommendedFirstModule: string;
+}
+
+interface QuestionSignalDefinition {
+  questionCategories: string[];
+  mustScreenTags: string[];
+  missedScreenPattern?: string | null;
+}
+
+interface QuestionSignals extends QuestionSignalDefinition {
+  missedScreenPattern: string | null;
+}
+
+interface QuestionDefinition {
+  data_type?: string;
+  critical?: boolean;
+  [key: string]: unknown;
+}
+
+interface SessionState {
+  answered_questions: string[];
+  last_question_asked: string | null;
+  [key: string]: unknown;
+}
+
+interface TriageEngineModule {
+  createSession: () => SessionState;
+  addSymptoms: (session: SessionState, symptomKeys: string[]) => SessionState;
+  getQuestionText: (questionId: string) => string;
+  getSymptomPriorityScore: (symptomKey: string) => number;
+}
+
+interface QuestionSelectionModule {
+  getNextQuestionAvoidingRepeat: (
+    session: SessionState,
+    symptomKeys: string[]
+  ) => string | null | undefined;
+}
+
+interface ClinicalMatrixModule {
+  FOLLOW_UP_QUESTIONS: Record<string, QuestionDefinition>;
+}
+
+interface QuestionRuntime
+  extends TriageEngineModule,
+    QuestionSelectionModule,
+    ClinicalMatrixModule {}
+
+interface CaseEvaluationResult {
+  caseDefinition: EvalFixtureCase;
+  questionId: string | null;
+  questionText: string;
+  questionCategories: string[];
+  mustScreenHits: string[];
+  missedMustScreen: string[];
+  idealCategoryHits: string[];
+  isGeneric: boolean;
+  repeated: boolean;
+  scores: CategoryScoreMap;
+  averageScore: number;
+  weakPatterns: string[];
+}
+
+interface ComplaintFamilyAccumulator {
+  count: number;
+  totalScore: number;
+  weakCases: number;
+  missedScreens: number;
+  genericCases: number;
+  questionIds: Set<string>;
+  recommendedFirstModule: string;
+}
+
+interface ComplaintFamilySummary {
+  complaintFamily: string;
+  averageScore: number;
+  count: number;
+  weakCases: number;
+  missedScreens: number;
+  genericCases: number;
+  questionIds: string[];
+  recommendedFirstModule: string;
+}
+
+interface RecommendedModuleAccumulator {
+  count: number;
+  complaintFamilies: string[];
+  weakestScore: number;
+}
+
+interface RecommendedModuleSummary {
+  moduleId: string;
+  count: number;
+  weakestScore: number;
+  complaintFamilies: string[];
+  description: string;
+}
+
+interface FrequencyAccumulatorEntry {
+  count: number;
+  cases: string[];
+  complaintFamilies: Set<string>;
+  questionIds: Set<string>;
+}
+
+type FrequencySummaryItem<LabelKey extends string> = Record<LabelKey, string> & {
+  count: number;
+  cases: string[];
+  complaintFamilies: string[];
+  questionIds: string[];
+};
+
+interface EvaluationSummary {
+  totalCases: number;
+  categoryCounts: CategoryCountMap;
+  averageQuestionScore: number;
+  genericQuestionRate: number;
+  emergencyRedFlagMissRate: number;
+  firstQuestionEmergencyScreenRate: number;
+  repeatedQuestionRate: number;
+  categoryScores: CategoryScoreMap;
+  weakPatterns: FrequencySummaryItem<"pattern">[];
+  missedRedFlagPatterns: FrequencySummaryItem<"pattern">[];
+  complaintFamilySummaries: ComplaintFamilySummary[];
+  worstComplaintFamilies: ComplaintFamilySummary[];
+  recommendedFirstModules: RecommendedModuleSummary[];
+}
+
+interface EvaluationReport {
+  fixturePath: string;
+  cases: EvalFixtureCase[];
+  caseResults: CaseEvaluationResult[];
+  summary: EvaluationSummary;
+}
+
+interface RunEvaluationOptions {
+  fixturePath?: string;
+}
+
+interface ResolveHookContext {
+  parentURL?: string;
+}
+
+type ResolveFunction = (
+  specifier: string,
+  context: ResolveHookContext,
+  defaultResolve: ResolveFunction
+) => unknown;
+
+type EmitWarningValue = string | Error;
+type EmitWarningFunction = (warning: EmitWarningValue, ...args: unknown[]) => void;
+
+const QUESTION_SIGNAL_MAP: Record<string, QuestionSignalDefinition> = {
   abdomen_onset: {
     questionCategories: ["abdominal_emergency_screen", "gdv_screen", "timeline"],
     mustScreenTags: ["abdominal_distension"],
@@ -493,9 +670,25 @@ const QUESTION_SIGNAL_MAP = {
 };
 
 let hooksRegistered = false;
-let runtimePromise = null;
+let runtimePromise: Promise<QuestionRuntime> | null = null;
 
-function normalizeText(value) {
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function getErrorCode(error: unknown): string | undefined {
+  if (!isRecord(error) || typeof error.code !== "string") {
+    return undefined;
+  }
+
+  return error.code;
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizeText(value: unknown): string {
   return String(value)
     .trim()
     .toLowerCase()
@@ -504,45 +697,45 @@ function normalizeText(value) {
     .replace(/\s+/g, " ");
 }
 
-function uniqueStrings(values) {
+function uniqueStrings(values: readonly unknown[]): string[] {
   return [
     ...new Set(
       values
-        .filter((value) => value !== null && value !== undefined)
-        .map((value) => String(value).trim())
+        .filter((value: unknown) => value !== null && value !== undefined)
+        .map((value: unknown) => String(value).trim())
         .filter(Boolean)
     ),
   ];
 }
 
-function average(values) {
+function average(values: readonly number[]): number {
   if (values.length === 0) return 0;
-  return values.reduce((sum, value) => sum + value, 0) / values.length;
+  return values.reduce((sum: number, value: number) => sum + value, 0) / values.length;
 }
 
-function round(value) {
+function round(value: number): number {
   return Number(value.toFixed(2));
 }
 
-function clampScore(value) {
+function clampScore(value: number): number {
   return Math.max(0, Math.min(3, value));
 }
 
-function rate(numerator, denominator) {
+function rate(numerator: number, denominator: number): number {
   if (denominator <= 0) return 0;
   return numerator / denominator;
 }
 
-function formatScore(value) {
+function formatScore(value: number): string {
   return `${value.toFixed(2)} / 3.00`;
 }
 
-function formatPercent(value) {
+function formatPercent(value: number): string {
   return `${(value * 100).toFixed(1)}%`;
 }
 
-function normalizeCaseDefinition(rawCase, index) {
-  if (!rawCase || typeof rawCase !== "object") {
+function normalizeCaseDefinition(rawCase: unknown, index: number): EvalFixtureCase {
+  if (!isRecord(rawCase)) {
     throw new Error(`Case at index ${index} must be an object`);
   }
 
@@ -551,17 +744,17 @@ function normalizeCaseDefinition(rawCase, index) {
   const complaintFamily = String(rawCase.complaintFamily ?? "").trim();
   const initialMessage = String(rawCase.initialMessage ?? "").trim();
   const expectedUrgency = String(rawCase.expectedUrgency ?? "").trim();
-  const expectedMustScreen = uniqueStrings(rawCase.expectedMustScreen ?? []);
-  const badFirstQuestions = uniqueStrings(rawCase.badFirstQuestions ?? []);
+  const expectedMustScreen = uniqueStrings(asArray(rawCase.expectedMustScreen));
+  const badFirstQuestions = uniqueStrings(asArray(rawCase.badFirstQuestions));
   const idealQuestionCategories = uniqueStrings(
-    rawCase.idealQuestionCategories ?? []
+    asArray(rawCase.idealQuestionCategories)
   );
-  const symptomKeys = uniqueStrings(rawCase.symptomKeys ?? []);
-  const turnFocusSymptoms = uniqueStrings(rawCase.turnFocusSymptoms ?? []);
+  const symptomKeys = uniqueStrings(asArray(rawCase.symptomKeys));
+  const turnFocusSymptoms = uniqueStrings(asArray(rawCase.turnFocusSymptoms));
   const recommendedFirstModule = String(
     rawCase.recommendedFirstModule ?? ""
   ).trim();
-  const pet = rawCase.pet ?? {};
+  const pet = isRecord(rawCase.pet) ? rawCase.pet : {};
 
   if (!category) throw new Error(`Case "${id}" is missing category`);
   if (!complaintFamily) throw new Error(`Case "${id}" is missing complaintFamily`);
@@ -602,14 +795,14 @@ function normalizeCaseDefinition(rawCase, index) {
   };
 }
 
-function countByCategory(cases) {
-  return cases.reduce((counts, caseDefinition) => {
+function countByCategory(cases: EvalFixtureCase[]): CategoryCountMap {
+  return cases.reduce((counts: CategoryCountMap, caseDefinition: EvalFixtureCase) => {
     counts[caseDefinition.category] = (counts[caseDefinition.category] ?? 0) + 1;
     return counts;
   }, {});
 }
 
-function validateCaseSet(cases) {
+function validateCaseSet(cases: EvalFixtureCase[]): void {
   if (cases.length < 150) {
     throw new Error(`Expected at least 150 question-quality cases, found ${cases.length}`);
   }
@@ -637,15 +830,15 @@ function validateCaseSet(cases) {
   }
 }
 
-function loadCases(fixturePath = FIXTURE_PATH) {
+function loadCases(fixturePath: string = FIXTURE_PATH): EvalFixtureCase[] {
   if (!fs.existsSync(fixturePath)) {
     throw new Error(`Question-quality fixture not found: ${fixturePath}`);
   }
 
-  const rawFixture = JSON.parse(fs.readFileSync(fixturePath, "utf8"));
+  const rawFixture: unknown = JSON.parse(fs.readFileSync(fixturePath, "utf8"));
   const rawCases = Array.isArray(rawFixture)
     ? rawFixture
-    : Array.isArray(rawFixture?.cases)
+    : isRecord(rawFixture) && Array.isArray(rawFixture.cases)
       ? rawFixture.cases
       : null;
 
@@ -667,7 +860,11 @@ function registerTypeScriptHooks() {
   hooksRegistered = true;
 
   registerHooks({
-    resolve(specifier, context, defaultResolve) {
+    resolve(
+      specifier: string,
+      context: ResolveHookContext,
+      defaultResolve: ResolveFunction
+    ) {
       if (specifier.startsWith("@/")) {
         const mappedPath = path.join(ROOT, "src", specifier.slice(2));
         for (const candidate of [
@@ -713,24 +910,17 @@ function registerTypeScriptHooks() {
   });
 }
 
-async function withFilteredRuntimeWarnings(work) {
-  const originalEmitWarning = process.emitWarning;
-  process.emitWarning = function patchedEmitWarning(warning, ...args) {
+async function withFilteredRuntimeWarnings<T>(work: () => Promise<T>): Promise<T> {
+  const originalEmitWarning = process.emitWarning.bind(
+    process
+  ) as unknown as EmitWarningFunction;
+  process.emitWarning = ((warning: EmitWarningValue, ...args: unknown[]) => {
     const primaryArg = args[0];
-    const warningCode =
-      (warning && typeof warning === "object" && warning.code) ||
-      (primaryArg &&
-      typeof primaryArg === "object" &&
-      !Array.isArray(primaryArg) &&
-      primaryArg.code
-        ? primaryArg.code
-        : null);
+    const warningCode = getErrorCode(warning) || getErrorCode(primaryArg);
     const warningText =
       typeof warning === "string"
         ? warning
-        : warning && typeof warning.message === "string"
-          ? warning.message
-          : "";
+        : warning.message;
 
     if (
       warningCode === "MODULE_TYPELESS_PACKAGE_JSON" ||
@@ -739,8 +929,8 @@ async function withFilteredRuntimeWarnings(work) {
       return;
     }
 
-    return originalEmitWarning.call(process, warning, ...args);
-  };
+    originalEmitWarning(warning, ...args);
+  }) as unknown as typeof process.emitWarning;
 
   try {
     return await work();
@@ -749,8 +939,8 @@ async function withFilteredRuntimeWarnings(work) {
   }
 }
 
-async function loadQuestionRuntime() {
-  if (runtimePromise) {
+async function loadQuestionRuntime(): Promise<QuestionRuntime> {
+  if (runtimePromise !== null) {
     return runtimePromise;
   }
 
@@ -758,17 +948,17 @@ async function loadQuestionRuntime() {
     registerTypeScriptHooks();
 
     return withFilteredRuntimeWarnings(async () => {
-      const triageEngine = await import(
+      const triageEngine = (await import(
         pathToFileURL(path.join(ROOT, "src", "lib", "triage-engine.ts")).href
-      );
-      const questionSelection = await import(
+      )) as TriageEngineModule;
+      const questionSelection = (await import(
         pathToFileURL(
           path.join(ROOT, "src", "lib", "symptom-chat", "answer-coercion.ts")
         ).href
-      );
-      const clinicalMatrix = await import(
+      )) as QuestionSelectionModule;
+      const clinicalMatrix = (await import(
         pathToFileURL(path.join(ROOT, "src", "lib", "clinical-matrix.ts")).href
-      );
+      )) as ClinicalMatrixModule;
 
       return {
         createSession: triageEngine.createSession,
@@ -785,10 +975,10 @@ async function loadQuestionRuntime() {
   return runtimePromise;
 }
 
-function inferSignalsFromQuestionText(questionText) {
+function inferSignalsFromQuestionText(questionText: string): QuestionSignalDefinition {
   const lower = questionText.toLowerCase();
-  const questionCategories = [];
-  const mustScreenTags = [];
+  const questionCategories: string[] = [];
+  const mustScreenTags: string[] = [];
 
   if (lower.includes("gum")) {
     questionCategories.push("gum_color_screen");
@@ -858,8 +1048,13 @@ function inferSignalsFromQuestionText(questionText) {
   };
 }
 
-function getQuestionSignals(questionId, questionText) {
-  const mappedSignals = QUESTION_SIGNAL_MAP[questionId] ?? {
+function getQuestionSignals(
+  questionId: string | null,
+  questionText: string
+): QuestionSignals {
+  const mappedSignals: QuestionSignalDefinition = (questionId
+    ? QUESTION_SIGNAL_MAP[questionId]
+    : null) ?? {
     questionCategories: [],
     mustScreenTags: [],
   };
@@ -878,7 +1073,11 @@ function getQuestionSignals(questionId, questionText) {
   };
 }
 
-function isGenericQuestion(questionText, badFirstQuestions, questionCategories) {
+function isGenericQuestion(
+  questionText: string,
+  badFirstQuestions: string[],
+  questionCategories: string[]
+): boolean {
   if (!questionText) return true;
 
   const normalizedQuestion = normalizeText(questionText);
@@ -898,12 +1097,12 @@ function isGenericQuestion(questionText, badFirstQuestions, questionCategories) 
 }
 
 function scoreQuestionSpecificity(
-  questionDef,
-  isGeneric,
-  idealCategoryHits,
-  mustScreenHits,
-  questionCategories
-) {
+  questionDef: QuestionDefinition | null,
+  isGeneric: boolean,
+  idealCategoryHits: string[],
+  mustScreenHits: string[],
+  questionCategories: string[]
+): number {
   if (!questionDef) return 0;
   if (isGeneric) return 0;
 
@@ -918,7 +1117,11 @@ function scoreQuestionSpecificity(
   return clampScore(score);
 }
 
-function scoreUrgencyChangingValue(questionDef, mustScreenHits, questionCategories) {
+function scoreUrgencyChangingValue(
+  questionDef: QuestionDefinition | null,
+  mustScreenHits: string[],
+  questionCategories: string[]
+): number {
   if (!questionDef) return 0;
   if (mustScreenHits.length > 0) return 3;
   if (
@@ -932,11 +1135,11 @@ function scoreUrgencyChangingValue(questionDef, mustScreenHits, questionCategori
 }
 
 function scoreEmergencyRedFlagCoverage(
-  caseDefinition,
-  mustScreenHits,
-  questionDef,
-  questionCategories
-) {
+  caseDefinition: EvalFixtureCase,
+  mustScreenHits: string[],
+  questionDef: QuestionDefinition | null,
+  questionCategories: string[]
+): number {
   if (!questionDef) return 0;
   if (caseDefinition.expectedMustScreen.length === 0) return 3;
   if (mustScreenHits.includes(caseDefinition.expectedMustScreen[0])) return 3;
@@ -950,7 +1153,11 @@ function scoreEmergencyRedFlagCoverage(
   return 0;
 }
 
-function scoreConcernBucketDiscrimination(questionDef, idealCategoryHits, questionCategories) {
+function scoreConcernBucketDiscrimination(
+  questionDef: QuestionDefinition | null,
+  idealCategoryHits: string[],
+  questionCategories: string[]
+): number {
   if (!questionDef) return 0;
   if (
     idealCategoryHits.length > 0 &&
@@ -963,7 +1170,11 @@ function scoreConcernBucketDiscrimination(questionDef, idealCategoryHits, questi
   return 0;
 }
 
-function scoreOwnerAnswerability(questionDef, questionText, questionCategories) {
+function scoreOwnerAnswerability(
+  questionDef: QuestionDefinition | null,
+  questionText: string,
+  questionCategories: string[]
+): number {
   if (!questionDef || !questionText) return 0;
 
   if (
@@ -985,11 +1196,16 @@ function scoreOwnerAnswerability(questionDef, questionText, questionCategories) 
   return wordCount <= 18 ? 2 : 1;
 }
 
-function scoreRepeatedQuestionBehavior(repeated) {
+function scoreRepeatedQuestionBehavior(repeated: boolean): number {
   return repeated ? 0 : 3;
 }
 
-function scoreGenericWording(isGeneric, questionCategories, idealCategoryHits, mustScreenHits) {
+function scoreGenericWording(
+  isGeneric: boolean,
+  questionCategories: string[],
+  idealCategoryHits: string[],
+  mustScreenHits: string[]
+): number {
   if (isGeneric) return 0;
   if (questionCategories.includes("open_clarification")) return 1;
   if (idealCategoryHits.length > 0 || mustScreenHits.length > 0) return 3;
@@ -997,11 +1213,11 @@ function scoreGenericWording(isGeneric, questionCategories, idealCategoryHits, m
 }
 
 function scoreReportUsefulnessValue(
-  questionDef,
-  questionCategories,
-  idealCategoryHits,
-  mustScreenHits
-) {
+  questionDef: QuestionDefinition | null,
+  questionCategories: string[],
+  idealCategoryHits: string[],
+  mustScreenHits: string[]
+): number {
   if (!questionDef) return 0;
   if (
     (questionDef.data_type === "boolean" ||
@@ -1023,7 +1239,12 @@ function scoreReportUsefulnessValue(
   return 1;
 }
 
-function buildWeakPatternLabel(questionId, questionSignals, mustScreenMiss, isGeneric) {
+function buildWeakPatternLabel(
+  questionId: string | null,
+  questionSignals: QuestionSignals,
+  mustScreenMiss: boolean,
+  isGeneric: boolean
+): string | null {
   if (isGeneric) {
     return "generic-first-question";
   }
@@ -1070,10 +1291,15 @@ function buildWeakPatternLabel(questionId, questionSignals, mustScreenMiss, isGe
   return "missed-first-emergency-screen";
 }
 
-function addFrequencyEntry(map, key, caseDefinition, questionId) {
+function addFrequencyEntry(
+  map: Map<string, FrequencyAccumulatorEntry>,
+  key: string | null,
+  caseDefinition: EvalFixtureCase,
+  questionId: string | null
+): void {
   if (!key) return;
 
-  const current = map.get(key) ?? {
+  const current: FrequencyAccumulatorEntry = map.get(key) ?? {
     count: 0,
     cases: [],
     complaintFamilies: new Set(),
@@ -1090,7 +1316,11 @@ function addFrequencyEntry(map, key, caseDefinition, questionId) {
   map.set(key, current);
 }
 
-function summarizeFrequencyMap(map, limit, labelKey) {
+function summarizeFrequencyMap<LabelKey extends string>(
+  map: Map<string, FrequencyAccumulatorEntry>,
+  limit: number,
+  labelKey: LabelKey
+): Array<FrequencySummaryItem<LabelKey>> {
   return [...map.entries()]
     .sort((left, right) => {
       if (right[1].count !== left[1].count) {
@@ -1099,16 +1329,22 @@ function summarizeFrequencyMap(map, limit, labelKey) {
       return String(left[0]).localeCompare(String(right[0]));
     })
     .slice(0, limit)
-    .map(([label, entry]) => ({
-      [labelKey]: label,
-      count: entry.count,
-      cases: entry.cases,
-      complaintFamilies: [...entry.complaintFamilies].sort(),
-      questionIds: [...entry.questionIds].sort(),
-    }));
+    .map(
+      ([label, entry]) =>
+        ({
+          [labelKey]: label,
+          count: entry.count,
+          cases: entry.cases,
+          complaintFamilies: [...entry.complaintFamilies].sort(),
+          questionIds: [...entry.questionIds].sort(),
+        }) as FrequencySummaryItem<LabelKey>
+    );
 }
 
-function evaluateCase(caseDefinition, runtime) {
+function evaluateCase(
+  caseDefinition: EvalFixtureCase,
+  runtime: QuestionRuntime
+): CaseEvaluationResult {
   let session = runtime.createSession();
   session = runtime.addSymptoms(session, caseDefinition.symptomKeys);
 
@@ -1116,20 +1352,24 @@ function evaluateCase(caseDefinition, runtime) {
     caseDefinition.turnFocusSymptoms.length > 0
       ? caseDefinition.turnFocusSymptoms
       : caseDefinition.symptomKeys;
-  const questionId = runtime.getNextQuestionAvoidingRepeat(
+  const selectedQuestionId = runtime.getNextQuestionAvoidingRepeat(
     session,
     preferredSymptoms
   );
+  const questionId =
+    typeof selectedQuestionId === "string" && selectedQuestionId.trim()
+      ? selectedQuestionId
+      : null;
   const questionText = questionId ? runtime.getQuestionText(questionId) : "";
   const questionDef = questionId ? runtime.FOLLOW_UP_QUESTIONS[questionId] ?? null : null;
-  const questionSignals = getQuestionSignals(questionId, questionText);
-  const mustScreenHits = caseDefinition.expectedMustScreen.filter((tag) =>
+  const questionSignals: QuestionSignals = getQuestionSignals(questionId, questionText);
+  const mustScreenHits = caseDefinition.expectedMustScreen.filter((tag: string) =>
     questionSignals.mustScreenTags.includes(tag)
   );
   const missedMustScreen = caseDefinition.expectedMustScreen.filter(
-    (tag) => !mustScreenHits.includes(tag)
+    (tag: string) => !mustScreenHits.includes(tag)
   );
-  const idealCategoryHits = caseDefinition.idealQuestionCategories.filter((tag) =>
+  const idealCategoryHits = caseDefinition.idealQuestionCategories.filter((tag: string) =>
     questionSignals.questionCategories.includes(tag)
   );
   const isGeneric = isGenericQuestion(
@@ -1137,8 +1377,9 @@ function evaluateCase(caseDefinition, runtime) {
     caseDefinition.badFirstQuestions,
     questionSignals.questionCategories
   );
-  const repeated = Boolean(questionId) && (() => {
-    const replaySession = {
+  const repeated = questionId
+    ? (() => {
+    const replaySession: SessionState = {
       ...session,
       answered_questions: session.answered_questions.includes(questionId)
         ? [...session.answered_questions]
@@ -1149,9 +1390,10 @@ function evaluateCase(caseDefinition, runtime) {
       runtime.getNextQuestionAvoidingRepeat(replaySession, preferredSymptoms) ===
       questionId
     );
-  })();
+      })()
+    : false;
 
-  const scores = {
+  const scores: CategoryScoreMap = {
     questionSpecificity: scoreQuestionSpecificity(
       questionDef,
       isGeneric,
@@ -1195,7 +1437,9 @@ function evaluateCase(caseDefinition, runtime) {
     ),
   };
 
-  const averageScore = round(average(CATEGORY_KEYS.map((key) => scores[key])));
+  const averageScore = round(
+    average(CATEGORY_KEYS.map((key: ScoreCategoryKey) => scores[key]))
+  );
   const mustScreenMiss = mustScreenHits.length === 0;
   const weakPatterns = uniqueStrings([
     buildWeakPatternLabel(questionId, questionSignals, mustScreenMiss, isGeneric),
@@ -1222,12 +1466,14 @@ function evaluateCase(caseDefinition, runtime) {
   };
 }
 
-function summarizeComplaintFamilies(caseResults) {
-  const grouped = new Map();
+function summarizeComplaintFamilies(
+  caseResults: CaseEvaluationResult[]
+): ComplaintFamilySummary[] {
+  const grouped = new Map<string, ComplaintFamilyAccumulator>();
 
   for (const result of caseResults) {
     const complaintFamily = result.caseDefinition.complaintFamily;
-    const current = grouped.get(complaintFamily) ?? {
+    const current: ComplaintFamilyAccumulator = grouped.get(complaintFamily) ?? {
       count: 0,
       totalScore: 0,
       weakCases: 0,
@@ -1266,8 +1512,10 @@ function summarizeComplaintFamilies(caseResults) {
     });
 }
 
-function summarizeRecommendedModules(complaintFamilySummaries) {
-  const moduleMap = new Map();
+function summarizeRecommendedModules(
+  complaintFamilySummaries: ComplaintFamilySummary[]
+): RecommendedModuleSummary[] {
+  const moduleMap = new Map<string, RecommendedModuleAccumulator>();
 
   for (const summary of complaintFamilySummaries) {
     if (summary.averageScore >= 2 && summary.missedScreens === 0) {
@@ -1277,7 +1525,7 @@ function summarizeRecommendedModules(complaintFamilySummaries) {
     const moduleId = summary.recommendedFirstModule;
     if (!moduleId) continue;
 
-    const current = moduleMap.get(moduleId) ?? {
+    const current: RecommendedModuleAccumulator = moduleMap.get(moduleId) ?? {
       count: 0,
       complaintFamilies: [],
       weakestScore: 3,
@@ -1296,7 +1544,7 @@ function summarizeRecommendedModules(complaintFamilySummaries) {
       count: entry.count,
       weakestScore: round(entry.weakestScore),
       complaintFamilies: entry.complaintFamilies.sort(),
-      description: MODULE_DESCRIPTIONS[moduleId] || "No description available.",
+      description: MODULE_DESCRIPTIONS[moduleId] ?? "No description available.",
     }))
     .sort((left, right) => {
       if (right.count !== left.count) {
@@ -1306,9 +1554,12 @@ function summarizeRecommendedModules(complaintFamilySummaries) {
     });
 }
 
-function aggregateResults(cases, caseResults) {
-  const weakPatternMap = new Map();
-  const missedScreenMap = new Map();
+function aggregateResults(
+  cases: EvalFixtureCase[],
+  caseResults: CaseEvaluationResult[]
+): EvaluationSummary {
+  const weakPatternMap = new Map<string, FrequencyAccumulatorEntry>();
+  const missedScreenMap = new Map<string, FrequencyAccumulatorEntry>();
 
   for (const result of caseResults) {
     for (const weakPattern of result.weakPatterns) {
@@ -1324,7 +1575,7 @@ function aggregateResults(cases, caseResults) {
       key,
       round(average(caseResults.map((result) => result.scores[key]))),
     ])
-  );
+  ) as CategoryScoreMap;
   const complaintFamilySummaries = summarizeComplaintFamilies(caseResults);
 
   return {
@@ -1360,7 +1611,9 @@ function aggregateResults(cases, caseResults) {
   };
 }
 
-async function runEvaluation(options = {}) {
+async function runEvaluation(
+  options: RunEvaluationOptions = {}
+): Promise<EvaluationReport> {
   const runtime = await loadQuestionRuntime();
   const fixturePath = options.fixturePath || FIXTURE_PATH;
   const cases = loadCases(fixturePath);
@@ -1376,8 +1629,8 @@ async function runEvaluation(options = {}) {
   };
 }
 
-function formatSummary(report) {
-  const lines = [];
+function formatSummary(report: EvaluationReport): string {
+  const lines: string[] = [];
   lines.push("PAWVITAL QUESTION INTELLIGENCE BASELINE");
   lines.push("=======================================");
   lines.push(`Fixture: ${report.fixturePath}`);
@@ -1448,7 +1701,7 @@ function formatSummary(report) {
   return `${lines.join("\n")}\n`;
 }
 
-async function main() {
+async function main(): Promise<void> {
   const report = await runEvaluation();
   process.stdout.write(formatSummary(report));
 }

--- a/scripts/eval-question-quality.ts
+++ b/scripts/eval-question-quality.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
 const fs = require("node:fs");
 const path = require("node:path");
 const { fileURLToPath, pathToFileURL } = require("node:url");
@@ -11,236 +12,629 @@ const FIXTURE_PATH = path.join(
   "question-quality-cases.json"
 );
 const CATEGORY_KEYS = [
-  "specificity",
-  "urgencyValue",
-  "redFlagCoverage",
+  "questionSpecificity",
+  "urgencyChangingValue",
+  "emergencyRedFlagCoverage",
   "concernBucketDiscrimination",
   "ownerAnswerability",
-  "reportValue",
-  "repetitionSafety",
+  "repeatedQuestionBehavior",
+  "genericWording",
+  "reportUsefulnessValue",
 ];
 const CATEGORY_LABELS = {
-  specificity: "specificity",
-  urgencyValue: "urgency value",
-  redFlagCoverage: "red-flag coverage",
+  questionSpecificity: "question specificity",
+  urgencyChangingValue: "urgency-changing value",
+  emergencyRedFlagCoverage: "emergency red-flag coverage",
   concernBucketDiscrimination: "concern-bucket discrimination",
-  ownerAnswerability: "owner answerability",
-  reportValue: "report value",
-  repetitionSafety: "repetition safety",
+  ownerAnswerability: "owner-answerability",
+  repeatedQuestionBehavior: "repeated-question behavior",
+  genericWording: "generic wording",
+  reportUsefulnessValue: "report usefulness value",
 };
+const REQUIRED_CATEGORY_MINIMUMS = {
+  emergency: 45,
+  urgent_same_day: 40,
+  routine_unclear: 40,
+  confusing_multi_symptom: 25,
+};
+const REQUIRED_COMPLAINT_FAMILIES = new Set([
+  "collapse_pale_gums",
+  "breathing_difficulty",
+  "bloat_nonproductive_retching_swollen_abdomen",
+  "seizure_or_repeated_seizures",
+  "toxin_ingestion",
+  "trauma",
+  "urinary_blockage",
+  "heat_stroke",
+  "vomiting_and_lethargy",
+  "bloody_diarrhea",
+  "eye_injury",
+  "non_weight_bearing_limp",
+  "wound_or_bite",
+  "painful_abdomen_without_collapse",
+  "mild_itching",
+  "mild_limp",
+  "eating_less",
+  "ear_scratching",
+  "occasional_vomiting",
+  "mild_diarrhea",
+  "itching_and_vomiting",
+  "limping_and_lethargy",
+  "drinking_more_and_weight_loss",
+  "coughing_and_tiredness",
+  "old_dog_vague_weakness",
+]);
 const GENERIC_QUESTION_PATTERNS = [
   /\bcan you tell me more\b/i,
   /\btell me more\b/i,
-  /\bwhat else\b/i,
-  /\bwhat has changed\b/i,
+  /\bwhat else have you noticed\b/i,
   /\bwhat have you noticed\b/i,
   /\bcan you describe\b/i,
-  /\btell me what you've noticed\b/i,
-];
-const DISCRIMINATIVE_QUESTION_PATTERNS = [
-  /\bhow long\b/i,
-  /\bhow often\b/i,
-  /\bwhen\b/i,
-  /\bwhat color\b/i,
-  /\bwhich\b/i,
-  /\bwhere\b/i,
-  /\bhow much\b/i,
-  /\bhow many\b/i,
-  /\brate\b/i,
-  /\bfrequency\b/i,
-  /\bduration\b/i,
-  /\bonset\b/i,
-  /\bamount\b/i,
-  /\bsize\b/i,
-  /\bleg\b/i,
-  /\bgum\b/i,
-  /\bblood\b/i,
-  /\bdrink\b/i,
-  /\beat\b/i,
-  /\bretch\b/i,
-  /\bweight\bW*bearing\b/i,
+  /\bwhat's your best guess\b/i,
 ];
 const OWNER_JARGON_PATTERNS = [
   /\bcyanosis\b/i,
   /\bdyspnea\b/i,
   /\bhematochezia\b/i,
   /\bpolydipsia\b/i,
-  /\bregurgitation\b/i,
   /\bneurologic\b/i,
   /\bmucous membranes?\b/i,
   /\babdominal distension\b/i,
 ];
+const CRITICAL_QUESTION_CATEGORIES = new Set([
+  "abdominal_emergency_screen",
+  "bleeding_screen",
+  "breathing_distress_screen",
+  "collapse_screen",
+  "eye_emergency_screen",
+  "gdv_screen",
+  "gum_color_screen",
+  "heat_exposure_screen",
+  "mobility_screen",
+  "seizure_duration",
+  "toxin_screen",
+  "urinary_obstruction_screen",
+  "vision_screen",
+  "vomiting_screen",
+]);
+const DISCRIMINATIVE_CATEGORIES = new Set([
+  "abdominal_emergency_screen",
+  "appetite_duration",
+  "bite_trauma_history",
+  "bucket_split",
+  "cough_character",
+  "endocrine_discrimination",
+  "eye_emergency_screen",
+  "gi_bleeding_screen",
+  "heat_exposure_screen",
+  "hydration_screen",
+  "limp_location",
+  "mobility_screen",
+  "pain_severity",
+  "respiratory_vs_systemic_split",
+  "seizure_duration",
+  "stool_blood_screen",
+  "symptom_timing",
+  "timeline",
+  "toxin_screen",
+  "urinary_obstruction_screen",
+  "vision_screen",
+  "vomiting_severity",
+  "weight_change",
+  "wound_severity",
+]);
+const LOCATION_FIRST_CATEGORIES = new Set([
+  "itch_location",
+  "limp_location",
+  "wound_location",
+]);
+const DETAIL_FIRST_CATEGORIES = new Set([
+  "ear_discharge",
+  "ocular_discharge_color",
+  "urination_change",
+  "weight_change",
+]);
+const TIMELINE_FIRST_CATEGORIES = new Set([
+  "appetite_duration",
+  "timeline",
+  "vomiting_severity",
+]);
+const OPEN_FIRST_CATEGORIES = new Set(["open_clarification"]);
+const REPORT_STRONG_CATEGORIES = new Set([
+  "abdominal_emergency_screen",
+  "bleeding_screen",
+  "breathing_distress_screen",
+  "collapse_screen",
+  "cough_character",
+  "ear_discharge",
+  "endocrine_discrimination",
+  "eye_emergency_screen",
+  "gdv_screen",
+  "gi_bleeding_screen",
+  "gum_color_screen",
+  "heat_exposure_screen",
+  "hydration_screen",
+  "limp_location",
+  "mobility_screen",
+  "pain_severity",
+  "seizure_duration",
+  "stool_blood_screen",
+  "toxin_screen",
+  "urinary_obstruction_screen",
+  "vision_screen",
+  "vomiting_severity",
+  "wound_severity",
+]);
 const MODULE_DESCRIPTIONS = {
-  emergency_screening:
-    "Prioritize immediate red-flag screening for high-risk symptom clusters.",
-  red_flag_coverage:
-    "Improve direct coverage of symptom-specific emergency triggers.",
-  question_specificity:
-    "Reduce generic prompts and anchor follow-ups to observable complaint details.",
-  concern_bucket_discrimination:
-    "Bias question choice toward prompts that separate complaint families cleanly.",
-  owner_answerability:
-    "Prefer owner-observable questions and avoid phrasing that requires interpretation.",
-  report_structure:
-    "Favor structured answers that produce cleaner downstream report facts.",
-  repeat_guard:
-    "Strengthen repeat-avoidance when a follow-up was just asked or answered.",
-  question_selection_alignment:
-    "Align deterministic selection with explicitly expected or reviewed follow-up targets.",
+  collapse_shock_screen:
+    "Add a collapse and shock opener that checks responsiveness, gum color, and breathing before other detail questions.",
+  respiratory_distress_screen:
+    "Add a dedicated breathing-distress opener that checks onset, effort, and gum color first.",
+  bloat_gdv_screen:
+    "Add a bloat/GDV opener that screens retching, abdominal distension, and restlessness immediately.",
+  seizure_episode_screen:
+    "Add a seizure opener that checks duration, recurrence, breathing, and post-event responsiveness first.",
+  toxin_exposure_screen:
+    "Add a toxin-exposure opener that checks the substance, timing, and active symptoms before generic detail gathering.",
+  major_trauma_screen:
+    "Add a trauma opener that screens bleeding, breathing compromise, mobility loss, and fracture risk immediately.",
+  urinary_obstruction_screen:
+    "Add a urinary-obstruction opener that asks about straining with little or no urine before routine urinary detail.",
+  heat_illness_screen:
+    "Add a heat-illness opener that checks exposure, collapse, gum color, and vomiting first.",
+  vomiting_lethargy_module:
+    "Add a combined vomiting plus lethargy opener that screens hydration, gum color, and frequency before timeline only.",
+  gi_bleeding_module:
+    "Add a bloody-diarrhea opener that screens bleeding severity and perfusion before lower-value detail.",
+  eye_injury_module:
+    "Add an eye-injury opener that checks squinting, vision change, trauma, and swelling before discharge detail.",
+  limp_severity_module:
+    "Add a non-weight-bearing limp opener that asks about weight bearing before location-only detail.",
+  wound_bite_module:
+    "Add a wound or bite opener that screens wound depth, bleeding, and bite trauma severity before location-only detail.",
+  abdominal_pain_module:
+    "Add an abdominal-pain opener that checks distension, vomiting, and collapse risk before lower-value detail.",
+  itching_module:
+    "Add a mild-itching opener that screens allergy red flags before routine itch-location questions.",
+  mild_limp_module:
+    "Add a mild-limp opener that checks weight bearing and trauma before routine location and timing questions.",
+  reduced_appetite_module:
+    "Add a reduced-appetite opener that screens vomiting and hydration before duration-only questions.",
+  ear_scratching_module:
+    "Add an ear-scratching opener that checks head tilt and balance changes before routine discharge detail.",
+  vomiting_module:
+    "Add an occasional-vomiting opener that screens frequency and hydration before routine follow-up.",
+  mild_diarrhea_module:
+    "Add a mild-diarrhea opener that checks blood and hydration before stool-detail questions.",
+  itching_vomiting_split_module:
+    "Add a bucket-splitting opener for itching plus vomiting so the checker can separate allergy risk from GI severity first.",
+  limping_lethargy_split_module:
+    "Add a bucket-splitting opener for limping plus lethargy that screens perfusion and non-weight-bearing risk first.",
+  polydipsia_weight_loss_module:
+    "Add a drinking-more plus weight-loss opener that separates endocrine, urinary, and intact-female emergency paths earlier.",
+  cough_lethargy_module:
+    "Add a coughing plus tiredness opener that splits respiratory distress from lower-acuity cough characterization.",
+  senior_vague_weakness_module:
+    "Add an older-dog vague-weakness opener that screens responsiveness, breathing, gum color, and last-normal time first.",
 };
-const RED_FLAG_SCREEN_QUESTION_IDS = {
-  active_bleeding_trauma: ["active_bleeding_trauma"],
-  balance_loss: ["balance_issues", "head_tilt"],
-  blue_gums: ["gum_color"],
-  bloody_diarrhea_puppy: ["stool_blood", "blood_amount"],
-  breathing_difficulty: ["breathing_rate", "position_preference"],
-  breathing_onset_sudden: ["breathing_onset"],
-  collapse: ["consciousness_level"],
-  cough_blood: ["cough_type", "cough_timing"],
-  eye_bulging: ["eye_redness", "vision_changes"],
-  eye_swollen_shut: ["squinting", "eye_redness"],
-  face_swelling: ["hives_with_breathing", "skin_changes"],
-  hives_widespread: ["hives_with_breathing", "skin_changes"],
-  inability_to_stand: ["trauma_mobility", "hind_limb_function", "weight_bearing"],
-  large_blood_volume: ["blood_amount", "stool_blood"],
-  no_water_24h: ["water_intake"],
-  non_weight_bearing: ["weight_bearing", "trauma_mobility", "hind_limb_function"],
-  not_drinking: ["water_intake"],
-  pale_gums: ["gum_color"],
-  pyometra_signs: ["spay_status"],
-  rapid_onset_distension: ["abdomen_onset", "restlessness"],
-  rat_poison_confirmed: ["rat_poison_access", "toxin_exposure"],
-  sudden_blindness: ["vision_changes"],
-  sudden_paralysis: ["weight_bearing", "hind_limb_function", "trauma_mobility"],
-  toxin_confirmed: [
-    "toxin_exposure",
-    "reaction_symptoms",
-    "medication_name",
-    "current_medications",
-  ],
-  unproductive_retching: ["unproductive_retching"],
-  unresponsive: ["consciousness_level"],
-  visible_fracture: ["visible_fracture", "trauma_mobility"],
-  wound_bone_visible: ["wound_size", "wound_color"],
-  wound_deep_bleeding: ["wound_discharge", "wound_color", "wound_size"],
-  wound_spreading_rapidly: ["wound_duration", "wound_size", "wound_color"],
-  wound_tissue_exposed: ["wound_size", "wound_color"],
-};
-const RED_FLAG_KEYWORD_ALIASES = {
-  active_bleeding_trauma: ["bleeding", "bleed", "blood"],
-  balance_loss: ["balance", "falling", "wobbly"],
-  blue_gums: ["gum", "gums"],
-  bloody_diarrhea_puppy: ["blood", "bloody"],
-  breathing_difficulty: ["breathing", "breathe", "air"],
-  breathing_onset_sudden: ["started", "sudden", "suddenly", "onset"],
-  collapse: ["responsive", "conscious", "collapse"],
-  cough_blood: ["blood", "bloody"],
-  eye_bulging: ["eye", "bulging", "swollen"],
-  eye_swollen_shut: ["eye", "shut", "swollen"],
-  face_swelling: ["face", "swelling", "swollen"],
-  hives_widespread: ["hives", "widespread", "skin"],
-  inability_to_stand: ["stand", "standing", "walk"],
-  large_blood_volume: ["blood", "amount", "how much"],
-  no_water_24h: ["drink", "water", "drinking"],
-  non_weight_bearing: ["weight", "bearing", "walk", "stand"],
-  not_drinking: ["drink", "water", "drinking"],
-  pale_gums: ["gum", "gums"],
-  pyometra_signs: ["spayed", "spay"],
-  rapid_onset_distension: ["started", "sudden", "swollen", "abdomen", "belly"],
-  rat_poison_confirmed: ["rat poison", "bait", "toxin", "rodenticide"],
-  sudden_blindness: ["vision", "see", "blind"],
-  sudden_paralysis: ["stand", "walk", "legs", "paralysis"],
-  toxin_confirmed: ["toxin", "medication", "poison", "exposure"],
-  unproductive_retching: ["retch", "trying to vomit"],
-  unresponsive: ["responsive", "conscious"],
-  visible_fracture: ["fracture", "broken", "bone"],
-  wound_bone_visible: ["wound", "bone", "deep"],
-  wound_deep_bleeding: ["wound", "bleeding", "blood"],
-  wound_spreading_rapidly: ["spreading", "rapidly", "wound"],
-  wound_tissue_exposed: ["wound", "tissue", "exposed"],
+const QUESTION_SIGNAL_MAP = {
+  abdomen_onset: {
+    questionCategories: ["abdominal_emergency_screen", "gdv_screen", "timeline"],
+    mustScreenTags: ["abdominal_distension"],
+  },
+  active_bleeding_trauma: {
+    questionCategories: ["bleeding_screen"],
+    mustScreenTags: ["active_bleeding"],
+  },
+  appetite_duration: {
+    questionCategories: ["appetite_duration", "timeline"],
+    mustScreenTags: [],
+    missedScreenPattern: "appetite-duration-before-dehydration-screen",
+  },
+  appetite_status: {
+    questionCategories: ["appetite_severity"],
+    mustScreenTags: [],
+  },
+  balance_issues: {
+    questionCategories: ["head_tilt_balance"],
+    mustScreenTags: ["head_tilt_balance", "collapse_or_weakness"],
+  },
+  blood_amount: {
+    questionCategories: ["gi_bleeding_screen"],
+    mustScreenTags: ["bloody_stool_or_vomit"],
+  },
+  blood_color: {
+    questionCategories: ["gi_bleeding_screen"],
+    mustScreenTags: ["bloody_stool_or_vomit"],
+  },
+  blood_in_either: {
+    questionCategories: ["gi_bleeding_screen"],
+    mustScreenTags: ["bloody_stool_or_vomit"],
+  },
+  blood_in_urine: {
+    questionCategories: ["urination_change"],
+    mustScreenTags: [],
+  },
+  breathing_onset: {
+    questionCategories: ["breathing_distress_screen", "timeline"],
+    mustScreenTags: ["breathing_difficulty"],
+  },
+  breathing_rate: {
+    questionCategories: ["breathing_distress_screen"],
+    mustScreenTags: ["breathing_difficulty"],
+  },
+  breathing_status: {
+    questionCategories: ["breathing_distress_screen"],
+    mustScreenTags: ["breathing_difficulty"],
+  },
+  chief_complaint_guess: {
+    questionCategories: ["open_clarification"],
+    mustScreenTags: [],
+    missedScreenPattern: "open-guess-before-safety-screen",
+  },
+  combined_diarrhea_duration: {
+    questionCategories: ["timeline", "vomiting_severity"],
+    mustScreenTags: [],
+    missedScreenPattern: "timeline-before-safety-screen",
+  },
+  combined_vomiting_duration: {
+    questionCategories: ["timeline", "vomiting_severity"],
+    mustScreenTags: [],
+    missedScreenPattern: "timeline-before-safety-screen",
+  },
+  consciousness_level: {
+    questionCategories: ["collapse_screen"],
+    mustScreenTags: ["collapse_or_weakness"],
+  },
+  cough_duration: {
+    questionCategories: ["respiratory_vs_systemic_split", "timeline"],
+    mustScreenTags: [],
+  },
+  cough_type: {
+    questionCategories: ["cough_character", "respiratory_vs_systemic_split"],
+    mustScreenTags: [],
+  },
+  coughing_breathing_onset: {
+    questionCategories: ["breathing_distress_screen", "respiratory_vs_systemic_split"],
+    mustScreenTags: ["breathing_difficulty"],
+  },
+  discharge_color: {
+    questionCategories: ["ocular_discharge_color"],
+    mustScreenTags: [],
+    missedScreenPattern: "discharge-color-before-eye-emergency-screen",
+  },
+  ear_discharge: {
+    questionCategories: ["ear_discharge"],
+    mustScreenTags: [],
+    missedScreenPattern: "ear-detail-before-neuro-screen",
+  },
+  energy_level: {
+    questionCategories: ["vague_weakness_screen", "energy_change"],
+    mustScreenTags: [],
+  },
+  exercise_intolerance: {
+    questionCategories: ["respiratory_vs_systemic_split"],
+    mustScreenTags: [],
+  },
+  eye_redness: {
+    questionCategories: ["eye_emergency_screen"],
+    mustScreenTags: ["eye_swelling"],
+  },
+  gum_color: {
+    questionCategories: ["gum_color_screen"],
+    mustScreenTags: ["pale_or_blue_gums"],
+  },
+  heat_exposure_duration: {
+    questionCategories: ["heat_exposure_screen", "timeline"],
+    mustScreenTags: ["heat_exposure"],
+  },
+  head_tilt: {
+    questionCategories: ["head_tilt_balance"],
+    mustScreenTags: ["head_tilt_balance"],
+  },
+  last_normal: {
+    questionCategories: ["last_normal", "vague_weakness_screen", "timeline"],
+    mustScreenTags: [],
+  },
+  lethargy_duration: {
+    questionCategories: ["energy_change", "timeline"],
+    mustScreenTags: [],
+    missedScreenPattern: "duration-before-shock-screen",
+  },
+  limping_onset: {
+    questionCategories: ["limp_timing", "timeline"],
+    mustScreenTags: [],
+  },
+  medication_name: {
+    questionCategories: ["toxin_screen", "medication_name"],
+    mustScreenTags: ["toxin_exposure"],
+  },
+  position_preference: {
+    questionCategories: ["breathing_distress_screen", "position_preference"],
+    mustScreenTags: ["breathing_difficulty"],
+  },
+  prior_seizures: {
+    questionCategories: ["seizure_history", "bucket_split"],
+    mustScreenTags: [],
+  },
+  question_cards: {
+    questionCategories: [],
+    mustScreenTags: [],
+  },
+  reaction_symptoms: {
+    questionCategories: ["toxin_screen", "symptom_timing"],
+    mustScreenTags: ["toxin_exposure"],
+  },
+  scratch_location: {
+    questionCategories: ["itch_location"],
+    mustScreenTags: [],
+    missedScreenPattern: "itch-location-before-allergy-screen",
+  },
+  seizure_duration: {
+    questionCategories: ["seizure_duration", "collapse_screen", "timeline"],
+    mustScreenTags: ["seizure_activity"],
+  },
+  squinting: {
+    questionCategories: ["eye_emergency_screen", "vision_screen"],
+    mustScreenTags: ["vision_loss_or_eye_trauma", "eye_swelling"],
+  },
+  stool_blood: {
+    questionCategories: ["stool_blood_screen", "gi_bleeding_screen"],
+    mustScreenTags: ["bloody_stool_or_vomit"],
+  },
+  stool_consistency: {
+    questionCategories: ["stool_consistency"],
+    mustScreenTags: [],
+  },
+  straining_present: {
+    questionCategories: ["urinary_obstruction_screen", "urine_output"],
+    mustScreenTags: ["straining_with_no_urine"],
+  },
+  temperature_exposure: {
+    questionCategories: ["heat_exposure_screen", "timeline"],
+    mustScreenTags: ["heat_exposure"],
+  },
+  toxin_exposure: {
+    questionCategories: ["toxin_screen", "symptom_timing"],
+    mustScreenTags: ["toxin_exposure"],
+  },
+  trauma_mechanism: {
+    questionCategories: ["trauma_mechanism", "bite_trauma_history"],
+    mustScreenTags: [],
+  },
+  trauma_mobility: {
+    questionCategories: ["mobility_screen"],
+    mustScreenTags: ["collapse_or_weakness", "non_weight_bearing"],
+  },
+  treats_accepted: {
+    questionCategories: ["appetite_severity"],
+    mustScreenTags: [],
+  },
+  unproductive_retching: {
+    questionCategories: ["gdv_screen", "abdominal_emergency_screen"],
+    mustScreenTags: ["unproductive_retching"],
+  },
+  urination_accidents: {
+    questionCategories: ["urination_change"],
+    mustScreenTags: [],
+  },
+  urination_frequency: {
+    questionCategories: ["urination_change", "urine_output"],
+    mustScreenTags: [],
+    missedScreenPattern: "frequency-before-obstruction-screen",
+  },
+  vision_changes: {
+    questionCategories: ["vision_screen", "eye_emergency_screen"],
+    mustScreenTags: ["vision_loss_or_eye_trauma"],
+  },
+  visible_fracture: {
+    questionCategories: ["fracture_screen", "mobility_screen"],
+    mustScreenTags: ["fracture_or_bone_exposure"],
+  },
+  vomit_duration: {
+    questionCategories: ["vomiting_severity", "timeline"],
+    mustScreenTags: [],
+    missedScreenPattern: "vomit-duration-before-danger-screen",
+  },
+  vomit_frequency: {
+    questionCategories: ["vomiting_severity"],
+    mustScreenTags: ["repeated_vomiting"],
+  },
+  vomiting_present: {
+    questionCategories: ["vomiting_screen"],
+    mustScreenTags: [],
+  },
+  water_amount_change: {
+    questionCategories: ["endocrine_discrimination", "hydration_screen"],
+    mustScreenTags: [],
+  },
+  water_intake: {
+    questionCategories: ["hydration_screen"],
+    mustScreenTags: ["not_drinking"],
+  },
+  weight_bearing: {
+    questionCategories: ["mobility_screen", "weight_bearing"],
+    mustScreenTags: ["non_weight_bearing"],
+  },
+  weight_change: {
+    questionCategories: ["weight_change", "endocrine_discrimination"],
+    mustScreenTags: [],
+  },
+  weight_loss: {
+    questionCategories: ["weight_change"],
+    mustScreenTags: [],
+  },
+  weight_loss_duration: {
+    questionCategories: ["weight_change", "timeline"],
+    mustScreenTags: [],
+  },
+  which_leg: {
+    questionCategories: ["limp_location"],
+    mustScreenTags: [],
+    missedScreenPattern: "limb-location-before-weight-bearing-screen",
+  },
+  wound_color: {
+    questionCategories: ["wound_severity"],
+    mustScreenTags: [],
+  },
+  wound_discharge: {
+    questionCategories: ["wound_severity", "bleeding_screen"],
+    mustScreenTags: ["wound_depth_or_bleeding"],
+  },
+  wound_location: {
+    questionCategories: ["wound_location"],
+    mustScreenTags: [],
+    missedScreenPattern: "location-before-wound-depth-screen",
+  },
+  wound_size: {
+    questionCategories: ["wound_severity"],
+    mustScreenTags: ["wound_depth_or_bleeding"],
+  },
 };
 
 let hooksRegistered = false;
 let runtimePromise = null;
 
-function mean(values) {
-  if (!values.length) return 0;
+function normalizeText(value) {
+  return String(value)
+    .trim()
+    .toLowerCase()
+    .replace(/[_-]+/g, " ")
+    .replace(/[^a-z0-9\s]+/g, "")
+    .replace(/\s+/g, " ");
+}
+
+function uniqueStrings(values) {
+  return [
+    ...new Set(
+      values
+        .filter((value) => value !== null && value !== undefined)
+        .map((value) => String(value).trim())
+        .filter(Boolean)
+    ),
+  ];
+}
+
+function average(values) {
+  if (values.length === 0) return 0;
   return values.reduce((sum, value) => sum + value, 0) / values.length;
 }
 
 function round(value) {
-  return Number(value.toFixed(3));
+  return Number(value.toFixed(2));
 }
 
-function clamp01(value) {
-  return Math.max(0, Math.min(1, value));
+function clampScore(value) {
+  return Math.max(0, Math.min(3, value));
 }
 
-function safeRate(numerator, denominator) {
+function rate(numerator, denominator) {
   if (denominator <= 0) return 0;
   return numerator / denominator;
+}
+
+function formatScore(value) {
+  return `${value.toFixed(2)} / 3.00`;
 }
 
 function formatPercent(value) {
   return `${(value * 100).toFixed(1)}%`;
 }
 
-function normalizeStringArray(value) {
-  if (!Array.isArray(value)) return [];
-  return [...new Set(value.map((item) => String(item).trim()).filter(Boolean))];
-}
-
-function getTextCaseId(rawCase, index) {
-  const value = rawCase.id ?? rawCase.caseId ?? rawCase.slug ?? `case-${index + 1}`;
-  return String(value).trim();
-}
-
 function normalizeCaseDefinition(rawCase, index) {
   if (!rawCase || typeof rawCase !== "object") {
-    throw new Error(`Fixture case at index ${index} must be an object`);
+    throw new Error(`Case at index ${index} must be an object`);
   }
 
-  const id = getTextCaseId(rawCase, index);
-  const symptomKeys = normalizeStringArray(
-    rawCase.symptomKeys ?? rawCase.symptoms ?? rawCase.knownSymptoms
+  const id = String(rawCase.id ?? "").trim() || `case-${index + 1}`;
+  const category = String(rawCase.category ?? "").trim();
+  const complaintFamily = String(rawCase.complaintFamily ?? "").trim();
+  const initialMessage = String(rawCase.initialMessage ?? "").trim();
+  const expectedUrgency = String(rawCase.expectedUrgency ?? "").trim();
+  const expectedMustScreen = uniqueStrings(rawCase.expectedMustScreen ?? []);
+  const badFirstQuestions = uniqueStrings(rawCase.badFirstQuestions ?? []);
+  const idealQuestionCategories = uniqueStrings(
+    rawCase.idealQuestionCategories ?? []
   );
-  const turnFocusSymptoms = normalizeStringArray(
-    rawCase.turnFocusSymptoms ??
-      rawCase.focusSymptoms ??
-      rawCase.preferredSymptoms ??
-      rawCase.turn_focus_symptoms
-  );
-  const redFlags = normalizeStringArray(
-    rawCase.redFlags ?? rawCase.expectedRedFlags ?? rawCase.emergencySignals
-  );
-  const tags = normalizeStringArray(rawCase.tags);
-  const expectedQuestionIds = normalizeStringArray(
-    rawCase.expectedQuestionIds ?? rawCase.expectedQuestionId
-  );
-  const recommendedModules = normalizeStringArray(
-    rawCase.recommendedModules ?? rawCase.modules
-  );
+  const symptomKeys = uniqueStrings(rawCase.symptomKeys ?? []);
+  const turnFocusSymptoms = uniqueStrings(rawCase.turnFocusSymptoms ?? []);
+  const recommendedFirstModule = String(
+    rawCase.recommendedFirstModule ?? ""
+  ).trim();
+  const pet = rawCase.pet ?? {};
 
+  if (!category) throw new Error(`Case "${id}" is missing category`);
+  if (!complaintFamily) throw new Error(`Case "${id}" is missing complaintFamily`);
+  if (!initialMessage) throw new Error(`Case "${id}" is missing initialMessage`);
+  if (!expectedUrgency) throw new Error(`Case "${id}" is missing expectedUrgency`);
+  if (expectedMustScreen.length === 0) {
+    throw new Error(`Case "${id}" must include expectedMustScreen`);
+  }
+  if (badFirstQuestions.length === 0) {
+    throw new Error(`Case "${id}" must include badFirstQuestions`);
+  }
+  if (idealQuestionCategories.length === 0) {
+    throw new Error(`Case "${id}" must include idealQuestionCategories`);
+  }
   if (symptomKeys.length === 0) {
-    throw new Error(`Fixture case "${id}" must include at least one symptom key`);
+    throw new Error(`Case "${id}" must include symptomKeys for deterministic replay`);
   }
 
   return {
     id,
+    category,
+    complaintFamily,
+    pet: {
+      species: String(pet.species ?? "").trim(),
+      breed: String(pet.breed ?? "").trim(),
+      ageYears: Number(pet.ageYears),
+      weightLbs: Number(pet.weightLbs),
+      sexNeuter: String(pet.sexNeuter ?? "").trim(),
+    },
+    initialMessage,
+    expectedMustScreen,
+    badFirstQuestions,
+    idealQuestionCategories,
+    expectedUrgency,
     symptomKeys,
     turnFocusSymptoms,
-    concernBucket: rawCase.concernBucket ?? rawCase.expectedConcernBucket ?? null,
-    emergency:
-      Boolean(rawCase.emergency) ||
-      Boolean(rawCase.mustScreenEmergency) ||
-      Boolean(rawCase.mustScreenUrgent) ||
-      redFlags.length > 0,
-    redFlags,
-    expectedQuestionIds,
-    recommendedModules,
-    tags,
-    notes: rawCase.notes ? String(rawCase.notes) : null,
+    recommendedFirstModule,
   };
+}
+
+function countByCategory(cases) {
+  return cases.reduce((counts, caseDefinition) => {
+    counts[caseDefinition.category] = (counts[caseDefinition.category] ?? 0) + 1;
+    return counts;
+  }, {});
+}
+
+function validateCaseSet(cases) {
+  if (cases.length < 150) {
+    throw new Error(`Expected at least 150 question-quality cases, found ${cases.length}`);
+  }
+
+  const categoryCounts = countByCategory(cases);
+  for (const [category, minimum] of Object.entries(REQUIRED_CATEGORY_MINIMUMS)) {
+    if ((categoryCounts[category] ?? 0) < minimum) {
+      throw new Error(
+        `Expected at least ${minimum} ${category} cases, found ${categoryCounts[category] ?? 0}`
+      );
+    }
+  }
+
+  const complaintFamilies = new Set(cases.map((caseDefinition) => caseDefinition.complaintFamily));
+  for (const complaintFamily of REQUIRED_COMPLAINT_FAMILIES) {
+    if (!complaintFamilies.has(complaintFamily)) {
+      throw new Error(`Missing required complaintFamily "${complaintFamily}"`);
+    }
+  }
+
+  for (const caseDefinition of cases) {
+    if (caseDefinition.pet.species !== "dog") {
+      throw new Error(`Case "${caseDefinition.id}" must be dog-only`);
+    }
+  }
 }
 
 function loadCases(fixturePath = FIXTURE_PATH) {
@@ -261,7 +655,11 @@ function loadCases(fixturePath = FIXTURE_PATH) {
     );
   }
 
-  return rawCases.map((rawCase, index) => normalizeCaseDefinition(rawCase, index));
+  const cases = rawCases.map((rawCase, index) =>
+    normalizeCaseDefinition(rawCase, index)
+  );
+  validateCaseSet(cases);
+  return cases;
 }
 
 function registerTypeScriptHooks() {
@@ -380,7 +778,6 @@ async function loadQuestionRuntime() {
         getNextQuestionAvoidingRepeat:
           questionSelection.getNextQuestionAvoidingRepeat,
         FOLLOW_UP_QUESTIONS: clinicalMatrix.FOLLOW_UP_QUESTIONS,
-        SYMPTOM_MAP: clinicalMatrix.SYMPTOM_MAP,
       };
     });
   })();
@@ -388,269 +785,312 @@ async function loadQuestionRuntime() {
   return runtimePromise;
 }
 
-function questionUsesGenericPattern(questionText) {
+function inferSignalsFromQuestionText(questionText) {
+  const lower = questionText.toLowerCase();
+  const questionCategories = [];
+  const mustScreenTags = [];
+
+  if (lower.includes("gum")) {
+    questionCategories.push("gum_color_screen");
+    mustScreenTags.push("pale_or_blue_gums");
+  }
+  if (lower.includes("breathe") || lower.includes("breathing")) {
+    questionCategories.push("breathing_distress_screen");
+    mustScreenTags.push("breathing_difficulty");
+  }
+  if (lower.includes("collapse") || lower.includes("responsive")) {
+    questionCategories.push("collapse_screen");
+    mustScreenTags.push("collapse_or_weakness");
+  }
+  if (lower.includes("seizure")) {
+    questionCategories.push("seizure_duration");
+    mustScreenTags.push("seizure_activity");
+  }
+  if (lower.includes("retch") || lower.includes("abdomen") || lower.includes("belly")) {
+    questionCategories.push("abdominal_emergency_screen");
+    mustScreenTags.push("abdominal_distension");
+  }
+  if (lower.includes("poison") || lower.includes("toxin") || lower.includes("medication")) {
+    questionCategories.push("toxin_screen");
+    mustScreenTags.push("toxin_exposure");
+  }
+  if (lower.includes("urinate") || lower.includes("pee") || lower.includes("urine")) {
+    questionCategories.push("urinary_obstruction_screen");
+    mustScreenTags.push("straining_with_no_urine");
+  }
+  if (lower.includes("heat") || lower.includes("hot car") || lower.includes("sun")) {
+    questionCategories.push("heat_exposure_screen");
+    mustScreenTags.push("heat_exposure");
+  }
+  if (lower.includes("blood")) {
+    questionCategories.push("gi_bleeding_screen");
+    mustScreenTags.push("bloody_stool_or_vomit");
+  }
+  if (lower.includes("vision") || lower.includes("eye")) {
+    questionCategories.push("eye_emergency_screen");
+    mustScreenTags.push("vision_loss_or_eye_trauma");
+  }
+  if (lower.includes("weight") && lower.includes("leg")) {
+    questionCategories.push("mobility_screen");
+    mustScreenTags.push("non_weight_bearing");
+  }
+  if (lower.includes("wound") || lower.includes("bite")) {
+    questionCategories.push("wound_severity");
+    mustScreenTags.push("wound_depth_or_bleeding");
+  }
+
+  if (lower.startsWith("when ") || lower.startsWith("how long")) {
+    questionCategories.push("timeline");
+  }
+  if (lower.includes("what color")) {
+    questionCategories.push("detail_question");
+  }
+  if (lower.includes("which leg") || lower.includes("where is")) {
+    questionCategories.push("location_question");
+  }
+  if (lower.includes("best guess")) {
+    questionCategories.push("open_clarification");
+  }
+
+  return {
+    questionCategories: uniqueStrings(questionCategories),
+    mustScreenTags: uniqueStrings(mustScreenTags),
+  };
+}
+
+function getQuestionSignals(questionId, questionText) {
+  const mappedSignals = QUESTION_SIGNAL_MAP[questionId] ?? {
+    questionCategories: [],
+    mustScreenTags: [],
+  };
+  const inferredSignals = inferSignalsFromQuestionText(questionText);
+
+  return {
+    questionCategories: uniqueStrings([
+      ...(mappedSignals.questionCategories ?? []),
+      ...inferredSignals.questionCategories,
+    ]),
+    mustScreenTags: uniqueStrings([
+      ...(mappedSignals.mustScreenTags ?? []),
+      ...inferredSignals.mustScreenTags,
+    ]),
+    missedScreenPattern: mappedSignals.missedScreenPattern ?? null,
+  };
+}
+
+function isGenericQuestion(questionText, badFirstQuestions, questionCategories) {
   if (!questionText) return true;
-  return GENERIC_QUESTION_PATTERNS.some((pattern) => pattern.test(questionText));
-}
 
-function questionHasDiscriminativeSignal(questionText) {
-  return DISCRIMINATIVE_QUESTION_PATTERNS.some((pattern) => pattern.test(questionText));
-}
-
-function normalizeFlagTokens(value) {
-  return String(value)
-    .toLowerCase()
-    .replace(/[_-]+/g, " ")
-    .split(/\s+/)
-    .map((token) => token.replace(/s$/u, ""))
-    .filter((token) => token.length >= 3);
-}
-
-function questionScreensRedFlag(questionId, questionText, redFlag) {
-  if (!questionId || !questionText || !redFlag) {
-    return false;
-  }
-
-  if (questionId === redFlag) {
+  const normalizedQuestion = normalizeText(questionText);
+  if (
+    badFirstQuestions.some(
+      (badQuestion) => normalizeText(badQuestion) === normalizedQuestion
+    )
+  ) {
     return true;
   }
 
-  const aliasQuestionIds = RED_FLAG_SCREEN_QUESTION_IDS[redFlag] ?? [];
-  if (aliasQuestionIds.includes(questionId)) {
+  if (GENERIC_QUESTION_PATTERNS.some((pattern) => pattern.test(questionText))) {
     return true;
   }
 
-  const lowerText = questionText.toLowerCase();
-  const questionTokens = new Set([
-    ...normalizeFlagTokens(questionId),
-    ...normalizeFlagTokens(questionText),
-  ]);
-  const redFlagTokens = normalizeFlagTokens(redFlag);
-  const keywordAliases = RED_FLAG_KEYWORD_ALIASES[redFlag] ?? [];
-
-  if (keywordAliases.some((keyword) => lowerText.includes(keyword.toLowerCase()))) {
-    return true;
-  }
-
-  return redFlagTokens.some((token) => questionTokens.has(token));
+  return questionCategories.includes("open_clarification");
 }
 
-function getRelevantRedFlags(caseDefinition, focusSymptoms, symptomMap) {
-  if (caseDefinition.redFlags.length > 0) {
-    return caseDefinition.redFlags;
-  }
-
-  return [...new Set(
-    focusSymptoms.flatMap((symptom) => symptomMap[symptom]?.red_flags ?? [])
-  )];
-}
-
-function scoreSpecificity({
+function scoreQuestionSpecificity(
   questionDef,
-  questionId,
-  questionText,
-  generic,
-  focusMatchCount,
-}) {
-  if (!questionId || !questionDef || !questionText) return 0;
-
-  let score = 0.3;
-  if (!generic) score += 0.2;
-  if (questionDef.critical) score += 0.15;
-  if (questionDef.data_type !== "string") score += 0.15;
-  if (questionHasDiscriminativeSignal(questionText)) score += 0.15;
-  if (focusMatchCount > 0) score += 0.1;
-  if (Array.isArray(questionDef.choices) && questionDef.choices.length > 0) {
-    score += 0.05;
-  }
-
-  return clamp01(score);
-}
-
-function scoreUrgencyValue({
-  questionDef,
-  isEmergencyCase,
-  emergencyScreened,
-  generic,
-  focusPriority,
-}) {
+  isGeneric,
+  idealCategoryHits,
+  mustScreenHits,
+  questionCategories
+) {
   if (!questionDef) return 0;
+  if (isGeneric) return 0;
 
-  if (isEmergencyCase || focusPriority >= 8) {
-    if (questionDef.critical && emergencyScreened) return 1;
-    if (emergencyScreened) return 0.8;
-    if (questionDef.critical) return 0.45;
-    return generic ? 0.1 : 0.25;
+  let score = 1;
+  if (questionDef.data_type !== "string" || questionCategories.length > 0) {
+    score += 1;
+  }
+  if (idealCategoryHits.length > 0 || mustScreenHits.length > 0) {
+    score += 1;
   }
 
-  if (questionDef.critical) return 0.95;
-  if (generic) return 0.55;
-  return 0.8;
+  return clampScore(score);
 }
 
-function scoreRedFlagCoverage(relevantRedFlags, coveredRedFlags, questionDef) {
+function scoreUrgencyChangingValue(questionDef, mustScreenHits, questionCategories) {
   if (!questionDef) return 0;
-  if (relevantRedFlags.length === 0) {
-    return questionDef.critical ? 1 : 0.8;
+  if (mustScreenHits.length > 0) return 3;
+  if (
+    questionDef.critical ||
+    questionCategories.some((category) => CRITICAL_QUESTION_CATEGORIES.has(category))
+  ) {
+    return 2;
   }
-
-  return coveredRedFlags.length / relevantRedFlags.length;
+  if (questionCategories.length > 0) return 1;
+  return 0;
 }
 
-function scoreConcernBucketDiscrimination({
-  questionId,
-  questionText,
-  focusMatchCount,
-  focusSymptoms,
-  sessionFocusFollowUpCount,
-  generic,
-}) {
-  if (!questionId || !questionText) return 0;
-
-  let score = generic ? 0.2 : 0.4;
-  if (focusMatchCount > 0) score += 0.25;
-  if (focusSymptoms.length > 1 && focusMatchCount === 1) score += 0.15;
-  if (sessionFocusFollowUpCount <= 3) score += 0.1;
-  if (questionHasDiscriminativeSignal(questionText)) score += 0.1;
-
-  return clamp01(score);
-}
-
-function scoreOwnerAnswerability(questionDef, questionText) {
-  if (!questionDef || !questionText) return 0;
-
-  const dataTypeScore = {
-    boolean: 0.95,
-    choice: 0.9,
-    number: 0.85,
-    string: 0.75,
-  }[questionDef.data_type] ?? 0.7;
-
-  let score = dataTypeScore;
-  const wordCount = questionText.trim().split(/\s+/).filter(Boolean).length;
-  if (wordCount > 18) score -= 0.15;
-  if (OWNER_JARGON_PATTERNS.some((pattern) => pattern.test(questionText))) {
-    score -= 0.2;
-  }
-  if (/^(is|are|has|have|did|does|when|how long|how often|what color|which)\b/i.test(questionText)) {
-    score += 0.05;
-  }
-
-  return clamp01(score);
-}
-
-function scoreReportValue(questionDef, questionText, generic) {
-  if (!questionDef || !questionText) return 0;
-
-  let score = {
-    choice: 0.95,
-    boolean: 0.9,
-    number: 0.85,
-    string: 0.7,
-  }[questionDef.data_type] ?? 0.7;
-
-  if (questionDef.critical) score += 0.05;
-  if (String(questionDef.extraction_hint ?? "").trim().length >= 10) score += 0.05;
-  if (generic) score -= 0.25;
-
-  return clamp01(score);
-}
-
-function buildWeakPatterns({
+function scoreEmergencyRedFlagCoverage(
   caseDefinition,
-  generic,
-  questionId,
-  questionText,
-  categories,
-  repeated,
-  missedRedFlags,
-  emergencyMiss,
-}) {
-  const weakPatterns = [];
+  mustScreenHits,
+  questionDef,
+  questionCategories
+) {
+  if (!questionDef) return 0;
+  if (caseDefinition.expectedMustScreen.length === 0) return 3;
+  if (mustScreenHits.includes(caseDefinition.expectedMustScreen[0])) return 3;
+  if (mustScreenHits.length > 0) return 2;
+  if (
+    questionDef.critical ||
+    questionCategories.some((category) => CRITICAL_QUESTION_CATEGORIES.has(category))
+  ) {
+    return 1;
+  }
+  return 0;
+}
 
+function scoreConcernBucketDiscrimination(questionDef, idealCategoryHits, questionCategories) {
+  if (!questionDef) return 0;
+  if (
+    idealCategoryHits.length > 0 &&
+    questionCategories.some((category) => DISCRIMINATIVE_CATEGORIES.has(category))
+  ) {
+    return 3;
+  }
+  if (idealCategoryHits.length > 0) return 2;
+  if (questionCategories.length > 0) return 1;
+  return 0;
+}
+
+function scoreOwnerAnswerability(questionDef, questionText, questionCategories) {
+  if (!questionDef || !questionText) return 0;
+
+  if (
+    questionCategories.includes("open_clarification") ||
+    OWNER_JARGON_PATTERNS.some((pattern) => pattern.test(questionText))
+  ) {
+    return 1;
+  }
+
+  if (
+    questionDef.data_type === "boolean" ||
+    questionDef.data_type === "choice" ||
+    questionDef.data_type === "number"
+  ) {
+    return 3;
+  }
+
+  const wordCount = questionText.split(/\s+/).filter(Boolean).length;
+  return wordCount <= 18 ? 2 : 1;
+}
+
+function scoreRepeatedQuestionBehavior(repeated) {
+  return repeated ? 0 : 3;
+}
+
+function scoreGenericWording(isGeneric, questionCategories, idealCategoryHits, mustScreenHits) {
+  if (isGeneric) return 0;
+  if (questionCategories.includes("open_clarification")) return 1;
+  if (idealCategoryHits.length > 0 || mustScreenHits.length > 0) return 3;
+  return 2;
+}
+
+function scoreReportUsefulnessValue(
+  questionDef,
+  questionCategories,
+  idealCategoryHits,
+  mustScreenHits
+) {
+  if (!questionDef) return 0;
+  if (
+    (questionDef.data_type === "boolean" ||
+      questionDef.data_type === "choice" ||
+      questionDef.data_type === "number") &&
+    (idealCategoryHits.length > 0 ||
+      mustScreenHits.length > 0 ||
+      questionCategories.some((category) => REPORT_STRONG_CATEGORIES.has(category)))
+  ) {
+    return 3;
+  }
+  if (
+    questionCategories.some((category) => REPORT_STRONG_CATEGORIES.has(category)) ||
+    idealCategoryHits.length > 0
+  ) {
+    return 2;
+  }
+  if (questionCategories.includes("open_clarification")) return 1;
+  return 1;
+}
+
+function buildWeakPatternLabel(questionId, questionSignals, mustScreenMiss, isGeneric) {
+  if (isGeneric) {
+    return "generic-first-question";
+  }
+
+  if (!mustScreenMiss) {
+    return null;
+  }
+
+  if (questionSignals.missedScreenPattern) {
+    return questionSignals.missedScreenPattern;
+  }
+
+  if (
+    questionSignals.questionCategories.some((category) =>
+      OPEN_FIRST_CATEGORIES.has(category)
+    )
+  ) {
+    return "open-clarification-before-safety-screen";
+  }
+  if (
+    questionSignals.questionCategories.some((category) =>
+      LOCATION_FIRST_CATEGORIES.has(category)
+    )
+  ) {
+    return "location-before-safety-screen";
+  }
+  if (
+    questionSignals.questionCategories.some((category) =>
+      DETAIL_FIRST_CATEGORIES.has(category)
+    )
+  ) {
+    return "detail-before-safety-screen";
+  }
+  if (
+    questionSignals.questionCategories.some((category) =>
+      TIMELINE_FIRST_CATEGORIES.has(category)
+    )
+  ) {
+    return "timeline-before-safety-screen";
+  }
   if (!questionId) {
-    weakPatterns.push("no-question-selected");
-    return weakPatterns;
+    return "no-first-question";
   }
-
-  if (generic) weakPatterns.push("generic-question");
-  if (categories.specificity < 0.7) weakPatterns.push("low-specificity");
-  if (categories.urgencyValue < 0.7) weakPatterns.push("low-urgency-value");
-  if (categories.redFlagCoverage < 0.75) weakPatterns.push("weak-red-flag-coverage");
-  if (categories.concernBucketDiscrimination < 0.75) {
-    weakPatterns.push("weak-concern-bucket-discrimination");
-  }
-  if (categories.ownerAnswerability < 0.75) {
-    weakPatterns.push("low-owner-answerability");
-  }
-  if (categories.reportValue < 0.75) weakPatterns.push("low-report-value");
-  if (repeated) weakPatterns.push("repeat-guard-failure");
-  if (
-    caseDefinition.expectedQuestionIds.length > 0 &&
-    !caseDefinition.expectedQuestionIds.includes(questionId)
-  ) {
-    weakPatterns.push("unexpected-question-selection");
-  }
-  if (emergencyMiss) weakPatterns.push("missed-emergency-screen");
-  for (const redFlag of missedRedFlags) {
-    weakPatterns.push(`missed-red-flag:${redFlag}`);
-  }
-  if (!questionText.trim()) weakPatterns.push("empty-question-text");
-
-  return weakPatterns;
+  return "missed-first-emergency-screen";
 }
 
-function buildRecommendedModules(caseResult) {
-  const modules = [];
+function addFrequencyEntry(map, key, caseDefinition, questionId) {
+  if (!key) return;
 
-  if (caseResult.generic || caseResult.categories.specificity < 0.7) {
-    modules.push("question_specificity");
-  }
-  if (caseResult.emergencyMiss || caseResult.categories.urgencyValue < 0.7) {
-    modules.push("emergency_screening");
-  }
-  if (caseResult.categories.redFlagCoverage < 0.75) {
-    modules.push("red_flag_coverage");
-  }
-  if (caseResult.categories.concernBucketDiscrimination < 0.75) {
-    modules.push("concern_bucket_discrimination");
-  }
-  if (caseResult.categories.ownerAnswerability < 0.75) {
-    modules.push("owner_answerability");
-  }
-  if (caseResult.categories.reportValue < 0.75) {
-    modules.push("report_structure");
-  }
-  if (caseResult.repeated) {
-    modules.push("repeat_guard");
-  }
-  if (
-    caseResult.caseDefinition.expectedQuestionIds.length > 0 &&
-    !caseResult.caseDefinition.expectedQuestionIds.includes(caseResult.questionId)
-  ) {
-    modules.push("question_selection_alignment");
-  }
-
-  return [...new Set([...modules, ...caseResult.caseDefinition.recommendedModules])];
-}
-
-function createFrequencyMap() {
-  return new Map();
-}
-
-function addFrequencyEntry(map, key, caseId, extra) {
-  const current = map.get(key) ?? { count: 0, cases: [], extras: new Set() };
+  const current = map.get(key) ?? {
+    count: 0,
+    cases: [],
+    complaintFamilies: new Set(),
+    questionIds: new Set(),
+  };
   current.count += 1;
-  if (current.cases.length < 5 && !current.cases.includes(caseId)) {
-    current.cases.push(caseId);
+  if (current.cases.length < 5 && !current.cases.includes(caseDefinition.id)) {
+    current.cases.push(caseDefinition.id);
   }
-  if (extra) {
-    current.extras.add(extra);
+  current.complaintFamilies.add(caseDefinition.complaintFamily);
+  if (questionId) {
+    current.questionIds.add(questionId);
   }
   map.set(key, current);
 }
 
-function summarizeFrequencyMap(map, limit, formatter) {
+function summarizeFrequencyMap(map, limit, labelKey) {
   return [...map.entries()]
     .sort((left, right) => {
       if (right[1].count !== left[1].count) {
@@ -659,234 +1099,264 @@ function summarizeFrequencyMap(map, limit, formatter) {
       return String(left[0]).localeCompare(String(right[0]));
     })
     .slice(0, limit)
-    .map(([key, entry]) => formatter(key, entry));
+    .map(([label, entry]) => ({
+      [labelKey]: label,
+      count: entry.count,
+      cases: entry.cases,
+      complaintFamilies: [...entry.complaintFamilies].sort(),
+      questionIds: [...entry.questionIds].sort(),
+    }));
 }
 
 function evaluateCase(caseDefinition, runtime) {
-  const session = runtime.addSymptoms(
-    runtime.createSession(),
-    caseDefinition.symptomKeys
-  );
-  const focusSymptoms =
+  let session = runtime.createSession();
+  session = runtime.addSymptoms(session, caseDefinition.symptomKeys);
+
+  const preferredSymptoms =
     caseDefinition.turnFocusSymptoms.length > 0
       ? caseDefinition.turnFocusSymptoms
       : caseDefinition.symptomKeys;
-  const questionId = runtime.getNextQuestionAvoidingRepeat(session, focusSymptoms);
+  const questionId = runtime.getNextQuestionAvoidingRepeat(
+    session,
+    preferredSymptoms
+  );
   const questionText = questionId ? runtime.getQuestionText(questionId) : "";
   const questionDef = questionId ? runtime.FOLLOW_UP_QUESTIONS[questionId] ?? null : null;
-  const generic = questionUsesGenericPattern(questionText);
-  const relevantRedFlags = getRelevantRedFlags(
-    caseDefinition,
-    focusSymptoms,
-    runtime.SYMPTOM_MAP
+  const questionSignals = getQuestionSignals(questionId, questionText);
+  const mustScreenHits = caseDefinition.expectedMustScreen.filter((tag) =>
+    questionSignals.mustScreenTags.includes(tag)
   );
-  const coveredRedFlags = relevantRedFlags.filter((redFlag) =>
-    questionScreensRedFlag(questionId, questionText, redFlag)
+  const missedMustScreen = caseDefinition.expectedMustScreen.filter(
+    (tag) => !mustScreenHits.includes(tag)
   );
-  const missedRedFlags = relevantRedFlags.filter(
-    (redFlag) => !coveredRedFlags.includes(redFlag)
+  const idealCategoryHits = caseDefinition.idealQuestionCategories.filter((tag) =>
+    questionSignals.questionCategories.includes(tag)
   );
-  const focusEntries = focusSymptoms
-    .map((symptom) => runtime.SYMPTOM_MAP[symptom])
-    .filter(Boolean);
-  const focusPriority = Math.max(
-    0,
-    ...focusSymptoms.map((symptom) => runtime.getSymptomPriorityScore(symptom))
+  const isGeneric = isGenericQuestion(
+    questionText,
+    caseDefinition.badFirstQuestions,
+    questionSignals.questionCategories
   );
-  const focusMatchCount = focusSymptoms.filter((symptom) =>
-    runtime.SYMPTOM_MAP[symptom]?.follow_up_questions?.includes(questionId)
-  ).length;
-  const sessionFocusFollowUpCount = new Set(
-    focusEntries.flatMap((entry) => entry.follow_up_questions ?? [])
-  ).size;
-  const isEmergencyCase =
-    caseDefinition.emergency || relevantRedFlags.length > 0 || focusPriority >= 8;
-  const emergencyScreened =
-    Boolean(questionDef?.critical) || coveredRedFlags.length > 0;
-
   const repeated = Boolean(questionId) && (() => {
-    const answeredQuestions = [...session.answered_questions];
-    if (!answeredQuestions.includes(questionId)) {
-      answeredQuestions.push(questionId);
-    }
     const replaySession = {
       ...session,
-      answered_questions: answeredQuestions,
+      answered_questions: session.answered_questions.includes(questionId)
+        ? [...session.answered_questions]
+        : [...session.answered_questions, questionId],
       last_question_asked: questionId,
     };
     return (
-      runtime.getNextQuestionAvoidingRepeat(replaySession, focusSymptoms) === questionId
+      runtime.getNextQuestionAvoidingRepeat(replaySession, preferredSymptoms) ===
+      questionId
     );
   })();
 
-  const categories = {
-    specificity: round(
-      scoreSpecificity({
-        questionDef,
-        questionId,
-        questionText,
-        generic,
-        focusMatchCount,
-      })
+  const scores = {
+    questionSpecificity: scoreQuestionSpecificity(
+      questionDef,
+      isGeneric,
+      idealCategoryHits,
+      mustScreenHits,
+      questionSignals.questionCategories
     ),
-    urgencyValue: round(
-      scoreUrgencyValue({
-        questionDef,
-        isEmergencyCase,
-        emergencyScreened,
-        generic,
-        focusPriority,
-      })
+    urgencyChangingValue: scoreUrgencyChangingValue(
+      questionDef,
+      mustScreenHits,
+      questionSignals.questionCategories
     ),
-    redFlagCoverage: round(
-      scoreRedFlagCoverage(relevantRedFlags, coveredRedFlags, questionDef)
+    emergencyRedFlagCoverage: scoreEmergencyRedFlagCoverage(
+      caseDefinition,
+      mustScreenHits,
+      questionDef,
+      questionSignals.questionCategories
     ),
-    concernBucketDiscrimination: round(
-      scoreConcernBucketDiscrimination({
-        questionId,
-        questionText,
-        focusMatchCount,
-        focusSymptoms,
-        sessionFocusFollowUpCount,
-        generic,
-      })
+    concernBucketDiscrimination: scoreConcernBucketDiscrimination(
+      questionDef,
+      idealCategoryHits,
+      questionSignals.questionCategories
     ),
-    ownerAnswerability: round(scoreOwnerAnswerability(questionDef, questionText)),
-    reportValue: round(scoreReportValue(questionDef, questionText, generic)),
-    repetitionSafety: repeated ? 0 : 1,
+    ownerAnswerability: scoreOwnerAnswerability(
+      questionDef,
+      questionText,
+      questionSignals.questionCategories
+    ),
+    repeatedQuestionBehavior: scoreRepeatedQuestionBehavior(repeated),
+    genericWording: scoreGenericWording(
+      isGeneric,
+      questionSignals.questionCategories,
+      idealCategoryHits,
+      mustScreenHits
+    ),
+    reportUsefulnessValue: scoreReportUsefulnessValue(
+      questionDef,
+      questionSignals.questionCategories,
+      idealCategoryHits,
+      mustScreenHits
+    ),
   };
 
-  const overallScore = round(mean(CATEGORY_KEYS.map((key) => categories[key])));
-  const emergencyMiss = Boolean(isEmergencyCase && !emergencyScreened);
-  const weakPatterns = buildWeakPatterns({
-    caseDefinition,
-    generic,
-    questionId,
-    questionText,
-    categories,
-    repeated,
-    missedRedFlags,
-    emergencyMiss,
-  });
-
-  const caseResult = {
-    caseDefinition,
-    questionId,
-    questionText,
-    questionDef,
-    categories,
-    overallScore,
-    generic,
-    repeated,
-    focusPriority,
-    isEmergencyCase,
-    emergencyScreened,
-    emergencyMiss,
-    relevantRedFlags,
-    coveredRedFlags,
-    missedRedFlags,
-    weakPatterns,
-  };
+  const averageScore = round(average(CATEGORY_KEYS.map((key) => scores[key])));
+  const mustScreenMiss = mustScreenHits.length === 0;
+  const weakPatterns = uniqueStrings([
+    buildWeakPatternLabel(questionId, questionSignals, mustScreenMiss, isGeneric),
+    mustScreenMiss ? "no-first-screen-hit" : null,
+    repeated ? "repeat-question-risk" : null,
+    idealCategoryHits.length === 0 ? "off-ideal-first-question" : null,
+    scores.questionSpecificity <= 1 ? "low-specificity-first-question" : null,
+    scores.reportUsefulnessValue <= 1 ? "low-report-value-first-question" : null,
+  ]);
 
   return {
-    ...caseResult,
-    recommendedModules: buildRecommendedModules(caseResult),
+    caseDefinition,
+    questionId,
+    questionText,
+    questionCategories: questionSignals.questionCategories,
+    mustScreenHits,
+    missedMustScreen,
+    idealCategoryHits,
+    isGeneric,
+    repeated,
+    scores,
+    averageScore,
+    weakPatterns,
   };
 }
 
-function aggregateResults(caseResults) {
-  const emergencyCaseCount = caseResults.filter(
-    (result) => result.isEmergencyCase
-  ).length;
-  const categoryScores = Object.fromEntries(
-    CATEGORY_KEYS.map((key) => [
-      key,
-      round(mean(caseResults.map((result) => result.categories[key]))),
-    ])
-  );
-  const weakPatternMap = createFrequencyMap();
-  const missedRedFlagMap = createFrequencyMap();
-  const recommendedModuleMap = createFrequencyMap();
+function summarizeComplaintFamilies(caseResults) {
+  const grouped = new Map();
+
+  for (const result of caseResults) {
+    const complaintFamily = result.caseDefinition.complaintFamily;
+    const current = grouped.get(complaintFamily) ?? {
+      count: 0,
+      totalScore: 0,
+      weakCases: 0,
+      missedScreens: 0,
+      genericCases: 0,
+      questionIds: new Set(),
+      recommendedFirstModule: result.caseDefinition.recommendedFirstModule,
+    };
+    current.count += 1;
+    current.totalScore += result.averageScore;
+    current.weakCases += result.averageScore < 2 ? 1 : 0;
+    current.missedScreens += result.mustScreenHits.length === 0 ? 1 : 0;
+    current.genericCases += result.isGeneric ? 1 : 0;
+    if (result.questionId) {
+      current.questionIds.add(result.questionId);
+    }
+    grouped.set(complaintFamily, current);
+  }
+
+  return [...grouped.entries()]
+    .map(([complaintFamily, entry]) => ({
+      complaintFamily,
+      averageScore: round(entry.totalScore / entry.count),
+      count: entry.count,
+      weakCases: entry.weakCases,
+      missedScreens: entry.missedScreens,
+      genericCases: entry.genericCases,
+      questionIds: [...entry.questionIds].sort(),
+      recommendedFirstModule: entry.recommendedFirstModule,
+    }))
+    .sort((left, right) => {
+      if (left.averageScore !== right.averageScore) {
+        return left.averageScore - right.averageScore;
+      }
+      return right.missedScreens - left.missedScreens;
+    });
+}
+
+function summarizeRecommendedModules(complaintFamilySummaries) {
+  const moduleMap = new Map();
+
+  for (const summary of complaintFamilySummaries) {
+    if (summary.averageScore >= 2 && summary.missedScreens === 0) {
+      continue;
+    }
+
+    const moduleId = summary.recommendedFirstModule;
+    if (!moduleId) continue;
+
+    const current = moduleMap.get(moduleId) ?? {
+      count: 0,
+      complaintFamilies: [],
+      weakestScore: 3,
+    };
+    current.count += summary.weakCases > 0 ? summary.weakCases : summary.count;
+    if (!current.complaintFamilies.includes(summary.complaintFamily)) {
+      current.complaintFamilies.push(summary.complaintFamily);
+    }
+    current.weakestScore = Math.min(current.weakestScore, summary.averageScore);
+    moduleMap.set(moduleId, current);
+  }
+
+  return [...moduleMap.entries()]
+    .map(([moduleId, entry]) => ({
+      moduleId,
+      count: entry.count,
+      weakestScore: round(entry.weakestScore),
+      complaintFamilies: entry.complaintFamilies.sort(),
+      description: MODULE_DESCRIPTIONS[moduleId] || "No description available.",
+    }))
+    .sort((left, right) => {
+      if (right.count !== left.count) {
+        return right.count - left.count;
+      }
+      return left.weakestScore - right.weakestScore;
+    });
+}
+
+function aggregateResults(cases, caseResults) {
+  const weakPatternMap = new Map();
+  const missedScreenMap = new Map();
 
   for (const result of caseResults) {
     for (const weakPattern of result.weakPatterns) {
-      addFrequencyEntry(
-        weakPatternMap,
-        weakPattern,
-        result.caseDefinition.id,
-        result.questionId || "none"
-      );
+      addFrequencyEntry(weakPatternMap, weakPattern, result.caseDefinition, result.questionId);
     }
-    for (const redFlag of result.missedRedFlags) {
-      addFrequencyEntry(
-        missedRedFlagMap,
-        redFlag,
-        result.caseDefinition.id,
-        result.questionId || "none"
-      );
-    }
-    for (const moduleId of result.recommendedModules) {
-      addFrequencyEntry(
-        recommendedModuleMap,
-        moduleId,
-        result.caseDefinition.id,
-        result.questionId || "none"
-      );
+    for (const missedTag of result.missedMustScreen) {
+      addFrequencyEntry(missedScreenMap, missedTag, result.caseDefinition, result.questionId);
     }
   }
 
+  const categoryScores = Object.fromEntries(
+    CATEGORY_KEYS.map((key) => [
+      key,
+      round(average(caseResults.map((result) => result.scores[key]))),
+    ])
+  );
+  const complaintFamilySummaries = summarizeComplaintFamilies(caseResults);
+
   return {
-    totalCases: caseResults.length,
-    averageScore: round(mean(caseResults.map((result) => result.overallScore))),
+    totalCases: cases.length,
+    categoryCounts: countByCategory(cases),
+    averageQuestionScore: round(
+      average(caseResults.map((result) => result.averageScore))
+    ),
+    genericQuestionRate: round(
+      rate(caseResults.filter((result) => result.isGeneric).length, caseResults.length)
+    ),
+    emergencyRedFlagMissRate: round(
+      rate(
+        caseResults.filter((result) => result.mustScreenHits.length === 0).length,
+        caseResults.length
+      )
+    ),
+    firstQuestionEmergencyScreenRate: round(
+      rate(
+        caseResults.filter((result) => result.mustScreenHits.length > 0).length,
+        caseResults.length
+      )
+    ),
+    repeatedQuestionRate: round(
+      rate(caseResults.filter((result) => result.repeated).length, caseResults.length)
+    ),
     categoryScores,
-    genericRate: round(
-      safeRate(
-        caseResults.filter((result) => result.generic).length,
-        caseResults.length
-      )
-    ),
-    emergencyCaseCount,
-    emergencyMissRate: round(
-      safeRate(
-        caseResults.filter((result) => result.emergencyMiss).length,
-        emergencyCaseCount
-      )
-    ),
-    emergencyScreenRate: round(
-      safeRate(
-        caseResults.filter((result) => result.emergencyScreened).length,
-        emergencyCaseCount
-      )
-    ),
-    repeatedRate: round(
-      safeRate(
-        caseResults.filter((result) => result.repeated).length,
-        caseResults.length
-      )
-    ),
-    weakPatterns: summarizeFrequencyMap(weakPatternMap, 20, (pattern, entry) => ({
-      pattern,
-      count: entry.count,
-      cases: entry.cases,
-      questionIds: [...entry.extras],
-    })),
-    missedRedFlags: summarizeFrequencyMap(missedRedFlagMap, 20, (redFlag, entry) => ({
-      redFlag,
-      count: entry.count,
-      cases: entry.cases,
-      questionIds: [...entry.extras],
-    })),
-    recommendedModules: summarizeFrequencyMap(
-      recommendedModuleMap,
-      20,
-      (moduleId, entry) => ({
-        moduleId,
-        count: entry.count,
-        cases: entry.cases,
-        questionIds: [...entry.extras],
-        description: MODULE_DESCRIPTIONS[moduleId] || "No description available.",
-      })
-    ),
+    weakPatterns: summarizeFrequencyMap(weakPatternMap, 20, "pattern"),
+    missedRedFlagPatterns: summarizeFrequencyMap(missedScreenMap, 20, "pattern"),
+    complaintFamilySummaries,
+    worstComplaintFamilies: complaintFamilySummaries.slice(0, 8),
+    recommendedFirstModules: summarizeRecommendedModules(complaintFamilySummaries),
   };
 }
 
@@ -900,62 +1370,77 @@ async function runEvaluation(options = {}) {
 
   return {
     fixturePath,
+    cases,
     caseResults,
-    summary: aggregateResults(caseResults),
+    summary: aggregateResults(cases, caseResults),
   };
 }
 
 function formatSummary(report) {
   const lines = [];
-  lines.push("PAWVITAL QUESTION-QUALITY EVAL");
-  lines.push("================================");
+  lines.push("PAWVITAL QUESTION INTELLIGENCE BASELINE");
+  lines.push("=======================================");
   lines.push(`Fixture: ${report.fixturePath}`);
   lines.push(`Total cases: ${report.summary.totalCases}`);
-  lines.push(`Average score: ${formatPercent(report.summary.averageScore)}`);
-  lines.push("Category scores:");
+  lines.push(
+    `Scenario counts: emergency=${report.summary.categoryCounts.emergency ?? 0}, urgent_same_day=${report.summary.categoryCounts.urgent_same_day ?? 0}, routine_unclear=${report.summary.categoryCounts.routine_unclear ?? 0}, confusing_multi_symptom=${report.summary.categoryCounts.confusing_multi_symptom ?? 0}`
+  );
+  lines.push(
+    `Average question score: ${formatScore(report.summary.averageQuestionScore)}`
+  );
+  lines.push(
+    `Generic question rate: ${formatPercent(report.summary.genericQuestionRate)}`
+  );
+  lines.push(
+    `Emergency red-flag miss rate: ${formatPercent(report.summary.emergencyRedFlagMissRate)}`
+  );
+  lines.push(
+    `First-question emergency-screen rate: ${formatPercent(report.summary.firstQuestionEmergencyScreenRate)}`
+  );
+  lines.push(
+    `Repeated-question rate: ${formatPercent(report.summary.repeatedQuestionRate)}`
+  );
+  lines.push("Per-category scores:");
   for (const key of CATEGORY_KEYS) {
+    lines.push(`  ${CATEGORY_LABELS[key]}: ${formatScore(report.summary.categoryScores[key])}`);
+  }
+
+  lines.push("Worst complaint families:");
+  for (const family of report.summary.worstComplaintFamilies) {
     lines.push(
-      `  ${CATEGORY_LABELS[key]}: ${formatPercent(report.summary.categoryScores[key])}`
+      `  ${family.complaintFamily}: ${formatScore(family.averageScore)} | missed screens ${family.missedScreens}/${family.count} | first questions ${family.questionIds.join(", ")}`
     );
   }
-  lines.push(`Generic rate: ${formatPercent(report.summary.genericRate)}`);
-  lines.push(
-    `Emergency miss rate: ${formatPercent(report.summary.emergencyMissRate)} (${report.summary.emergencyCaseCount} emergency case(s))`
-  );
-  lines.push(
-    `Emergency-screen rate: ${formatPercent(report.summary.emergencyScreenRate)} (${report.summary.emergencyCaseCount} emergency case(s))`
-  );
-  lines.push(`Repeated rate: ${formatPercent(report.summary.repeatedRate)}`);
 
-  lines.push("Top 20 weak patterns:");
+  lines.push("Top 20 generic or weak question patterns:");
   if (report.summary.weakPatterns.length === 0) {
     lines.push("  none");
   } else {
-    for (const item of report.summary.weakPatterns) {
+    for (const pattern of report.summary.weakPatterns) {
       lines.push(
-        `  ${item.pattern}: ${item.count} case(s) [${item.cases.join(", ")}]`
+        `  ${pattern.pattern}: ${pattern.count} case(s) [${pattern.complaintFamilies.join(", ")}]`
       );
     }
   }
 
-  lines.push("Top 20 missed red flags:");
-  if (report.summary.missedRedFlags.length === 0) {
+  lines.push("Top 20 missed red-flag patterns:");
+  if (report.summary.missedRedFlagPatterns.length === 0) {
     lines.push("  none");
   } else {
-    for (const item of report.summary.missedRedFlags) {
+    for (const pattern of report.summary.missedRedFlagPatterns) {
       lines.push(
-        `  ${item.redFlag}: ${item.count} case(s) [${item.cases.join(", ")}]`
+        `  ${pattern.pattern}: ${pattern.count} case(s) [${pattern.complaintFamilies.join(", ")}]`
       );
     }
   }
 
-  lines.push("Recommended modules:");
-  if (report.summary.recommendedModules.length === 0) {
+  lines.push("Recommended first complaint modules:");
+  if (report.summary.recommendedFirstModules.length === 0) {
     lines.push("  none");
   } else {
-    for (const item of report.summary.recommendedModules) {
+    for (const moduleSummary of report.summary.recommendedFirstModules) {
       lines.push(
-        `  ${item.moduleId}: ${item.count} case(s) [${item.cases.join(", ")}] — ${item.description}`
+        `  ${moduleSummary.moduleId}: ${moduleSummary.count} weak case(s) [${moduleSummary.complaintFamilies.join(", ")}] — ${moduleSummary.description}`
       );
     }
   }
@@ -978,7 +1463,6 @@ if (require.main === module) {
 module.exports = {
   CATEGORY_KEYS,
   FIXTURE_PATH,
-  evaluateCase,
   formatSummary,
   loadCases,
   loadQuestionRuntime,
@@ -986,15 +1470,20 @@ module.exports = {
   runEvaluation,
   __private: {
     aggregateResults,
-    buildRecommendedModules,
-    buildWeakPatterns,
-    questionScreensRedFlag,
-    questionUsesGenericPattern,
+    buildWeakPatternLabel,
+    evaluateCase,
+    getQuestionSignals,
+    isGenericQuestion,
     scoreConcernBucketDiscrimination,
+    scoreEmergencyRedFlagCoverage,
+    scoreGenericWording,
     scoreOwnerAnswerability,
-    scoreRedFlagCoverage,
-    scoreReportValue,
-    scoreSpecificity,
-    scoreUrgencyValue,
+    scoreQuestionSpecificity,
+    scoreRepeatedQuestionBehavior,
+    scoreReportUsefulnessValue,
+    scoreUrgencyChangingValue,
+    summarizeComplaintFamilies,
+    summarizeRecommendedModules,
+    validateCaseSet,
   },
 };

--- a/tests/fixtures/question-quality-cases.json
+++ b/tests/fixtures/question-quality-cases.json
@@ -1,0 +1,5620 @@
+[
+  {
+    "id": "collapse_pale_gums_001",
+    "category": "emergency",
+    "complaintFamily": "collapse_pale_gums",
+    "pet": {
+      "species": "dog",
+      "breed": "Beagle",
+      "ageYears": 4,
+      "weightLbs": 22,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog suddenly collapsed and the gums look very pale.",
+    "symptomKeys": [
+      "seizure_collapse"
+    ],
+    "turnFocusSymptoms": [
+      "seizure_collapse"
+    ],
+    "expectedMustScreen": [
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "collapse_screen",
+      "gum_color_screen",
+      "breathing_distress_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "collapse_shock_screen"
+  },
+  {
+    "id": "collapse_pale_gums_002",
+    "category": "emergency",
+    "complaintFamily": "collapse_pale_gums",
+    "pet": {
+      "species": "dog",
+      "breed": "Poodle",
+      "ageYears": 9,
+      "weightLbs": 24,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog went down and the gums are almost white.",
+    "symptomKeys": [
+      "seizure_collapse"
+    ],
+    "turnFocusSymptoms": [
+      "seizure_collapse"
+    ],
+    "expectedMustScreen": [
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "collapse_screen",
+      "gum_color_screen",
+      "breathing_distress_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "collapse_shock_screen"
+  },
+  {
+    "id": "collapse_pale_gums_003",
+    "category": "emergency",
+    "complaintFamily": "collapse_pale_gums",
+    "pet": {
+      "species": "dog",
+      "breed": "Cocker Spaniel",
+      "ageYears": 11,
+      "weightLbs": 32,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog had a collapse episode and the gums look pale right now.",
+    "symptomKeys": [
+      "seizure_collapse"
+    ],
+    "turnFocusSymptoms": [
+      "seizure_collapse"
+    ],
+    "expectedMustScreen": [
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "collapse_screen",
+      "gum_color_screen",
+      "breathing_distress_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "collapse_shock_screen"
+  },
+  {
+    "id": "collapse_pale_gums_004",
+    "category": "emergency",
+    "complaintFamily": "collapse_pale_gums",
+    "pet": {
+      "species": "dog",
+      "breed": "Mixed Breed",
+      "ageYears": 1,
+      "weightLbs": 66,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog suddenly collapsed and the gums look very pale.",
+    "symptomKeys": [
+      "seizure_collapse"
+    ],
+    "turnFocusSymptoms": [
+      "seizure_collapse"
+    ],
+    "expectedMustScreen": [
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "collapse_screen",
+      "gum_color_screen",
+      "breathing_distress_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "collapse_shock_screen"
+  },
+  {
+    "id": "collapse_pale_gums_005",
+    "category": "emergency",
+    "complaintFamily": "collapse_pale_gums",
+    "pet": {
+      "species": "dog",
+      "breed": "Rottweiler",
+      "ageYears": 5,
+      "weightLbs": 72,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog went down and the gums are almost white.",
+    "symptomKeys": [
+      "seizure_collapse"
+    ],
+    "turnFocusSymptoms": [
+      "seizure_collapse"
+    ],
+    "expectedMustScreen": [
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "collapse_screen",
+      "gum_color_screen",
+      "breathing_distress_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "collapse_shock_screen"
+  },
+  {
+    "id": "collapse_pale_gums_006",
+    "category": "emergency",
+    "complaintFamily": "collapse_pale_gums",
+    "pet": {
+      "species": "dog",
+      "breed": "Pug",
+      "ageYears": 7,
+      "weightLbs": 18,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog had a collapse episode and the gums look pale right now.",
+    "symptomKeys": [
+      "seizure_collapse"
+    ],
+    "turnFocusSymptoms": [
+      "seizure_collapse"
+    ],
+    "expectedMustScreen": [
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "collapse_screen",
+      "gum_color_screen",
+      "breathing_distress_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "collapse_shock_screen"
+  },
+  {
+    "id": "breathing_difficulty_001",
+    "category": "emergency",
+    "complaintFamily": "breathing_difficulty",
+    "pet": {
+      "species": "dog",
+      "breed": "Cocker Spaniel",
+      "ageYears": 5,
+      "weightLbs": 24,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog is struggling to breathe and looks panicked.",
+    "symptomKeys": [
+      "difficulty_breathing"
+    ],
+    "turnFocusSymptoms": [
+      "difficulty_breathing"
+    ],
+    "expectedMustScreen": [
+      "breathing_difficulty",
+      "pale_or_blue_gums",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "What breed is your dog?",
+      "Can you tell me more?",
+      "Has this happened before in general?"
+    ],
+    "idealQuestionCategories": [
+      "breathing_distress_screen",
+      "gum_color_screen",
+      "position_preference"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "respiratory_distress_screen"
+  },
+  {
+    "id": "breathing_difficulty_002",
+    "category": "emergency",
+    "complaintFamily": "breathing_difficulty",
+    "pet": {
+      "species": "dog",
+      "breed": "Mixed Breed",
+      "ageYears": 8,
+      "weightLbs": 38,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog is breathing hard and cannot get comfortable.",
+    "symptomKeys": [
+      "difficulty_breathing"
+    ],
+    "turnFocusSymptoms": [
+      "difficulty_breathing"
+    ],
+    "expectedMustScreen": [
+      "breathing_difficulty",
+      "pale_or_blue_gums",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "What breed is your dog?",
+      "Can you tell me more?",
+      "Has this happened before in general?"
+    ],
+    "idealQuestionCategories": [
+      "breathing_distress_screen",
+      "gum_color_screen",
+      "position_preference"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "respiratory_distress_screen"
+  },
+  {
+    "id": "breathing_difficulty_003",
+    "category": "emergency",
+    "complaintFamily": "breathing_difficulty",
+    "pet": {
+      "species": "dog",
+      "breed": "Rottweiler",
+      "ageYears": 9,
+      "weightLbs": 96,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog has sudden trouble breathing and is breathing faster than normal.",
+    "symptomKeys": [
+      "difficulty_breathing"
+    ],
+    "turnFocusSymptoms": [
+      "difficulty_breathing"
+    ],
+    "expectedMustScreen": [
+      "breathing_difficulty",
+      "pale_or_blue_gums",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "What breed is your dog?",
+      "Can you tell me more?",
+      "Has this happened before in general?"
+    ],
+    "idealQuestionCategories": [
+      "breathing_distress_screen",
+      "gum_color_screen",
+      "position_preference"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "respiratory_distress_screen"
+  },
+  {
+    "id": "breathing_difficulty_004",
+    "category": "emergency",
+    "complaintFamily": "breathing_difficulty",
+    "pet": {
+      "species": "dog",
+      "breed": "Pug",
+      "ageYears": 2,
+      "weightLbs": 22,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog is struggling to breathe and looks panicked.",
+    "symptomKeys": [
+      "difficulty_breathing"
+    ],
+    "turnFocusSymptoms": [
+      "difficulty_breathing"
+    ],
+    "expectedMustScreen": [
+      "breathing_difficulty",
+      "pale_or_blue_gums",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "What breed is your dog?",
+      "Can you tell me more?",
+      "Has this happened before in general?"
+    ],
+    "idealQuestionCategories": [
+      "breathing_distress_screen",
+      "gum_color_screen",
+      "position_preference"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "respiratory_distress_screen"
+  },
+  {
+    "id": "breathing_difficulty_005",
+    "category": "emergency",
+    "complaintFamily": "breathing_difficulty",
+    "pet": {
+      "species": "dog",
+      "breed": "Labrador Retriever",
+      "ageYears": 4,
+      "weightLbs": 55,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog is breathing hard and cannot get comfortable.",
+    "symptomKeys": [
+      "difficulty_breathing"
+    ],
+    "turnFocusSymptoms": [
+      "difficulty_breathing"
+    ],
+    "expectedMustScreen": [
+      "breathing_difficulty",
+      "pale_or_blue_gums",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "What breed is your dog?",
+      "Can you tell me more?",
+      "Has this happened before in general?"
+    ],
+    "idealQuestionCategories": [
+      "breathing_distress_screen",
+      "gum_color_screen",
+      "position_preference"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "respiratory_distress_screen"
+  },
+  {
+    "id": "breathing_difficulty_006",
+    "category": "emergency",
+    "complaintFamily": "breathing_difficulty",
+    "pet": {
+      "species": "dog",
+      "breed": "Golden Retriever",
+      "ageYears": 7,
+      "weightLbs": 65,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog has sudden trouble breathing and is breathing faster than normal.",
+    "symptomKeys": [
+      "difficulty_breathing"
+    ],
+    "turnFocusSymptoms": [
+      "difficulty_breathing"
+    ],
+    "expectedMustScreen": [
+      "breathing_difficulty",
+      "pale_or_blue_gums",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "What breed is your dog?",
+      "Can you tell me more?",
+      "Has this happened before in general?"
+    ],
+    "idealQuestionCategories": [
+      "breathing_distress_screen",
+      "gum_color_screen",
+      "position_preference"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "respiratory_distress_screen"
+  },
+  {
+    "id": "bloat_nonproductive_retching_swollen_abdomen_001",
+    "category": "emergency",
+    "complaintFamily": "bloat_nonproductive_retching_swollen_abdomen",
+    "pet": {
+      "species": "dog",
+      "breed": "Cocker Spaniel",
+      "ageYears": 5,
+      "weightLbs": 24,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog keeps trying to vomit but nothing comes up and the belly looks swollen.",
+    "symptomKeys": [
+      "swollen_abdomen",
+      "vomiting"
+    ],
+    "turnFocusSymptoms": [
+      "swollen_abdomen"
+    ],
+    "expectedMustScreen": [
+      "unproductive_retching",
+      "abdominal_distension",
+      "collapse_or_weakness",
+      "pale_or_blue_gums"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What has the appetite been like this week?"
+    ],
+    "idealQuestionCategories": [
+      "abdominal_emergency_screen",
+      "gdv_screen",
+      "gum_color_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "bloat_gdv_screen"
+  },
+  {
+    "id": "bloat_nonproductive_retching_swollen_abdomen_002",
+    "category": "emergency",
+    "complaintFamily": "bloat_nonproductive_retching_swollen_abdomen",
+    "pet": {
+      "species": "dog",
+      "breed": "Mixed Breed",
+      "ageYears": 8,
+      "weightLbs": 38,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog is retching without producing anything and the abdomen suddenly looks big.",
+    "symptomKeys": [
+      "swollen_abdomen",
+      "vomiting"
+    ],
+    "turnFocusSymptoms": [
+      "swollen_abdomen"
+    ],
+    "expectedMustScreen": [
+      "unproductive_retching",
+      "abdominal_distension",
+      "collapse_or_weakness",
+      "pale_or_blue_gums"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What has the appetite been like this week?"
+    ],
+    "idealQuestionCategories": [
+      "abdominal_emergency_screen",
+      "gdv_screen",
+      "gum_color_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "bloat_gdv_screen"
+  },
+  {
+    "id": "bloat_nonproductive_retching_swollen_abdomen_003",
+    "category": "emergency",
+    "complaintFamily": "bloat_nonproductive_retching_swollen_abdomen",
+    "pet": {
+      "species": "dog",
+      "breed": "Rottweiler",
+      "ageYears": 9,
+      "weightLbs": 96,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog looks bloated, restless, and keeps trying to throw up with nothing coming out.",
+    "symptomKeys": [
+      "swollen_abdomen",
+      "vomiting"
+    ],
+    "turnFocusSymptoms": [
+      "swollen_abdomen"
+    ],
+    "expectedMustScreen": [
+      "unproductive_retching",
+      "abdominal_distension",
+      "collapse_or_weakness",
+      "pale_or_blue_gums"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What has the appetite been like this week?"
+    ],
+    "idealQuestionCategories": [
+      "abdominal_emergency_screen",
+      "gdv_screen",
+      "gum_color_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "bloat_gdv_screen"
+  },
+  {
+    "id": "bloat_nonproductive_retching_swollen_abdomen_004",
+    "category": "emergency",
+    "complaintFamily": "bloat_nonproductive_retching_swollen_abdomen",
+    "pet": {
+      "species": "dog",
+      "breed": "Pug",
+      "ageYears": 2,
+      "weightLbs": 22,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog keeps trying to vomit but nothing comes up and the belly looks swollen.",
+    "symptomKeys": [
+      "swollen_abdomen",
+      "vomiting"
+    ],
+    "turnFocusSymptoms": [
+      "swollen_abdomen"
+    ],
+    "expectedMustScreen": [
+      "unproductive_retching",
+      "abdominal_distension",
+      "collapse_or_weakness",
+      "pale_or_blue_gums"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What has the appetite been like this week?"
+    ],
+    "idealQuestionCategories": [
+      "abdominal_emergency_screen",
+      "gdv_screen",
+      "gum_color_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "bloat_gdv_screen"
+  },
+  {
+    "id": "bloat_nonproductive_retching_swollen_abdomen_005",
+    "category": "emergency",
+    "complaintFamily": "bloat_nonproductive_retching_swollen_abdomen",
+    "pet": {
+      "species": "dog",
+      "breed": "Labrador Retriever",
+      "ageYears": 4,
+      "weightLbs": 55,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog is retching without producing anything and the abdomen suddenly looks big.",
+    "symptomKeys": [
+      "swollen_abdomen",
+      "vomiting"
+    ],
+    "turnFocusSymptoms": [
+      "swollen_abdomen"
+    ],
+    "expectedMustScreen": [
+      "unproductive_retching",
+      "abdominal_distension",
+      "collapse_or_weakness",
+      "pale_or_blue_gums"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What has the appetite been like this week?"
+    ],
+    "idealQuestionCategories": [
+      "abdominal_emergency_screen",
+      "gdv_screen",
+      "gum_color_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "bloat_gdv_screen"
+  },
+  {
+    "id": "bloat_nonproductive_retching_swollen_abdomen_006",
+    "category": "emergency",
+    "complaintFamily": "bloat_nonproductive_retching_swollen_abdomen",
+    "pet": {
+      "species": "dog",
+      "breed": "Golden Retriever",
+      "ageYears": 7,
+      "weightLbs": 65,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog looks bloated, restless, and keeps trying to throw up with nothing coming out.",
+    "symptomKeys": [
+      "swollen_abdomen",
+      "vomiting"
+    ],
+    "turnFocusSymptoms": [
+      "swollen_abdomen"
+    ],
+    "expectedMustScreen": [
+      "unproductive_retching",
+      "abdominal_distension",
+      "collapse_or_weakness",
+      "pale_or_blue_gums"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What has the appetite been like this week?"
+    ],
+    "idealQuestionCategories": [
+      "abdominal_emergency_screen",
+      "gdv_screen",
+      "gum_color_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "bloat_gdv_screen"
+  },
+  {
+    "id": "seizure_or_repeated_seizures_001",
+    "category": "emergency",
+    "complaintFamily": "seizure_or_repeated_seizures",
+    "pet": {
+      "species": "dog",
+      "breed": "Boxer",
+      "ageYears": 4,
+      "weightLbs": 48,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog just had a seizure and now seems out of it.",
+    "symptomKeys": [
+      "seizure_collapse"
+    ],
+    "turnFocusSymptoms": [
+      "seizure_collapse"
+    ],
+    "expectedMustScreen": [
+      "seizure_activity",
+      "collapse_or_weakness",
+      "breathing_difficulty",
+      "toxin_exposure"
+    ],
+    "badFirstQuestions": [
+      "What breed is your dog?",
+      "Can you tell me more?",
+      "Has your dog had diarrhea lately?"
+    ],
+    "idealQuestionCategories": [
+      "seizure_duration",
+      "collapse_screen",
+      "toxin_screen",
+      "breathing_distress_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "seizure_episode_screen"
+  },
+  {
+    "id": "seizure_or_repeated_seizures_002",
+    "category": "emergency",
+    "complaintFamily": "seizure_or_repeated_seizures",
+    "pet": {
+      "species": "dog",
+      "breed": "Dachshund",
+      "ageYears": 7,
+      "weightLbs": 18,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog has had repeated seizure-like episodes today.",
+    "symptomKeys": [
+      "seizure_collapse"
+    ],
+    "turnFocusSymptoms": [
+      "seizure_collapse"
+    ],
+    "expectedMustScreen": [
+      "seizure_activity",
+      "collapse_or_weakness",
+      "breathing_difficulty",
+      "toxin_exposure"
+    ],
+    "badFirstQuestions": [
+      "What breed is your dog?",
+      "Can you tell me more?",
+      "Has your dog had diarrhea lately?"
+    ],
+    "idealQuestionCategories": [
+      "seizure_duration",
+      "collapse_screen",
+      "toxin_screen",
+      "breathing_distress_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "seizure_episode_screen"
+  },
+  {
+    "id": "seizure_or_repeated_seizures_003",
+    "category": "emergency",
+    "complaintFamily": "seizure_or_repeated_seizures",
+    "pet": {
+      "species": "dog",
+      "breed": "Beagle",
+      "ageYears": 10,
+      "weightLbs": 30,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog collapsed with shaking and I am worried it is another seizure.",
+    "symptomKeys": [
+      "seizure_collapse"
+    ],
+    "turnFocusSymptoms": [
+      "seizure_collapse"
+    ],
+    "expectedMustScreen": [
+      "seizure_activity",
+      "collapse_or_weakness",
+      "breathing_difficulty",
+      "toxin_exposure"
+    ],
+    "badFirstQuestions": [
+      "What breed is your dog?",
+      "Can you tell me more?",
+      "Has your dog had diarrhea lately?"
+    ],
+    "idealQuestionCategories": [
+      "seizure_duration",
+      "collapse_screen",
+      "toxin_screen",
+      "breathing_distress_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "seizure_episode_screen"
+  },
+  {
+    "id": "seizure_or_repeated_seizures_004",
+    "category": "emergency",
+    "complaintFamily": "seizure_or_repeated_seizures",
+    "pet": {
+      "species": "dog",
+      "breed": "Poodle",
+      "ageYears": 2,
+      "weightLbs": 48,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog just had a seizure and now seems out of it.",
+    "symptomKeys": [
+      "seizure_collapse"
+    ],
+    "turnFocusSymptoms": [
+      "seizure_collapse"
+    ],
+    "expectedMustScreen": [
+      "seizure_activity",
+      "collapse_or_weakness",
+      "breathing_difficulty",
+      "toxin_exposure"
+    ],
+    "badFirstQuestions": [
+      "What breed is your dog?",
+      "Can you tell me more?",
+      "Has your dog had diarrhea lately?"
+    ],
+    "idealQuestionCategories": [
+      "seizure_duration",
+      "collapse_screen",
+      "toxin_screen",
+      "breathing_distress_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "seizure_episode_screen"
+  },
+  {
+    "id": "seizure_or_repeated_seizures_005",
+    "category": "emergency",
+    "complaintFamily": "seizure_or_repeated_seizures",
+    "pet": {
+      "species": "dog",
+      "breed": "Cocker Spaniel",
+      "ageYears": 5,
+      "weightLbs": 24,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog has had repeated seizure-like episodes today.",
+    "symptomKeys": [
+      "seizure_collapse"
+    ],
+    "turnFocusSymptoms": [
+      "seizure_collapse"
+    ],
+    "expectedMustScreen": [
+      "seizure_activity",
+      "collapse_or_weakness",
+      "breathing_difficulty",
+      "toxin_exposure"
+    ],
+    "badFirstQuestions": [
+      "What breed is your dog?",
+      "Can you tell me more?",
+      "Has your dog had diarrhea lately?"
+    ],
+    "idealQuestionCategories": [
+      "seizure_duration",
+      "collapse_screen",
+      "toxin_screen",
+      "breathing_distress_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "seizure_episode_screen"
+  },
+  {
+    "id": "seizure_or_repeated_seizures_006",
+    "category": "emergency",
+    "complaintFamily": "seizure_or_repeated_seizures",
+    "pet": {
+      "species": "dog",
+      "breed": "Mixed Breed",
+      "ageYears": 8,
+      "weightLbs": 38,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog collapsed with shaking and I am worried it is another seizure.",
+    "symptomKeys": [
+      "seizure_collapse"
+    ],
+    "turnFocusSymptoms": [
+      "seizure_collapse"
+    ],
+    "expectedMustScreen": [
+      "seizure_activity",
+      "collapse_or_weakness",
+      "breathing_difficulty",
+      "toxin_exposure"
+    ],
+    "badFirstQuestions": [
+      "What breed is your dog?",
+      "Can you tell me more?",
+      "Has your dog had diarrhea lately?"
+    ],
+    "idealQuestionCategories": [
+      "seizure_duration",
+      "collapse_screen",
+      "toxin_screen",
+      "breathing_distress_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "seizure_episode_screen"
+  },
+  {
+    "id": "toxin_ingestion_001",
+    "category": "emergency",
+    "complaintFamily": "toxin_ingestion",
+    "pet": {
+      "species": "dog",
+      "breed": "French Bulldog",
+      "ageYears": 3,
+      "weightLbs": 22,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog may have gotten into ibuprofen and started acting sick.",
+    "symptomKeys": [
+      "medication_reaction"
+    ],
+    "turnFocusSymptoms": [
+      "medication_reaction"
+    ],
+    "expectedMustScreen": [
+      "toxin_exposure",
+      "repeated_vomiting",
+      "collapse_or_weakness",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "toxin_screen",
+      "symptom_timing",
+      "collapse_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "toxin_exposure_screen"
+  },
+  {
+    "id": "toxin_ingestion_002",
+    "category": "emergency",
+    "complaintFamily": "toxin_ingestion",
+    "pet": {
+      "species": "dog",
+      "breed": "Boxer",
+      "ageYears": 6,
+      "weightLbs": 56,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog ate something toxic and is now vomiting and trembling.",
+    "symptomKeys": [
+      "medication_reaction"
+    ],
+    "turnFocusSymptoms": [
+      "medication_reaction"
+    ],
+    "expectedMustScreen": [
+      "toxin_exposure",
+      "repeated_vomiting",
+      "collapse_or_weakness",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "toxin_screen",
+      "symptom_timing",
+      "collapse_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "toxin_exposure_screen"
+  },
+  {
+    "id": "toxin_ingestion_003",
+    "category": "emergency",
+    "complaintFamily": "toxin_ingestion",
+    "pet": {
+      "species": "dog",
+      "breed": "Dachshund",
+      "ageYears": 11,
+      "weightLbs": 22,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog chewed a medication bottle and now looks weak and nauseated.",
+    "symptomKeys": [
+      "medication_reaction"
+    ],
+    "turnFocusSymptoms": [
+      "medication_reaction"
+    ],
+    "expectedMustScreen": [
+      "toxin_exposure",
+      "repeated_vomiting",
+      "collapse_or_weakness",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "toxin_screen",
+      "symptom_timing",
+      "collapse_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "toxin_exposure_screen"
+  },
+  {
+    "id": "toxin_ingestion_004",
+    "category": "emergency",
+    "complaintFamily": "toxin_ingestion",
+    "pet": {
+      "species": "dog",
+      "breed": "Beagle",
+      "ageYears": 2,
+      "weightLbs": 34,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog may have gotten into ibuprofen and started acting sick.",
+    "symptomKeys": [
+      "medication_reaction"
+    ],
+    "turnFocusSymptoms": [
+      "medication_reaction"
+    ],
+    "expectedMustScreen": [
+      "toxin_exposure",
+      "repeated_vomiting",
+      "collapse_or_weakness",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "toxin_screen",
+      "symptom_timing",
+      "collapse_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "toxin_exposure_screen"
+  },
+  {
+    "id": "toxin_ingestion_005",
+    "category": "emergency",
+    "complaintFamily": "toxin_ingestion",
+    "pet": {
+      "species": "dog",
+      "breed": "Poodle",
+      "ageYears": 6,
+      "weightLbs": 18,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog ate something toxic and is now vomiting and trembling.",
+    "symptomKeys": [
+      "medication_reaction"
+    ],
+    "turnFocusSymptoms": [
+      "medication_reaction"
+    ],
+    "expectedMustScreen": [
+      "toxin_exposure",
+      "repeated_vomiting",
+      "collapse_or_weakness",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "toxin_screen",
+      "symptom_timing",
+      "collapse_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "toxin_exposure_screen"
+  },
+  {
+    "id": "toxin_ingestion_006",
+    "category": "emergency",
+    "complaintFamily": "toxin_ingestion",
+    "pet": {
+      "species": "dog",
+      "breed": "Cocker Spaniel",
+      "ageYears": 8,
+      "weightLbs": 28,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog chewed a medication bottle and now looks weak and nauseated.",
+    "symptomKeys": [
+      "medication_reaction"
+    ],
+    "turnFocusSymptoms": [
+      "medication_reaction"
+    ],
+    "expectedMustScreen": [
+      "toxin_exposure",
+      "repeated_vomiting",
+      "collapse_or_weakness",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "toxin_screen",
+      "symptom_timing",
+      "collapse_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "toxin_exposure_screen"
+  },
+  {
+    "id": "trauma_001",
+    "category": "emergency",
+    "complaintFamily": "trauma",
+    "pet": {
+      "species": "dog",
+      "breed": "Beagle",
+      "ageYears": 4,
+      "weightLbs": 22,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog was hit by a car and is not acting normal.",
+    "symptomKeys": [
+      "trauma"
+    ],
+    "turnFocusSymptoms": [
+      "trauma"
+    ],
+    "expectedMustScreen": [
+      "active_bleeding",
+      "fracture_or_bone_exposure",
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "Has your dog ever had this before?"
+    ],
+    "idealQuestionCategories": [
+      "trauma_mechanism",
+      "bleeding_screen",
+      "mobility_screen",
+      "breathing_distress_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "major_trauma_screen"
+  },
+  {
+    "id": "trauma_002",
+    "category": "emergency",
+    "complaintFamily": "trauma",
+    "pet": {
+      "species": "dog",
+      "breed": "Poodle",
+      "ageYears": 9,
+      "weightLbs": 24,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog took a bad fall and now seems painful and weak.",
+    "symptomKeys": [
+      "trauma"
+    ],
+    "turnFocusSymptoms": [
+      "trauma"
+    ],
+    "expectedMustScreen": [
+      "active_bleeding",
+      "fracture_or_bone_exposure",
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "Has your dog ever had this before?"
+    ],
+    "idealQuestionCategories": [
+      "trauma_mechanism",
+      "bleeding_screen",
+      "mobility_screen",
+      "breathing_distress_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "major_trauma_screen"
+  },
+  {
+    "id": "trauma_003",
+    "category": "emergency",
+    "complaintFamily": "trauma",
+    "pet": {
+      "species": "dog",
+      "breed": "Cocker Spaniel",
+      "ageYears": 11,
+      "weightLbs": 32,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog was bitten during a fight and I am worried about internal injury.",
+    "symptomKeys": [
+      "trauma"
+    ],
+    "turnFocusSymptoms": [
+      "trauma"
+    ],
+    "expectedMustScreen": [
+      "active_bleeding",
+      "fracture_or_bone_exposure",
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "Has your dog ever had this before?"
+    ],
+    "idealQuestionCategories": [
+      "trauma_mechanism",
+      "bleeding_screen",
+      "mobility_screen",
+      "breathing_distress_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "major_trauma_screen"
+  },
+  {
+    "id": "trauma_004",
+    "category": "emergency",
+    "complaintFamily": "trauma",
+    "pet": {
+      "species": "dog",
+      "breed": "Mixed Breed",
+      "ageYears": 1,
+      "weightLbs": 66,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog was hit by a car and is not acting normal.",
+    "symptomKeys": [
+      "trauma"
+    ],
+    "turnFocusSymptoms": [
+      "trauma"
+    ],
+    "expectedMustScreen": [
+      "active_bleeding",
+      "fracture_or_bone_exposure",
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "Has your dog ever had this before?"
+    ],
+    "idealQuestionCategories": [
+      "trauma_mechanism",
+      "bleeding_screen",
+      "mobility_screen",
+      "breathing_distress_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "major_trauma_screen"
+  },
+  {
+    "id": "trauma_005",
+    "category": "emergency",
+    "complaintFamily": "trauma",
+    "pet": {
+      "species": "dog",
+      "breed": "Rottweiler",
+      "ageYears": 5,
+      "weightLbs": 72,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog took a bad fall and now seems painful and weak.",
+    "symptomKeys": [
+      "trauma"
+    ],
+    "turnFocusSymptoms": [
+      "trauma"
+    ],
+    "expectedMustScreen": [
+      "active_bleeding",
+      "fracture_or_bone_exposure",
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "Has your dog ever had this before?"
+    ],
+    "idealQuestionCategories": [
+      "trauma_mechanism",
+      "bleeding_screen",
+      "mobility_screen",
+      "breathing_distress_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "major_trauma_screen"
+  },
+  {
+    "id": "trauma_006",
+    "category": "emergency",
+    "complaintFamily": "trauma",
+    "pet": {
+      "species": "dog",
+      "breed": "Pug",
+      "ageYears": 7,
+      "weightLbs": 18,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog was bitten during a fight and I am worried about internal injury.",
+    "symptomKeys": [
+      "trauma"
+    ],
+    "turnFocusSymptoms": [
+      "trauma"
+    ],
+    "expectedMustScreen": [
+      "active_bleeding",
+      "fracture_or_bone_exposure",
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "Has your dog ever had this before?"
+    ],
+    "idealQuestionCategories": [
+      "trauma_mechanism",
+      "bleeding_screen",
+      "mobility_screen",
+      "breathing_distress_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "major_trauma_screen"
+  },
+  {
+    "id": "urinary_blockage_001",
+    "category": "emergency",
+    "complaintFamily": "urinary_blockage",
+    "pet": {
+      "species": "dog",
+      "breed": "Boxer",
+      "ageYears": 4,
+      "weightLbs": 48,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog keeps straining to pee and almost nothing comes out.",
+    "symptomKeys": [
+      "urination_problem"
+    ],
+    "turnFocusSymptoms": [
+      "urination_problem"
+    ],
+    "expectedMustScreen": [
+      "straining_with_no_urine",
+      "collapse_or_weakness",
+      "repeated_vomiting"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What food does your dog eat?"
+    ],
+    "idealQuestionCategories": [
+      "urinary_obstruction_screen",
+      "urine_output",
+      "vomiting_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "urinary_obstruction_screen"
+  },
+  {
+    "id": "urinary_blockage_002",
+    "category": "emergency",
+    "complaintFamily": "urinary_blockage",
+    "pet": {
+      "species": "dog",
+      "breed": "Dachshund",
+      "ageYears": 7,
+      "weightLbs": 18,
+      "sexNeuter": "intact male"
+    },
+    "initialMessage": "My dog is trying to urinate over and over but barely passes anything.",
+    "symptomKeys": [
+      "urination_problem"
+    ],
+    "turnFocusSymptoms": [
+      "urination_problem"
+    ],
+    "expectedMustScreen": [
+      "straining_with_no_urine",
+      "collapse_or_weakness",
+      "repeated_vomiting"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What food does your dog eat?"
+    ],
+    "idealQuestionCategories": [
+      "urinary_obstruction_screen",
+      "urine_output",
+      "vomiting_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "urinary_obstruction_screen"
+  },
+  {
+    "id": "urinary_blockage_003",
+    "category": "emergency",
+    "complaintFamily": "urinary_blockage",
+    "pet": {
+      "species": "dog",
+      "breed": "Beagle",
+      "ageYears": 10,
+      "weightLbs": 30,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog is pacing and straining to pee with very little urine.",
+    "symptomKeys": [
+      "urination_problem"
+    ],
+    "turnFocusSymptoms": [
+      "urination_problem"
+    ],
+    "expectedMustScreen": [
+      "straining_with_no_urine",
+      "collapse_or_weakness",
+      "repeated_vomiting"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What food does your dog eat?"
+    ],
+    "idealQuestionCategories": [
+      "urinary_obstruction_screen",
+      "urine_output",
+      "vomiting_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "urinary_obstruction_screen"
+  },
+  {
+    "id": "urinary_blockage_004",
+    "category": "emergency",
+    "complaintFamily": "urinary_blockage",
+    "pet": {
+      "species": "dog",
+      "breed": "Poodle",
+      "ageYears": 2,
+      "weightLbs": 48,
+      "sexNeuter": "intact male"
+    },
+    "initialMessage": "My dog keeps straining to pee and almost nothing comes out.",
+    "symptomKeys": [
+      "urination_problem"
+    ],
+    "turnFocusSymptoms": [
+      "urination_problem"
+    ],
+    "expectedMustScreen": [
+      "straining_with_no_urine",
+      "collapse_or_weakness",
+      "repeated_vomiting"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What food does your dog eat?"
+    ],
+    "idealQuestionCategories": [
+      "urinary_obstruction_screen",
+      "urine_output",
+      "vomiting_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "urinary_obstruction_screen"
+  },
+  {
+    "id": "urinary_blockage_005",
+    "category": "emergency",
+    "complaintFamily": "urinary_blockage",
+    "pet": {
+      "species": "dog",
+      "breed": "Cocker Spaniel",
+      "ageYears": 5,
+      "weightLbs": 24,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog is trying to urinate over and over but barely passes anything.",
+    "symptomKeys": [
+      "urination_problem"
+    ],
+    "turnFocusSymptoms": [
+      "urination_problem"
+    ],
+    "expectedMustScreen": [
+      "straining_with_no_urine",
+      "collapse_or_weakness",
+      "repeated_vomiting"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What food does your dog eat?"
+    ],
+    "idealQuestionCategories": [
+      "urinary_obstruction_screen",
+      "urine_output",
+      "vomiting_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "urinary_obstruction_screen"
+  },
+  {
+    "id": "heat_stroke_001",
+    "category": "emergency",
+    "complaintFamily": "heat_stroke",
+    "pet": {
+      "species": "dog",
+      "breed": "Pug",
+      "ageYears": 1,
+      "weightLbs": 18,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog overheated outside and is panting hard.",
+    "symptomKeys": [
+      "heat_intolerance"
+    ],
+    "turnFocusSymptoms": [
+      "heat_intolerance"
+    ],
+    "expectedMustScreen": [
+      "heat_exposure",
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "repeated_vomiting",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "Has the appetite changed this week?"
+    ],
+    "idealQuestionCategories": [
+      "heat_exposure_screen",
+      "collapse_screen",
+      "gum_color_screen",
+      "vomiting_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "heat_illness_screen"
+  },
+  {
+    "id": "heat_stroke_002",
+    "category": "emergency",
+    "complaintFamily": "heat_stroke",
+    "pet": {
+      "species": "dog",
+      "breed": "Labrador Retriever",
+      "ageYears": 2,
+      "weightLbs": 22,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog was out in the heat and now looks weak and distressed.",
+    "symptomKeys": [
+      "heat_intolerance"
+    ],
+    "turnFocusSymptoms": [
+      "heat_intolerance"
+    ],
+    "expectedMustScreen": [
+      "heat_exposure",
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "repeated_vomiting",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "Has the appetite changed this week?"
+    ],
+    "idealQuestionCategories": [
+      "heat_exposure_screen",
+      "collapse_screen",
+      "gum_color_screen",
+      "vomiting_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "heat_illness_screen"
+  },
+  {
+    "id": "heat_stroke_003",
+    "category": "emergency",
+    "complaintFamily": "heat_stroke",
+    "pet": {
+      "species": "dog",
+      "breed": "Golden Retriever",
+      "ageYears": 3,
+      "weightLbs": 28,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog got too hot in the sun and is now breathing fast and acting sick.",
+    "symptomKeys": [
+      "heat_intolerance"
+    ],
+    "turnFocusSymptoms": [
+      "heat_intolerance"
+    ],
+    "expectedMustScreen": [
+      "heat_exposure",
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "repeated_vomiting",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "Has the appetite changed this week?"
+    ],
+    "idealQuestionCategories": [
+      "heat_exposure_screen",
+      "collapse_screen",
+      "gum_color_screen",
+      "vomiting_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "heat_illness_screen"
+  },
+  {
+    "id": "heat_stroke_004",
+    "category": "emergency",
+    "complaintFamily": "heat_stroke",
+    "pet": {
+      "species": "dog",
+      "breed": "German Shepherd",
+      "ageYears": 5,
+      "weightLbs": 34,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog overheated outside and is panting hard.",
+    "symptomKeys": [
+      "heat_intolerance"
+    ],
+    "turnFocusSymptoms": [
+      "heat_intolerance"
+    ],
+    "expectedMustScreen": [
+      "heat_exposure",
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "repeated_vomiting",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "Has the appetite changed this week?"
+    ],
+    "idealQuestionCategories": [
+      "heat_exposure_screen",
+      "collapse_screen",
+      "gum_color_screen",
+      "vomiting_screen"
+    ],
+    "expectedUrgency": "emergency_vet_now",
+    "recommendedFirstModule": "heat_illness_screen"
+  },
+  {
+    "id": "vomiting_and_lethargy_001",
+    "category": "urgent_same_day",
+    "complaintFamily": "vomiting_and_lethargy",
+    "pet": {
+      "species": "dog",
+      "breed": "Mixed Breed",
+      "ageYears": 4,
+      "weightLbs": 25,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog has been vomiting and seems very tired today.",
+    "symptomKeys": [
+      "vomiting",
+      "lethargy"
+    ],
+    "turnFocusSymptoms": [
+      "vomiting",
+      "lethargy"
+    ],
+    "expectedMustScreen": [
+      "repeated_vomiting",
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "not_drinking"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "vomiting_severity",
+      "hydration_screen",
+      "gum_color_screen",
+      "energy_change"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "vomiting_lethargy_module"
+  },
+  {
+    "id": "vomiting_and_lethargy_002",
+    "category": "urgent_same_day",
+    "complaintFamily": "vomiting_and_lethargy",
+    "pet": {
+      "species": "dog",
+      "breed": "Rottweiler",
+      "ageYears": 7,
+      "weightLbs": 84,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog threw up several times and is much less active than usual.",
+    "symptomKeys": [
+      "vomiting",
+      "lethargy"
+    ],
+    "turnFocusSymptoms": [
+      "vomiting",
+      "lethargy"
+    ],
+    "expectedMustScreen": [
+      "repeated_vomiting",
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "not_drinking"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "vomiting_severity",
+      "hydration_screen",
+      "gum_color_screen",
+      "energy_change"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "vomiting_lethargy_module"
+  },
+  {
+    "id": "vomiting_and_lethargy_003",
+    "category": "urgent_same_day",
+    "complaintFamily": "vomiting_and_lethargy",
+    "pet": {
+      "species": "dog",
+      "breed": "Pug",
+      "ageYears": 10,
+      "weightLbs": 20,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog is vomiting and acting lethargic since this morning.",
+    "symptomKeys": [
+      "vomiting",
+      "lethargy"
+    ],
+    "turnFocusSymptoms": [
+      "vomiting",
+      "lethargy"
+    ],
+    "expectedMustScreen": [
+      "repeated_vomiting",
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "not_drinking"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "vomiting_severity",
+      "hydration_screen",
+      "gum_color_screen",
+      "energy_change"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "vomiting_lethargy_module"
+  },
+  {
+    "id": "vomiting_and_lethargy_004",
+    "category": "urgent_same_day",
+    "complaintFamily": "vomiting_and_lethargy",
+    "pet": {
+      "species": "dog",
+      "breed": "Labrador Retriever",
+      "ageYears": 2,
+      "weightLbs": 74,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog has been vomiting and seems very tired today.",
+    "symptomKeys": [
+      "vomiting",
+      "lethargy"
+    ],
+    "turnFocusSymptoms": [
+      "vomiting",
+      "lethargy"
+    ],
+    "expectedMustScreen": [
+      "repeated_vomiting",
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "not_drinking"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "vomiting_severity",
+      "hydration_screen",
+      "gum_color_screen",
+      "energy_change"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "vomiting_lethargy_module"
+  },
+  {
+    "id": "vomiting_and_lethargy_005",
+    "category": "urgent_same_day",
+    "complaintFamily": "vomiting_and_lethargy",
+    "pet": {
+      "species": "dog",
+      "breed": "Golden Retriever",
+      "ageYears": 5,
+      "weightLbs": 58,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog threw up several times and is much less active than usual.",
+    "symptomKeys": [
+      "vomiting",
+      "lethargy"
+    ],
+    "turnFocusSymptoms": [
+      "vomiting",
+      "lethargy"
+    ],
+    "expectedMustScreen": [
+      "repeated_vomiting",
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "not_drinking"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "vomiting_severity",
+      "hydration_screen",
+      "gum_color_screen",
+      "energy_change"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "vomiting_lethargy_module"
+  },
+  {
+    "id": "vomiting_and_lethargy_006",
+    "category": "urgent_same_day",
+    "complaintFamily": "vomiting_and_lethargy",
+    "pet": {
+      "species": "dog",
+      "breed": "German Shepherd",
+      "ageYears": 8,
+      "weightLbs": 72,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog is vomiting and acting lethargic since this morning.",
+    "symptomKeys": [
+      "vomiting",
+      "lethargy"
+    ],
+    "turnFocusSymptoms": [
+      "vomiting",
+      "lethargy"
+    ],
+    "expectedMustScreen": [
+      "repeated_vomiting",
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "not_drinking"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "vomiting_severity",
+      "hydration_screen",
+      "gum_color_screen",
+      "energy_change"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "vomiting_lethargy_module"
+  },
+  {
+    "id": "vomiting_and_lethargy_007",
+    "category": "urgent_same_day",
+    "complaintFamily": "vomiting_and_lethargy",
+    "pet": {
+      "species": "dog",
+      "breed": "French Bulldog",
+      "ageYears": 7,
+      "weightLbs": 28,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog has been vomiting and seems very tired today.",
+    "symptomKeys": [
+      "vomiting",
+      "lethargy"
+    ],
+    "turnFocusSymptoms": [
+      "vomiting",
+      "lethargy"
+    ],
+    "expectedMustScreen": [
+      "repeated_vomiting",
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "not_drinking"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "vomiting_severity",
+      "hydration_screen",
+      "gum_color_screen",
+      "energy_change"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "vomiting_lethargy_module"
+  },
+  {
+    "id": "bloody_diarrhea_001",
+    "category": "urgent_same_day",
+    "complaintFamily": "bloody_diarrhea",
+    "pet": {
+      "species": "dog",
+      "breed": "French Bulldog",
+      "ageYears": 3,
+      "weightLbs": 22,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog has diarrhea with blood in it.",
+    "symptomKeys": [
+      "blood_in_stool",
+      "diarrhea"
+    ],
+    "turnFocusSymptoms": [
+      "blood_in_stool",
+      "diarrhea"
+    ],
+    "expectedMustScreen": [
+      "bloody_stool_or_vomit",
+      "pale_or_blue_gums",
+      "collapse_or_weakness",
+      "not_drinking"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "gi_bleeding_screen",
+      "hydration_screen",
+      "gum_color_screen"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "gi_bleeding_module"
+  },
+  {
+    "id": "bloody_diarrhea_002",
+    "category": "urgent_same_day",
+    "complaintFamily": "bloody_diarrhea",
+    "pet": {
+      "species": "dog",
+      "breed": "Boxer",
+      "ageYears": 6,
+      "weightLbs": 56,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog passed bloody stool and seems uncomfortable.",
+    "symptomKeys": [
+      "blood_in_stool",
+      "diarrhea"
+    ],
+    "turnFocusSymptoms": [
+      "blood_in_stool",
+      "diarrhea"
+    ],
+    "expectedMustScreen": [
+      "bloody_stool_or_vomit",
+      "pale_or_blue_gums",
+      "collapse_or_weakness",
+      "not_drinking"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "gi_bleeding_screen",
+      "hydration_screen",
+      "gum_color_screen"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "gi_bleeding_module"
+  },
+  {
+    "id": "bloody_diarrhea_003",
+    "category": "urgent_same_day",
+    "complaintFamily": "bloody_diarrhea",
+    "pet": {
+      "species": "dog",
+      "breed": "Dachshund",
+      "ageYears": 11,
+      "weightLbs": 22,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog has bloody diarrhea and is going outside a lot.",
+    "symptomKeys": [
+      "blood_in_stool",
+      "diarrhea"
+    ],
+    "turnFocusSymptoms": [
+      "blood_in_stool",
+      "diarrhea"
+    ],
+    "expectedMustScreen": [
+      "bloody_stool_or_vomit",
+      "pale_or_blue_gums",
+      "collapse_or_weakness",
+      "not_drinking"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "gi_bleeding_screen",
+      "hydration_screen",
+      "gum_color_screen"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "gi_bleeding_module"
+  },
+  {
+    "id": "bloody_diarrhea_004",
+    "category": "urgent_same_day",
+    "complaintFamily": "bloody_diarrhea",
+    "pet": {
+      "species": "dog",
+      "breed": "Beagle",
+      "ageYears": 2,
+      "weightLbs": 34,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog has diarrhea with blood in it.",
+    "symptomKeys": [
+      "blood_in_stool",
+      "diarrhea"
+    ],
+    "turnFocusSymptoms": [
+      "blood_in_stool",
+      "diarrhea"
+    ],
+    "expectedMustScreen": [
+      "bloody_stool_or_vomit",
+      "pale_or_blue_gums",
+      "collapse_or_weakness",
+      "not_drinking"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "gi_bleeding_screen",
+      "hydration_screen",
+      "gum_color_screen"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "gi_bleeding_module"
+  },
+  {
+    "id": "bloody_diarrhea_005",
+    "category": "urgent_same_day",
+    "complaintFamily": "bloody_diarrhea",
+    "pet": {
+      "species": "dog",
+      "breed": "Poodle",
+      "ageYears": 6,
+      "weightLbs": 18,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog passed bloody stool and seems uncomfortable.",
+    "symptomKeys": [
+      "blood_in_stool",
+      "diarrhea"
+    ],
+    "turnFocusSymptoms": [
+      "blood_in_stool",
+      "diarrhea"
+    ],
+    "expectedMustScreen": [
+      "bloody_stool_or_vomit",
+      "pale_or_blue_gums",
+      "collapse_or_weakness",
+      "not_drinking"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "gi_bleeding_screen",
+      "hydration_screen",
+      "gum_color_screen"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "gi_bleeding_module"
+  },
+  {
+    "id": "bloody_diarrhea_006",
+    "category": "urgent_same_day",
+    "complaintFamily": "bloody_diarrhea",
+    "pet": {
+      "species": "dog",
+      "breed": "Cocker Spaniel",
+      "ageYears": 8,
+      "weightLbs": 28,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog has bloody diarrhea and is going outside a lot.",
+    "symptomKeys": [
+      "blood_in_stool",
+      "diarrhea"
+    ],
+    "turnFocusSymptoms": [
+      "blood_in_stool",
+      "diarrhea"
+    ],
+    "expectedMustScreen": [
+      "bloody_stool_or_vomit",
+      "pale_or_blue_gums",
+      "collapse_or_weakness",
+      "not_drinking"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "gi_bleeding_screen",
+      "hydration_screen",
+      "gum_color_screen"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "gi_bleeding_module"
+  },
+  {
+    "id": "bloody_diarrhea_007",
+    "category": "urgent_same_day",
+    "complaintFamily": "bloody_diarrhea",
+    "pet": {
+      "species": "dog",
+      "breed": "Mixed Breed",
+      "ageYears": 12,
+      "weightLbs": 52,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog has diarrhea with blood in it.",
+    "symptomKeys": [
+      "blood_in_stool",
+      "diarrhea"
+    ],
+    "turnFocusSymptoms": [
+      "blood_in_stool",
+      "diarrhea"
+    ],
+    "expectedMustScreen": [
+      "bloody_stool_or_vomit",
+      "pale_or_blue_gums",
+      "collapse_or_weakness",
+      "not_drinking"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "gi_bleeding_screen",
+      "hydration_screen",
+      "gum_color_screen"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "gi_bleeding_module"
+  },
+  {
+    "id": "eye_injury_001",
+    "category": "urgent_same_day",
+    "complaintFamily": "eye_injury",
+    "pet": {
+      "species": "dog",
+      "breed": "Rottweiler",
+      "ageYears": 5,
+      "weightLbs": 72,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog scratched an eye and now it looks painful.",
+    "symptomKeys": [
+      "eye_discharge"
+    ],
+    "turnFocusSymptoms": [
+      "eye_discharge"
+    ],
+    "expectedMustScreen": [
+      "vision_loss_or_eye_trauma",
+      "eye_swelling",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "eye_emergency_screen",
+      "vision_screen",
+      "trauma_history"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "eye_injury_module"
+  },
+  {
+    "id": "eye_injury_002",
+    "category": "urgent_same_day",
+    "complaintFamily": "eye_injury",
+    "pet": {
+      "species": "dog",
+      "breed": "Pug",
+      "ageYears": 7,
+      "weightLbs": 18,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog may have injured an eye and keeps squinting.",
+    "symptomKeys": [
+      "eye_discharge"
+    ],
+    "turnFocusSymptoms": [
+      "eye_discharge"
+    ],
+    "expectedMustScreen": [
+      "vision_loss_or_eye_trauma",
+      "eye_swelling",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "eye_emergency_screen",
+      "vision_screen",
+      "trauma_history"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "eye_injury_module"
+  },
+  {
+    "id": "eye_injury_003",
+    "category": "urgent_same_day",
+    "complaintFamily": "eye_injury",
+    "pet": {
+      "species": "dog",
+      "breed": "Labrador Retriever",
+      "ageYears": 8,
+      "weightLbs": 68,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog has sudden eye discharge after rubbing at the eye.",
+    "symptomKeys": [
+      "eye_discharge"
+    ],
+    "turnFocusSymptoms": [
+      "eye_discharge"
+    ],
+    "expectedMustScreen": [
+      "vision_loss_or_eye_trauma",
+      "eye_swelling",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "eye_emergency_screen",
+      "vision_screen",
+      "trauma_history"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "eye_injury_module"
+  },
+  {
+    "id": "eye_injury_004",
+    "category": "urgent_same_day",
+    "complaintFamily": "eye_injury",
+    "pet": {
+      "species": "dog",
+      "breed": "Golden Retriever",
+      "ageYears": 3,
+      "weightLbs": 80,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog scratched an eye and now it looks painful.",
+    "symptomKeys": [
+      "eye_discharge"
+    ],
+    "turnFocusSymptoms": [
+      "eye_discharge"
+    ],
+    "expectedMustScreen": [
+      "vision_loss_or_eye_trauma",
+      "eye_swelling",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "eye_emergency_screen",
+      "vision_screen",
+      "trauma_history"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "eye_injury_module"
+  },
+  {
+    "id": "eye_injury_005",
+    "category": "urgent_same_day",
+    "complaintFamily": "eye_injury",
+    "pet": {
+      "species": "dog",
+      "breed": "German Shepherd",
+      "ageYears": 5,
+      "weightLbs": 60,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog may have injured an eye and keeps squinting.",
+    "symptomKeys": [
+      "eye_discharge"
+    ],
+    "turnFocusSymptoms": [
+      "eye_discharge"
+    ],
+    "expectedMustScreen": [
+      "vision_loss_or_eye_trauma",
+      "eye_swelling",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "eye_emergency_screen",
+      "vision_screen",
+      "trauma_history"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "eye_injury_module"
+  },
+  {
+    "id": "eye_injury_006",
+    "category": "urgent_same_day",
+    "complaintFamily": "eye_injury",
+    "pet": {
+      "species": "dog",
+      "breed": "French Bulldog",
+      "ageYears": 5,
+      "weightLbs": 24,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog has sudden eye discharge after rubbing at the eye.",
+    "symptomKeys": [
+      "eye_discharge"
+    ],
+    "turnFocusSymptoms": [
+      "eye_discharge"
+    ],
+    "expectedMustScreen": [
+      "vision_loss_or_eye_trauma",
+      "eye_swelling",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "eye_emergency_screen",
+      "vision_screen",
+      "trauma_history"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "eye_injury_module"
+  },
+  {
+    "id": "non_weight_bearing_limp_001",
+    "category": "urgent_same_day",
+    "complaintFamily": "non_weight_bearing_limp",
+    "pet": {
+      "species": "dog",
+      "breed": "Pug",
+      "ageYears": 4,
+      "weightLbs": 16,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog will not put weight on one leg.",
+    "symptomKeys": [
+      "limping"
+    ],
+    "turnFocusSymptoms": [
+      "limping"
+    ],
+    "expectedMustScreen": [
+      "non_weight_bearing",
+      "fracture_or_bone_exposure",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "mobility_screen",
+      "limp_location",
+      "trauma_history"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "limp_severity_module"
+  },
+  {
+    "id": "non_weight_bearing_limp_002",
+    "category": "urgent_same_day",
+    "complaintFamily": "non_weight_bearing_limp",
+    "pet": {
+      "species": "dog",
+      "breed": "Labrador Retriever",
+      "ageYears": 6,
+      "weightLbs": 62,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog suddenly started limping and is holding the leg up.",
+    "symptomKeys": [
+      "limping"
+    ],
+    "turnFocusSymptoms": [
+      "limping"
+    ],
+    "expectedMustScreen": [
+      "non_weight_bearing",
+      "fracture_or_bone_exposure",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "mobility_screen",
+      "limp_location",
+      "trauma_history"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "limp_severity_module"
+  },
+  {
+    "id": "non_weight_bearing_limp_003",
+    "category": "urgent_same_day",
+    "complaintFamily": "non_weight_bearing_limp",
+    "pet": {
+      "species": "dog",
+      "breed": "Golden Retriever",
+      "ageYears": 9,
+      "weightLbs": 72,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog is non-weight-bearing on a back leg after playing.",
+    "symptomKeys": [
+      "limping"
+    ],
+    "turnFocusSymptoms": [
+      "limping"
+    ],
+    "expectedMustScreen": [
+      "non_weight_bearing",
+      "fracture_or_bone_exposure",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "mobility_screen",
+      "limp_location",
+      "trauma_history"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "limp_severity_module"
+  },
+  {
+    "id": "non_weight_bearing_limp_004",
+    "category": "urgent_same_day",
+    "complaintFamily": "non_weight_bearing_limp",
+    "pet": {
+      "species": "dog",
+      "breed": "German Shepherd",
+      "ageYears": 2,
+      "weightLbs": 90,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog will not put weight on one leg.",
+    "symptomKeys": [
+      "limping"
+    ],
+    "turnFocusSymptoms": [
+      "limping"
+    ],
+    "expectedMustScreen": [
+      "non_weight_bearing",
+      "fracture_or_bone_exposure",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "mobility_screen",
+      "limp_location",
+      "trauma_history"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "limp_severity_module"
+  },
+  {
+    "id": "non_weight_bearing_limp_005",
+    "category": "urgent_same_day",
+    "complaintFamily": "non_weight_bearing_limp",
+    "pet": {
+      "species": "dog",
+      "breed": "French Bulldog",
+      "ageYears": 3,
+      "weightLbs": 22,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog suddenly started limping and is holding the leg up.",
+    "symptomKeys": [
+      "limping"
+    ],
+    "turnFocusSymptoms": [
+      "limping"
+    ],
+    "expectedMustScreen": [
+      "non_weight_bearing",
+      "fracture_or_bone_exposure",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "mobility_screen",
+      "limp_location",
+      "trauma_history"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "limp_severity_module"
+  },
+  {
+    "id": "non_weight_bearing_limp_006",
+    "category": "urgent_same_day",
+    "complaintFamily": "non_weight_bearing_limp",
+    "pet": {
+      "species": "dog",
+      "breed": "Boxer",
+      "ageYears": 6,
+      "weightLbs": 56,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog is non-weight-bearing on a back leg after playing.",
+    "symptomKeys": [
+      "limping"
+    ],
+    "turnFocusSymptoms": [
+      "limping"
+    ],
+    "expectedMustScreen": [
+      "non_weight_bearing",
+      "fracture_or_bone_exposure",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "mobility_screen",
+      "limp_location",
+      "trauma_history"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "limp_severity_module"
+  },
+  {
+    "id": "non_weight_bearing_limp_007",
+    "category": "urgent_same_day",
+    "complaintFamily": "non_weight_bearing_limp",
+    "pet": {
+      "species": "dog",
+      "breed": "Dachshund",
+      "ageYears": 11,
+      "weightLbs": 22,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog will not put weight on one leg.",
+    "symptomKeys": [
+      "limping"
+    ],
+    "turnFocusSymptoms": [
+      "limping"
+    ],
+    "expectedMustScreen": [
+      "non_weight_bearing",
+      "fracture_or_bone_exposure",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "mobility_screen",
+      "limp_location",
+      "trauma_history"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "limp_severity_module"
+  },
+  {
+    "id": "wound_or_bite_001",
+    "category": "urgent_same_day",
+    "complaintFamily": "wound_or_bite",
+    "pet": {
+      "species": "dog",
+      "breed": "Golden Retriever",
+      "ageYears": 5,
+      "weightLbs": 58,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog has a bite wound from another dog.",
+    "symptomKeys": [
+      "wound_skin_issue"
+    ],
+    "turnFocusSymptoms": [
+      "wound_skin_issue"
+    ],
+    "expectedMustScreen": [
+      "wound_depth_or_bleeding",
+      "fracture_or_bone_exposure",
+      "pale_or_blue_gums",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "wound_severity",
+      "bleeding_screen",
+      "bite_trauma_history"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "wound_bite_module"
+  },
+  {
+    "id": "wound_or_bite_002",
+    "category": "urgent_same_day",
+    "complaintFamily": "wound_or_bite",
+    "pet": {
+      "species": "dog",
+      "breed": "German Shepherd",
+      "ageYears": 8,
+      "weightLbs": 72,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog has an open wound on the side that looks painful.",
+    "symptomKeys": [
+      "wound_skin_issue"
+    ],
+    "turnFocusSymptoms": [
+      "wound_skin_issue"
+    ],
+    "expectedMustScreen": [
+      "wound_depth_or_bleeding",
+      "fracture_or_bone_exposure",
+      "pale_or_blue_gums",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "wound_severity",
+      "bleeding_screen",
+      "bite_trauma_history"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "wound_bite_module"
+  },
+  {
+    "id": "wound_or_bite_003",
+    "category": "urgent_same_day",
+    "complaintFamily": "wound_or_bite",
+    "pet": {
+      "species": "dog",
+      "breed": "French Bulldog",
+      "ageYears": 7,
+      "weightLbs": 28,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog was bitten and now has a raw wound that is oozing.",
+    "symptomKeys": [
+      "wound_skin_issue"
+    ],
+    "turnFocusSymptoms": [
+      "wound_skin_issue"
+    ],
+    "expectedMustScreen": [
+      "wound_depth_or_bleeding",
+      "fracture_or_bone_exposure",
+      "pale_or_blue_gums",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "wound_severity",
+      "bleeding_screen",
+      "bite_trauma_history"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "wound_bite_module"
+  },
+  {
+    "id": "wound_or_bite_004",
+    "category": "urgent_same_day",
+    "complaintFamily": "wound_or_bite",
+    "pet": {
+      "species": "dog",
+      "breed": "Boxer",
+      "ageYears": 2,
+      "weightLbs": 72,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog has a bite wound from another dog.",
+    "symptomKeys": [
+      "wound_skin_issue"
+    ],
+    "turnFocusSymptoms": [
+      "wound_skin_issue"
+    ],
+    "expectedMustScreen": [
+      "wound_depth_or_bleeding",
+      "fracture_or_bone_exposure",
+      "pale_or_blue_gums",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "wound_severity",
+      "bleeding_screen",
+      "bite_trauma_history"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "wound_bite_module"
+  },
+  {
+    "id": "wound_or_bite_005",
+    "category": "urgent_same_day",
+    "complaintFamily": "wound_or_bite",
+    "pet": {
+      "species": "dog",
+      "breed": "Dachshund",
+      "ageYears": 5,
+      "weightLbs": 14,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog has an open wound on the side that looks painful.",
+    "symptomKeys": [
+      "wound_skin_issue"
+    ],
+    "turnFocusSymptoms": [
+      "wound_skin_issue"
+    ],
+    "expectedMustScreen": [
+      "wound_depth_or_bleeding",
+      "fracture_or_bone_exposure",
+      "pale_or_blue_gums",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "wound_severity",
+      "bleeding_screen",
+      "bite_trauma_history"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "wound_bite_module"
+  },
+  {
+    "id": "wound_or_bite_006",
+    "category": "urgent_same_day",
+    "complaintFamily": "wound_or_bite",
+    "pet": {
+      "species": "dog",
+      "breed": "Beagle",
+      "ageYears": 7,
+      "weightLbs": 26,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog was bitten and now has a raw wound that is oozing.",
+    "symptomKeys": [
+      "wound_skin_issue"
+    ],
+    "turnFocusSymptoms": [
+      "wound_skin_issue"
+    ],
+    "expectedMustScreen": [
+      "wound_depth_or_bleeding",
+      "fracture_or_bone_exposure",
+      "pale_or_blue_gums",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "wound_severity",
+      "bleeding_screen",
+      "bite_trauma_history"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "wound_bite_module"
+  },
+  {
+    "id": "wound_or_bite_007",
+    "category": "urgent_same_day",
+    "complaintFamily": "wound_or_bite",
+    "pet": {
+      "species": "dog",
+      "breed": "Poodle",
+      "ageYears": 12,
+      "weightLbs": 36,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog has a bite wound from another dog.",
+    "symptomKeys": [
+      "wound_skin_issue"
+    ],
+    "turnFocusSymptoms": [
+      "wound_skin_issue"
+    ],
+    "expectedMustScreen": [
+      "wound_depth_or_bleeding",
+      "fracture_or_bone_exposure",
+      "pale_or_blue_gums",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "wound_severity",
+      "bleeding_screen",
+      "bite_trauma_history"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "wound_bite_module"
+  },
+  {
+    "id": "painful_abdomen_without_collapse_001",
+    "category": "urgent_same_day",
+    "complaintFamily": "painful_abdomen_without_collapse",
+    "pet": {
+      "species": "dog",
+      "breed": "Cocker Spaniel",
+      "ageYears": 5,
+      "weightLbs": 24,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog seems painful in the belly but has not collapsed.",
+    "symptomKeys": [
+      "swollen_abdomen"
+    ],
+    "turnFocusSymptoms": [
+      "swollen_abdomen"
+    ],
+    "expectedMustScreen": [
+      "abdominal_distension",
+      "repeated_vomiting",
+      "collapse_or_weakness",
+      "not_drinking"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "abdominal_emergency_screen",
+      "pain_severity",
+      "vomiting_screen"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "abdominal_pain_module"
+  },
+  {
+    "id": "painful_abdomen_without_collapse_002",
+    "category": "urgent_same_day",
+    "complaintFamily": "painful_abdomen_without_collapse",
+    "pet": {
+      "species": "dog",
+      "breed": "Mixed Breed",
+      "ageYears": 8,
+      "weightLbs": 38,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog cries when I touch the abdomen and seems uncomfortable.",
+    "symptomKeys": [
+      "swollen_abdomen"
+    ],
+    "turnFocusSymptoms": [
+      "swollen_abdomen"
+    ],
+    "expectedMustScreen": [
+      "abdominal_distension",
+      "repeated_vomiting",
+      "collapse_or_weakness",
+      "not_drinking"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "abdominal_emergency_screen",
+      "pain_severity",
+      "vomiting_screen"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "abdominal_pain_module"
+  },
+  {
+    "id": "painful_abdomen_without_collapse_003",
+    "category": "urgent_same_day",
+    "complaintFamily": "painful_abdomen_without_collapse",
+    "pet": {
+      "species": "dog",
+      "breed": "Rottweiler",
+      "ageYears": 9,
+      "weightLbs": 96,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog looks tucked up and painful through the belly today.",
+    "symptomKeys": [
+      "swollen_abdomen"
+    ],
+    "turnFocusSymptoms": [
+      "swollen_abdomen"
+    ],
+    "expectedMustScreen": [
+      "abdominal_distension",
+      "repeated_vomiting",
+      "collapse_or_weakness",
+      "not_drinking"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "abdominal_emergency_screen",
+      "pain_severity",
+      "vomiting_screen"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "abdominal_pain_module"
+  },
+  {
+    "id": "painful_abdomen_without_collapse_004",
+    "category": "urgent_same_day",
+    "complaintFamily": "painful_abdomen_without_collapse",
+    "pet": {
+      "species": "dog",
+      "breed": "Pug",
+      "ageYears": 2,
+      "weightLbs": 22,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog seems painful in the belly but has not collapsed.",
+    "symptomKeys": [
+      "swollen_abdomen"
+    ],
+    "turnFocusSymptoms": [
+      "swollen_abdomen"
+    ],
+    "expectedMustScreen": [
+      "abdominal_distension",
+      "repeated_vomiting",
+      "collapse_or_weakness",
+      "not_drinking"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "abdominal_emergency_screen",
+      "pain_severity",
+      "vomiting_screen"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "abdominal_pain_module"
+  },
+  {
+    "id": "painful_abdomen_without_collapse_005",
+    "category": "urgent_same_day",
+    "complaintFamily": "painful_abdomen_without_collapse",
+    "pet": {
+      "species": "dog",
+      "breed": "Labrador Retriever",
+      "ageYears": 4,
+      "weightLbs": 55,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog cries when I touch the abdomen and seems uncomfortable.",
+    "symptomKeys": [
+      "swollen_abdomen"
+    ],
+    "turnFocusSymptoms": [
+      "swollen_abdomen"
+    ],
+    "expectedMustScreen": [
+      "abdominal_distension",
+      "repeated_vomiting",
+      "collapse_or_weakness",
+      "not_drinking"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "abdominal_emergency_screen",
+      "pain_severity",
+      "vomiting_screen"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "abdominal_pain_module"
+  },
+  {
+    "id": "painful_abdomen_without_collapse_006",
+    "category": "urgent_same_day",
+    "complaintFamily": "painful_abdomen_without_collapse",
+    "pet": {
+      "species": "dog",
+      "breed": "Golden Retriever",
+      "ageYears": 7,
+      "weightLbs": 65,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog looks tucked up and painful through the belly today.",
+    "symptomKeys": [
+      "swollen_abdomen"
+    ],
+    "turnFocusSymptoms": [
+      "swollen_abdomen"
+    ],
+    "expectedMustScreen": [
+      "abdominal_distension",
+      "repeated_vomiting",
+      "collapse_or_weakness",
+      "not_drinking"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "abdominal_emergency_screen",
+      "pain_severity",
+      "vomiting_screen"
+    ],
+    "expectedUrgency": "same_day_or_urgent_exam",
+    "recommendedFirstModule": "abdominal_pain_module"
+  },
+  {
+    "id": "mild_itching_001",
+    "category": "routine_unclear",
+    "complaintFamily": "mild_itching",
+    "pet": {
+      "species": "dog",
+      "breed": "Labrador Retriever",
+      "ageYears": 4,
+      "weightLbs": 55,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog has mild itching but is otherwise acting normal.",
+    "symptomKeys": [
+      "excessive_scratching"
+    ],
+    "turnFocusSymptoms": [
+      "excessive_scratching"
+    ],
+    "expectedMustScreen": [
+      "facial_swelling",
+      "breathing_difficulty",
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "repeated_vomiting"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "emergency_allergy_screen",
+      "itch_location",
+      "skin_changes"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "itching_module"
+  },
+  {
+    "id": "mild_itching_002",
+    "category": "routine_unclear",
+    "complaintFamily": "mild_itching",
+    "pet": {
+      "species": "dog",
+      "breed": "Golden Retriever",
+      "ageYears": 7,
+      "weightLbs": 65,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog keeps scratching a little but is eating and playing normally.",
+    "symptomKeys": [
+      "excessive_scratching"
+    ],
+    "turnFocusSymptoms": [
+      "excessive_scratching"
+    ],
+    "expectedMustScreen": [
+      "facial_swelling",
+      "breathing_difficulty",
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "repeated_vomiting"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "emergency_allergy_screen",
+      "itch_location",
+      "skin_changes"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "itching_module"
+  },
+  {
+    "id": "mild_itching_003",
+    "category": "routine_unclear",
+    "complaintFamily": "mild_itching",
+    "pet": {
+      "species": "dog",
+      "breed": "German Shepherd",
+      "ageYears": 10,
+      "weightLbs": 82,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog has some mild itchiness on and off this week.",
+    "symptomKeys": [
+      "excessive_scratching"
+    ],
+    "turnFocusSymptoms": [
+      "excessive_scratching"
+    ],
+    "expectedMustScreen": [
+      "facial_swelling",
+      "breathing_difficulty",
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "repeated_vomiting"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "emergency_allergy_screen",
+      "itch_location",
+      "skin_changes"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "itching_module"
+  },
+  {
+    "id": "mild_itching_004",
+    "category": "routine_unclear",
+    "complaintFamily": "mild_itching",
+    "pet": {
+      "species": "dog",
+      "breed": "French Bulldog",
+      "ageYears": 1,
+      "weightLbs": 30,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog has mild itching but is otherwise acting normal.",
+    "symptomKeys": [
+      "excessive_scratching"
+    ],
+    "turnFocusSymptoms": [
+      "excessive_scratching"
+    ],
+    "expectedMustScreen": [
+      "facial_swelling",
+      "breathing_difficulty",
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "repeated_vomiting"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "emergency_allergy_screen",
+      "itch_location",
+      "skin_changes"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "itching_module"
+  },
+  {
+    "id": "mild_itching_005",
+    "category": "routine_unclear",
+    "complaintFamily": "mild_itching",
+    "pet": {
+      "species": "dog",
+      "breed": "Boxer",
+      "ageYears": 4,
+      "weightLbs": 48,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog keeps scratching a little but is eating and playing normally.",
+    "symptomKeys": [
+      "excessive_scratching"
+    ],
+    "turnFocusSymptoms": [
+      "excessive_scratching"
+    ],
+    "expectedMustScreen": [
+      "facial_swelling",
+      "breathing_difficulty",
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "repeated_vomiting"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "emergency_allergy_screen",
+      "itch_location",
+      "skin_changes"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "itching_module"
+  },
+  {
+    "id": "mild_itching_006",
+    "category": "routine_unclear",
+    "complaintFamily": "mild_itching",
+    "pet": {
+      "species": "dog",
+      "breed": "Dachshund",
+      "ageYears": 7,
+      "weightLbs": 18,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog has some mild itchiness on and off this week.",
+    "symptomKeys": [
+      "excessive_scratching"
+    ],
+    "turnFocusSymptoms": [
+      "excessive_scratching"
+    ],
+    "expectedMustScreen": [
+      "facial_swelling",
+      "breathing_difficulty",
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "repeated_vomiting"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "emergency_allergy_screen",
+      "itch_location",
+      "skin_changes"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "itching_module"
+  },
+  {
+    "id": "mild_itching_007",
+    "category": "routine_unclear",
+    "complaintFamily": "mild_itching",
+    "pet": {
+      "species": "dog",
+      "breed": "Beagle",
+      "ageYears": 10,
+      "weightLbs": 30,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog has mild itching but is otherwise acting normal.",
+    "symptomKeys": [
+      "excessive_scratching"
+    ],
+    "turnFocusSymptoms": [
+      "excessive_scratching"
+    ],
+    "expectedMustScreen": [
+      "facial_swelling",
+      "breathing_difficulty",
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "repeated_vomiting"
+    ],
+    "badFirstQuestions": [
+      "How old is your dog?",
+      "Can you tell me more?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "emergency_allergy_screen",
+      "itch_location",
+      "skin_changes"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "itching_module"
+  },
+  {
+    "id": "mild_limp_001",
+    "category": "routine_unclear",
+    "complaintFamily": "mild_limp",
+    "pet": {
+      "species": "dog",
+      "breed": "Mixed Breed",
+      "ageYears": 4,
+      "weightLbs": 25,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog has a mild limp after a long walk.",
+    "symptomKeys": [
+      "limping"
+    ],
+    "turnFocusSymptoms": [
+      "limping"
+    ],
+    "expectedMustScreen": [
+      "non_weight_bearing",
+      "fracture_or_bone_exposure",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "limp_location",
+      "limp_timing",
+      "weight_bearing"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "mild_limp_module"
+  },
+  {
+    "id": "mild_limp_002",
+    "category": "routine_unclear",
+    "complaintFamily": "mild_limp",
+    "pet": {
+      "species": "dog",
+      "breed": "Rottweiler",
+      "ageYears": 7,
+      "weightLbs": 84,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog is favoring one leg a little but still walks on it.",
+    "symptomKeys": [
+      "limping"
+    ],
+    "turnFocusSymptoms": [
+      "limping"
+    ],
+    "expectedMustScreen": [
+      "non_weight_bearing",
+      "fracture_or_bone_exposure",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "limp_location",
+      "limp_timing",
+      "weight_bearing"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "mild_limp_module"
+  },
+  {
+    "id": "mild_limp_003",
+    "category": "routine_unclear",
+    "complaintFamily": "mild_limp",
+    "pet": {
+      "species": "dog",
+      "breed": "Pug",
+      "ageYears": 10,
+      "weightLbs": 20,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog seems a bit stiff and mildly lame after resting.",
+    "symptomKeys": [
+      "limping"
+    ],
+    "turnFocusSymptoms": [
+      "limping"
+    ],
+    "expectedMustScreen": [
+      "non_weight_bearing",
+      "fracture_or_bone_exposure",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "limp_location",
+      "limp_timing",
+      "weight_bearing"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "mild_limp_module"
+  },
+  {
+    "id": "mild_limp_004",
+    "category": "routine_unclear",
+    "complaintFamily": "mild_limp",
+    "pet": {
+      "species": "dog",
+      "breed": "Labrador Retriever",
+      "ageYears": 2,
+      "weightLbs": 74,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog has a mild limp after a long walk.",
+    "symptomKeys": [
+      "limping"
+    ],
+    "turnFocusSymptoms": [
+      "limping"
+    ],
+    "expectedMustScreen": [
+      "non_weight_bearing",
+      "fracture_or_bone_exposure",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "limp_location",
+      "limp_timing",
+      "weight_bearing"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "mild_limp_module"
+  },
+  {
+    "id": "mild_limp_005",
+    "category": "routine_unclear",
+    "complaintFamily": "mild_limp",
+    "pet": {
+      "species": "dog",
+      "breed": "Golden Retriever",
+      "ageYears": 5,
+      "weightLbs": 58,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog is favoring one leg a little but still walks on it.",
+    "symptomKeys": [
+      "limping"
+    ],
+    "turnFocusSymptoms": [
+      "limping"
+    ],
+    "expectedMustScreen": [
+      "non_weight_bearing",
+      "fracture_or_bone_exposure",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "limp_location",
+      "limp_timing",
+      "weight_bearing"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "mild_limp_module"
+  },
+  {
+    "id": "mild_limp_006",
+    "category": "routine_unclear",
+    "complaintFamily": "mild_limp",
+    "pet": {
+      "species": "dog",
+      "breed": "German Shepherd",
+      "ageYears": 8,
+      "weightLbs": 72,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog seems a bit stiff and mildly lame after resting.",
+    "symptomKeys": [
+      "limping"
+    ],
+    "turnFocusSymptoms": [
+      "limping"
+    ],
+    "expectedMustScreen": [
+      "non_weight_bearing",
+      "fracture_or_bone_exposure",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "limp_location",
+      "limp_timing",
+      "weight_bearing"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "mild_limp_module"
+  },
+  {
+    "id": "mild_limp_007",
+    "category": "routine_unclear",
+    "complaintFamily": "mild_limp",
+    "pet": {
+      "species": "dog",
+      "breed": "French Bulldog",
+      "ageYears": 7,
+      "weightLbs": 28,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog has a mild limp after a long walk.",
+    "symptomKeys": [
+      "limping"
+    ],
+    "turnFocusSymptoms": [
+      "limping"
+    ],
+    "expectedMustScreen": [
+      "non_weight_bearing",
+      "fracture_or_bone_exposure",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "limp_location",
+      "limp_timing",
+      "weight_bearing"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "mild_limp_module"
+  },
+  {
+    "id": "eating_less_001",
+    "category": "routine_unclear",
+    "complaintFamily": "eating_less",
+    "pet": {
+      "species": "dog",
+      "breed": "Pug",
+      "ageYears": 4,
+      "weightLbs": 16,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog is eating less than usual but still interested in treats.",
+    "symptomKeys": [
+      "not_eating"
+    ],
+    "turnFocusSymptoms": [
+      "not_eating"
+    ],
+    "expectedMustScreen": [
+      "repeated_vomiting",
+      "not_drinking",
+      "collapse_or_weakness",
+      "pale_or_blue_gums"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "appetite_duration",
+      "hydration_screen",
+      "vomiting_screen"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "reduced_appetite_module"
+  },
+  {
+    "id": "eating_less_002",
+    "category": "routine_unclear",
+    "complaintFamily": "eating_less",
+    "pet": {
+      "species": "dog",
+      "breed": "Labrador Retriever",
+      "ageYears": 6,
+      "weightLbs": 62,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog has a lower appetite over the last day or two.",
+    "symptomKeys": [
+      "not_eating"
+    ],
+    "turnFocusSymptoms": [
+      "not_eating"
+    ],
+    "expectedMustScreen": [
+      "repeated_vomiting",
+      "not_drinking",
+      "collapse_or_weakness",
+      "pale_or_blue_gums"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "appetite_duration",
+      "hydration_screen",
+      "vomiting_screen"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "reduced_appetite_module"
+  },
+  {
+    "id": "eating_less_003",
+    "category": "routine_unclear",
+    "complaintFamily": "eating_less",
+    "pet": {
+      "species": "dog",
+      "breed": "Golden Retriever",
+      "ageYears": 9,
+      "weightLbs": 72,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog is picky with meals but not completely refusing food.",
+    "symptomKeys": [
+      "not_eating"
+    ],
+    "turnFocusSymptoms": [
+      "not_eating"
+    ],
+    "expectedMustScreen": [
+      "repeated_vomiting",
+      "not_drinking",
+      "collapse_or_weakness",
+      "pale_or_blue_gums"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "appetite_duration",
+      "hydration_screen",
+      "vomiting_screen"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "reduced_appetite_module"
+  },
+  {
+    "id": "eating_less_004",
+    "category": "routine_unclear",
+    "complaintFamily": "eating_less",
+    "pet": {
+      "species": "dog",
+      "breed": "German Shepherd",
+      "ageYears": 2,
+      "weightLbs": 90,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog is eating less than usual but still interested in treats.",
+    "symptomKeys": [
+      "not_eating"
+    ],
+    "turnFocusSymptoms": [
+      "not_eating"
+    ],
+    "expectedMustScreen": [
+      "repeated_vomiting",
+      "not_drinking",
+      "collapse_or_weakness",
+      "pale_or_blue_gums"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "appetite_duration",
+      "hydration_screen",
+      "vomiting_screen"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "reduced_appetite_module"
+  },
+  {
+    "id": "eating_less_005",
+    "category": "routine_unclear",
+    "complaintFamily": "eating_less",
+    "pet": {
+      "species": "dog",
+      "breed": "French Bulldog",
+      "ageYears": 3,
+      "weightLbs": 22,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog has a lower appetite over the last day or two.",
+    "symptomKeys": [
+      "not_eating"
+    ],
+    "turnFocusSymptoms": [
+      "not_eating"
+    ],
+    "expectedMustScreen": [
+      "repeated_vomiting",
+      "not_drinking",
+      "collapse_or_weakness",
+      "pale_or_blue_gums"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "appetite_duration",
+      "hydration_screen",
+      "vomiting_screen"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "reduced_appetite_module"
+  },
+  {
+    "id": "eating_less_006",
+    "category": "routine_unclear",
+    "complaintFamily": "eating_less",
+    "pet": {
+      "species": "dog",
+      "breed": "Boxer",
+      "ageYears": 6,
+      "weightLbs": 56,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog is picky with meals but not completely refusing food.",
+    "symptomKeys": [
+      "not_eating"
+    ],
+    "turnFocusSymptoms": [
+      "not_eating"
+    ],
+    "expectedMustScreen": [
+      "repeated_vomiting",
+      "not_drinking",
+      "collapse_or_weakness",
+      "pale_or_blue_gums"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "appetite_duration",
+      "hydration_screen",
+      "vomiting_screen"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "reduced_appetite_module"
+  },
+  {
+    "id": "ear_scratching_001",
+    "category": "routine_unclear",
+    "complaintFamily": "ear_scratching",
+    "pet": {
+      "species": "dog",
+      "breed": "German Shepherd",
+      "ageYears": 5,
+      "weightLbs": 60,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog keeps scratching one ear.",
+    "symptomKeys": [
+      "ear_scratching"
+    ],
+    "turnFocusSymptoms": [
+      "ear_scratching"
+    ],
+    "expectedMustScreen": [
+      "head_tilt_balance",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "ear_discharge",
+      "head_tilt_balance",
+      "itch_location"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "ear_scratching_module"
+  },
+  {
+    "id": "ear_scratching_002",
+    "category": "routine_unclear",
+    "complaintFamily": "ear_scratching",
+    "pet": {
+      "species": "dog",
+      "breed": "French Bulldog",
+      "ageYears": 5,
+      "weightLbs": 24,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog has been pawing at an ear and shaking the head some.",
+    "symptomKeys": [
+      "ear_scratching"
+    ],
+    "turnFocusSymptoms": [
+      "ear_scratching"
+    ],
+    "expectedMustScreen": [
+      "head_tilt_balance",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "ear_discharge",
+      "head_tilt_balance",
+      "itch_location"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "ear_scratching_module"
+  },
+  {
+    "id": "ear_scratching_003",
+    "category": "routine_unclear",
+    "complaintFamily": "ear_scratching",
+    "pet": {
+      "species": "dog",
+      "breed": "Boxer",
+      "ageYears": 8,
+      "weightLbs": 64,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog keeps scratching around the ears and seems annoyed.",
+    "symptomKeys": [
+      "ear_scratching"
+    ],
+    "turnFocusSymptoms": [
+      "ear_scratching"
+    ],
+    "expectedMustScreen": [
+      "head_tilt_balance",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "ear_discharge",
+      "head_tilt_balance",
+      "itch_location"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "ear_scratching_module"
+  },
+  {
+    "id": "ear_scratching_004",
+    "category": "routine_unclear",
+    "complaintFamily": "ear_scratching",
+    "pet": {
+      "species": "dog",
+      "breed": "Dachshund",
+      "ageYears": 3,
+      "weightLbs": 26,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog keeps scratching one ear.",
+    "symptomKeys": [
+      "ear_scratching"
+    ],
+    "turnFocusSymptoms": [
+      "ear_scratching"
+    ],
+    "expectedMustScreen": [
+      "head_tilt_balance",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "ear_discharge",
+      "head_tilt_balance",
+      "itch_location"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "ear_scratching_module"
+  },
+  {
+    "id": "ear_scratching_005",
+    "category": "routine_unclear",
+    "complaintFamily": "ear_scratching",
+    "pet": {
+      "species": "dog",
+      "breed": "Beagle",
+      "ageYears": 4,
+      "weightLbs": 22,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog has been pawing at an ear and shaking the head some.",
+    "symptomKeys": [
+      "ear_scratching"
+    ],
+    "turnFocusSymptoms": [
+      "ear_scratching"
+    ],
+    "expectedMustScreen": [
+      "head_tilt_balance",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "ear_discharge",
+      "head_tilt_balance",
+      "itch_location"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "ear_scratching_module"
+  },
+  {
+    "id": "ear_scratching_006",
+    "category": "routine_unclear",
+    "complaintFamily": "ear_scratching",
+    "pet": {
+      "species": "dog",
+      "breed": "Poodle",
+      "ageYears": 9,
+      "weightLbs": 24,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog keeps scratching around the ears and seems annoyed.",
+    "symptomKeys": [
+      "ear_scratching"
+    ],
+    "turnFocusSymptoms": [
+      "ear_scratching"
+    ],
+    "expectedMustScreen": [
+      "head_tilt_balance",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "ear_discharge",
+      "head_tilt_balance",
+      "itch_location"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "ear_scratching_module"
+  },
+  {
+    "id": "ear_scratching_007",
+    "category": "routine_unclear",
+    "complaintFamily": "ear_scratching",
+    "pet": {
+      "species": "dog",
+      "breed": "Cocker Spaniel",
+      "ageYears": 11,
+      "weightLbs": 32,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog keeps scratching one ear.",
+    "symptomKeys": [
+      "ear_scratching"
+    ],
+    "turnFocusSymptoms": [
+      "ear_scratching"
+    ],
+    "expectedMustScreen": [
+      "head_tilt_balance",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "ear_discharge",
+      "head_tilt_balance",
+      "itch_location"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "ear_scratching_module"
+  },
+  {
+    "id": "occasional_vomiting_001",
+    "category": "routine_unclear",
+    "complaintFamily": "occasional_vomiting",
+    "pet": {
+      "species": "dog",
+      "breed": "Poodle",
+      "ageYears": 6,
+      "weightLbs": 18,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog vomited once and otherwise seems okay.",
+    "symptomKeys": [
+      "vomiting"
+    ],
+    "turnFocusSymptoms": [
+      "vomiting"
+    ],
+    "expectedMustScreen": [
+      "repeated_vomiting",
+      "not_drinking",
+      "collapse_or_weakness",
+      "pale_or_blue_gums"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "vomiting_severity",
+      "hydration_screen",
+      "dietary_change"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "vomiting_module"
+  },
+  {
+    "id": "occasional_vomiting_002",
+    "category": "routine_unclear",
+    "complaintFamily": "occasional_vomiting",
+    "pet": {
+      "species": "dog",
+      "breed": "Cocker Spaniel",
+      "ageYears": 8,
+      "weightLbs": 28,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog has had occasional vomiting but is still drinking.",
+    "symptomKeys": [
+      "vomiting"
+    ],
+    "turnFocusSymptoms": [
+      "vomiting"
+    ],
+    "expectedMustScreen": [
+      "repeated_vomiting",
+      "not_drinking",
+      "collapse_or_weakness",
+      "pale_or_blue_gums"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "vomiting_severity",
+      "hydration_screen",
+      "dietary_change"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "vomiting_module"
+  },
+  {
+    "id": "occasional_vomiting_003",
+    "category": "routine_unclear",
+    "complaintFamily": "occasional_vomiting",
+    "pet": {
+      "species": "dog",
+      "breed": "Mixed Breed",
+      "ageYears": 12,
+      "weightLbs": 52,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog threw up earlier and now seems mostly normal.",
+    "symptomKeys": [
+      "vomiting"
+    ],
+    "turnFocusSymptoms": [
+      "vomiting"
+    ],
+    "expectedMustScreen": [
+      "repeated_vomiting",
+      "not_drinking",
+      "collapse_or_weakness",
+      "pale_or_blue_gums"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "vomiting_severity",
+      "hydration_screen",
+      "dietary_change"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "vomiting_module"
+  },
+  {
+    "id": "occasional_vomiting_004",
+    "category": "routine_unclear",
+    "complaintFamily": "occasional_vomiting",
+    "pet": {
+      "species": "dog",
+      "breed": "Rottweiler",
+      "ageYears": 3,
+      "weightLbs": 108,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog vomited once and otherwise seems okay.",
+    "symptomKeys": [
+      "vomiting"
+    ],
+    "turnFocusSymptoms": [
+      "vomiting"
+    ],
+    "expectedMustScreen": [
+      "repeated_vomiting",
+      "not_drinking",
+      "collapse_or_weakness",
+      "pale_or_blue_gums"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "vomiting_severity",
+      "hydration_screen",
+      "dietary_change"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "vomiting_module"
+  },
+  {
+    "id": "occasional_vomiting_005",
+    "category": "routine_unclear",
+    "complaintFamily": "occasional_vomiting",
+    "pet": {
+      "species": "dog",
+      "breed": "Pug",
+      "ageYears": 4,
+      "weightLbs": 16,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog has had occasional vomiting but is still drinking.",
+    "symptomKeys": [
+      "vomiting"
+    ],
+    "turnFocusSymptoms": [
+      "vomiting"
+    ],
+    "expectedMustScreen": [
+      "repeated_vomiting",
+      "not_drinking",
+      "collapse_or_weakness",
+      "pale_or_blue_gums"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "vomiting_severity",
+      "hydration_screen",
+      "dietary_change"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "vomiting_module"
+  },
+  {
+    "id": "occasional_vomiting_006",
+    "category": "routine_unclear",
+    "complaintFamily": "occasional_vomiting",
+    "pet": {
+      "species": "dog",
+      "breed": "Labrador Retriever",
+      "ageYears": 6,
+      "weightLbs": 62,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog threw up earlier and now seems mostly normal.",
+    "symptomKeys": [
+      "vomiting"
+    ],
+    "turnFocusSymptoms": [
+      "vomiting"
+    ],
+    "expectedMustScreen": [
+      "repeated_vomiting",
+      "not_drinking",
+      "collapse_or_weakness",
+      "pale_or_blue_gums"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "vomiting_severity",
+      "hydration_screen",
+      "dietary_change"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "vomiting_module"
+  },
+  {
+    "id": "occasional_vomiting_007",
+    "category": "routine_unclear",
+    "complaintFamily": "occasional_vomiting",
+    "pet": {
+      "species": "dog",
+      "breed": "Golden Retriever",
+      "ageYears": 9,
+      "weightLbs": 72,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog vomited once and otherwise seems okay.",
+    "symptomKeys": [
+      "vomiting"
+    ],
+    "turnFocusSymptoms": [
+      "vomiting"
+    ],
+    "expectedMustScreen": [
+      "repeated_vomiting",
+      "not_drinking",
+      "collapse_or_weakness",
+      "pale_or_blue_gums"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "vomiting_severity",
+      "hydration_screen",
+      "dietary_change"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "vomiting_module"
+  },
+  {
+    "id": "mild_diarrhea_001",
+    "category": "routine_unclear",
+    "complaintFamily": "mild_diarrhea",
+    "pet": {
+      "species": "dog",
+      "breed": "Golden Retriever",
+      "ageYears": 5,
+      "weightLbs": 58,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog has mild diarrhea but is otherwise okay.",
+    "symptomKeys": [
+      "diarrhea"
+    ],
+    "turnFocusSymptoms": [
+      "diarrhea"
+    ],
+    "expectedMustScreen": [
+      "bloody_stool_or_vomit",
+      "not_drinking",
+      "collapse_or_weakness",
+      "pale_or_blue_gums"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "stool_blood_screen",
+      "stool_consistency",
+      "hydration_screen"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "mild_diarrhea_module"
+  },
+  {
+    "id": "mild_diarrhea_002",
+    "category": "routine_unclear",
+    "complaintFamily": "mild_diarrhea",
+    "pet": {
+      "species": "dog",
+      "breed": "German Shepherd",
+      "ageYears": 8,
+      "weightLbs": 72,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog has softer stool today and still wants to eat.",
+    "symptomKeys": [
+      "diarrhea"
+    ],
+    "turnFocusSymptoms": [
+      "diarrhea"
+    ],
+    "expectedMustScreen": [
+      "bloody_stool_or_vomit",
+      "not_drinking",
+      "collapse_or_weakness",
+      "pale_or_blue_gums"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "stool_blood_screen",
+      "stool_consistency",
+      "hydration_screen"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "mild_diarrhea_module"
+  },
+  {
+    "id": "mild_diarrhea_003",
+    "category": "routine_unclear",
+    "complaintFamily": "mild_diarrhea",
+    "pet": {
+      "species": "dog",
+      "breed": "French Bulldog",
+      "ageYears": 7,
+      "weightLbs": 28,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog has a mild bout of diarrhea with no other big changes.",
+    "symptomKeys": [
+      "diarrhea"
+    ],
+    "turnFocusSymptoms": [
+      "diarrhea"
+    ],
+    "expectedMustScreen": [
+      "bloody_stool_or_vomit",
+      "not_drinking",
+      "collapse_or_weakness",
+      "pale_or_blue_gums"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "stool_blood_screen",
+      "stool_consistency",
+      "hydration_screen"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "mild_diarrhea_module"
+  },
+  {
+    "id": "mild_diarrhea_004",
+    "category": "routine_unclear",
+    "complaintFamily": "mild_diarrhea",
+    "pet": {
+      "species": "dog",
+      "breed": "Boxer",
+      "ageYears": 2,
+      "weightLbs": 72,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog has mild diarrhea but is otherwise okay.",
+    "symptomKeys": [
+      "diarrhea"
+    ],
+    "turnFocusSymptoms": [
+      "diarrhea"
+    ],
+    "expectedMustScreen": [
+      "bloody_stool_or_vomit",
+      "not_drinking",
+      "collapse_or_weakness",
+      "pale_or_blue_gums"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "stool_blood_screen",
+      "stool_consistency",
+      "hydration_screen"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "mild_diarrhea_module"
+  },
+  {
+    "id": "mild_diarrhea_005",
+    "category": "routine_unclear",
+    "complaintFamily": "mild_diarrhea",
+    "pet": {
+      "species": "dog",
+      "breed": "Dachshund",
+      "ageYears": 5,
+      "weightLbs": 14,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog has softer stool today and still wants to eat.",
+    "symptomKeys": [
+      "diarrhea"
+    ],
+    "turnFocusSymptoms": [
+      "diarrhea"
+    ],
+    "expectedMustScreen": [
+      "bloody_stool_or_vomit",
+      "not_drinking",
+      "collapse_or_weakness",
+      "pale_or_blue_gums"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "stool_blood_screen",
+      "stool_consistency",
+      "hydration_screen"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "mild_diarrhea_module"
+  },
+  {
+    "id": "mild_diarrhea_006",
+    "category": "routine_unclear",
+    "complaintFamily": "mild_diarrhea",
+    "pet": {
+      "species": "dog",
+      "breed": "Beagle",
+      "ageYears": 7,
+      "weightLbs": 26,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog has a mild bout of diarrhea with no other big changes.",
+    "symptomKeys": [
+      "diarrhea"
+    ],
+    "turnFocusSymptoms": [
+      "diarrhea"
+    ],
+    "expectedMustScreen": [
+      "bloody_stool_or_vomit",
+      "not_drinking",
+      "collapse_or_weakness",
+      "pale_or_blue_gums"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "stool_blood_screen",
+      "stool_consistency",
+      "hydration_screen"
+    ],
+    "expectedUrgency": "non_emergency_unless_red_flags",
+    "recommendedFirstModule": "mild_diarrhea_module"
+  },
+  {
+    "id": "itching_and_vomiting_001",
+    "category": "confusing_multi_symptom",
+    "complaintFamily": "itching_and_vomiting",
+    "pet": {
+      "species": "dog",
+      "breed": "Cocker Spaniel",
+      "ageYears": 5,
+      "weightLbs": 24,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog is itchy and also vomited today.",
+    "symptomKeys": [
+      "excessive_scratching",
+      "vomiting"
+    ],
+    "turnFocusSymptoms": [
+      "excessive_scratching"
+    ],
+    "expectedMustScreen": [
+      "facial_swelling",
+      "breathing_difficulty",
+      "repeated_vomiting",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "bucket_split",
+      "vomiting_severity",
+      "emergency_allergy_screen",
+      "itch_location"
+    ],
+    "expectedUrgency": "same_day_if_red_flags_otherwise_question_first",
+    "recommendedFirstModule": "itching_vomiting_split_module"
+  },
+  {
+    "id": "itching_and_vomiting_002",
+    "category": "confusing_multi_symptom",
+    "complaintFamily": "itching_and_vomiting",
+    "pet": {
+      "species": "dog",
+      "breed": "Mixed Breed",
+      "ageYears": 8,
+      "weightLbs": 38,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog keeps scratching and has thrown up a couple of times.",
+    "symptomKeys": [
+      "excessive_scratching",
+      "vomiting"
+    ],
+    "turnFocusSymptoms": [
+      "vomiting"
+    ],
+    "expectedMustScreen": [
+      "facial_swelling",
+      "breathing_difficulty",
+      "repeated_vomiting",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "bucket_split",
+      "vomiting_severity",
+      "emergency_allergy_screen",
+      "itch_location"
+    ],
+    "expectedUrgency": "same_day_if_red_flags_otherwise_question_first",
+    "recommendedFirstModule": "itching_vomiting_split_module"
+  },
+  {
+    "id": "itching_and_vomiting_003",
+    "category": "confusing_multi_symptom",
+    "complaintFamily": "itching_and_vomiting",
+    "pet": {
+      "species": "dog",
+      "breed": "Rottweiler",
+      "ageYears": 9,
+      "weightLbs": 96,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog started itching and then vomited later the same day.",
+    "symptomKeys": [
+      "excessive_scratching",
+      "vomiting"
+    ],
+    "turnFocusSymptoms": [
+      "excessive_scratching"
+    ],
+    "expectedMustScreen": [
+      "facial_swelling",
+      "breathing_difficulty",
+      "repeated_vomiting",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "bucket_split",
+      "vomiting_severity",
+      "emergency_allergy_screen",
+      "itch_location"
+    ],
+    "expectedUrgency": "same_day_if_red_flags_otherwise_question_first",
+    "recommendedFirstModule": "itching_vomiting_split_module"
+  },
+  {
+    "id": "itching_and_vomiting_004",
+    "category": "confusing_multi_symptom",
+    "complaintFamily": "itching_and_vomiting",
+    "pet": {
+      "species": "dog",
+      "breed": "Pug",
+      "ageYears": 2,
+      "weightLbs": 22,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog is itchy and also vomited today.",
+    "symptomKeys": [
+      "excessive_scratching",
+      "vomiting"
+    ],
+    "turnFocusSymptoms": [
+      "vomiting"
+    ],
+    "expectedMustScreen": [
+      "facial_swelling",
+      "breathing_difficulty",
+      "repeated_vomiting",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "bucket_split",
+      "vomiting_severity",
+      "emergency_allergy_screen",
+      "itch_location"
+    ],
+    "expectedUrgency": "same_day_if_red_flags_otherwise_question_first",
+    "recommendedFirstModule": "itching_vomiting_split_module"
+  },
+  {
+    "id": "itching_and_vomiting_005",
+    "category": "confusing_multi_symptom",
+    "complaintFamily": "itching_and_vomiting",
+    "pet": {
+      "species": "dog",
+      "breed": "Labrador Retriever",
+      "ageYears": 4,
+      "weightLbs": 55,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog keeps scratching and has thrown up a couple of times.",
+    "symptomKeys": [
+      "excessive_scratching",
+      "vomiting"
+    ],
+    "turnFocusSymptoms": [
+      "excessive_scratching"
+    ],
+    "expectedMustScreen": [
+      "facial_swelling",
+      "breathing_difficulty",
+      "repeated_vomiting",
+      "collapse_or_weakness"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "bucket_split",
+      "vomiting_severity",
+      "emergency_allergy_screen",
+      "itch_location"
+    ],
+    "expectedUrgency": "same_day_if_red_flags_otherwise_question_first",
+    "recommendedFirstModule": "itching_vomiting_split_module"
+  },
+  {
+    "id": "limping_and_lethargy_001",
+    "category": "confusing_multi_symptom",
+    "complaintFamily": "limping_and_lethargy",
+    "pet": {
+      "species": "dog",
+      "breed": "Cocker Spaniel",
+      "ageYears": 5,
+      "weightLbs": 24,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog is limping and also seems unusually tired.",
+    "symptomKeys": [
+      "limping",
+      "lethargy"
+    ],
+    "turnFocusSymptoms": [
+      "limping"
+    ],
+    "expectedMustScreen": [
+      "non_weight_bearing",
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "bucket_split",
+      "mobility_screen",
+      "collapse_screen",
+      "gum_color_screen"
+    ],
+    "expectedUrgency": "same_day_if_worsening_or_non_weight_bearing",
+    "recommendedFirstModule": "limping_lethargy_split_module"
+  },
+  {
+    "id": "limping_and_lethargy_002",
+    "category": "confusing_multi_symptom",
+    "complaintFamily": "limping_and_lethargy",
+    "pet": {
+      "species": "dog",
+      "breed": "Mixed Breed",
+      "ageYears": 8,
+      "weightLbs": 38,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog is lame on one leg and much less active today.",
+    "symptomKeys": [
+      "limping",
+      "lethargy"
+    ],
+    "turnFocusSymptoms": [
+      "lethargy"
+    ],
+    "expectedMustScreen": [
+      "non_weight_bearing",
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "bucket_split",
+      "mobility_screen",
+      "collapse_screen",
+      "gum_color_screen"
+    ],
+    "expectedUrgency": "same_day_if_worsening_or_non_weight_bearing",
+    "recommendedFirstModule": "limping_lethargy_split_module"
+  },
+  {
+    "id": "limping_and_lethargy_003",
+    "category": "confusing_multi_symptom",
+    "complaintFamily": "limping_and_lethargy",
+    "pet": {
+      "species": "dog",
+      "breed": "Rottweiler",
+      "ageYears": 9,
+      "weightLbs": 96,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog has a limp and feels more weak and tired than normal.",
+    "symptomKeys": [
+      "limping",
+      "lethargy"
+    ],
+    "turnFocusSymptoms": [
+      "limping"
+    ],
+    "expectedMustScreen": [
+      "non_weight_bearing",
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "bucket_split",
+      "mobility_screen",
+      "collapse_screen",
+      "gum_color_screen"
+    ],
+    "expectedUrgency": "same_day_if_worsening_or_non_weight_bearing",
+    "recommendedFirstModule": "limping_lethargy_split_module"
+  },
+  {
+    "id": "limping_and_lethargy_004",
+    "category": "confusing_multi_symptom",
+    "complaintFamily": "limping_and_lethargy",
+    "pet": {
+      "species": "dog",
+      "breed": "Pug",
+      "ageYears": 2,
+      "weightLbs": 22,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog is limping and also seems unusually tired.",
+    "symptomKeys": [
+      "limping",
+      "lethargy"
+    ],
+    "turnFocusSymptoms": [
+      "lethargy"
+    ],
+    "expectedMustScreen": [
+      "non_weight_bearing",
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "bucket_split",
+      "mobility_screen",
+      "collapse_screen",
+      "gum_color_screen"
+    ],
+    "expectedUrgency": "same_day_if_worsening_or_non_weight_bearing",
+    "recommendedFirstModule": "limping_lethargy_split_module"
+  },
+  {
+    "id": "limping_and_lethargy_005",
+    "category": "confusing_multi_symptom",
+    "complaintFamily": "limping_and_lethargy",
+    "pet": {
+      "species": "dog",
+      "breed": "Labrador Retriever",
+      "ageYears": 4,
+      "weightLbs": 55,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog is lame on one leg and much less active today.",
+    "symptomKeys": [
+      "limping",
+      "lethargy"
+    ],
+    "turnFocusSymptoms": [
+      "limping"
+    ],
+    "expectedMustScreen": [
+      "non_weight_bearing",
+      "collapse_or_weakness",
+      "pale_or_blue_gums",
+      "breathing_difficulty"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "bucket_split",
+      "mobility_screen",
+      "collapse_screen",
+      "gum_color_screen"
+    ],
+    "expectedUrgency": "same_day_if_worsening_or_non_weight_bearing",
+    "recommendedFirstModule": "limping_lethargy_split_module"
+  },
+  {
+    "id": "drinking_more_and_weight_loss_001",
+    "category": "confusing_multi_symptom",
+    "complaintFamily": "drinking_more_and_weight_loss",
+    "pet": {
+      "species": "dog",
+      "breed": "Dachshund",
+      "ageYears": 5,
+      "weightLbs": 14,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog is drinking a lot more and losing weight.",
+    "symptomKeys": [
+      "drinking_more",
+      "weight_loss"
+    ],
+    "turnFocusSymptoms": [
+      "drinking_more"
+    ],
+    "expectedMustScreen": [
+      "collapse_or_weakness",
+      "repeated_vomiting",
+      "not_drinking",
+      "intact_female_discharge"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "endocrine_discrimination",
+      "weight_change",
+      "urination_change",
+      "spay_status_screen"
+    ],
+    "expectedUrgency": "prompt_veterinary_workup",
+    "recommendedFirstModule": "polydipsia_weight_loss_module"
+  },
+  {
+    "id": "drinking_more_and_weight_loss_002",
+    "category": "confusing_multi_symptom",
+    "complaintFamily": "drinking_more_and_weight_loss",
+    "pet": {
+      "species": "dog",
+      "breed": "Beagle",
+      "ageYears": 7,
+      "weightLbs": 26,
+      "sexNeuter": "intact female"
+    },
+    "initialMessage": "My dog seems thirstier than usual and is getting thinner.",
+    "symptomKeys": [
+      "drinking_more",
+      "weight_loss"
+    ],
+    "turnFocusSymptoms": [
+      "weight_loss"
+    ],
+    "expectedMustScreen": [
+      "collapse_or_weakness",
+      "repeated_vomiting",
+      "not_drinking",
+      "intact_female_discharge"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "endocrine_discrimination",
+      "weight_change",
+      "urination_change",
+      "spay_status_screen"
+    ],
+    "expectedUrgency": "prompt_veterinary_workup",
+    "recommendedFirstModule": "polydipsia_weight_loss_module"
+  },
+  {
+    "id": "drinking_more_and_weight_loss_003",
+    "category": "confusing_multi_symptom",
+    "complaintFamily": "drinking_more_and_weight_loss",
+    "pet": {
+      "species": "dog",
+      "breed": "Poodle",
+      "ageYears": 12,
+      "weightLbs": 36,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog is drinking excessively and has dropped weight over a few weeks.",
+    "symptomKeys": [
+      "drinking_more",
+      "weight_loss"
+    ],
+    "turnFocusSymptoms": [
+      "drinking_more"
+    ],
+    "expectedMustScreen": [
+      "collapse_or_weakness",
+      "repeated_vomiting",
+      "not_drinking",
+      "intact_female_discharge"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "endocrine_discrimination",
+      "weight_change",
+      "urination_change",
+      "spay_status_screen"
+    ],
+    "expectedUrgency": "prompt_veterinary_workup",
+    "recommendedFirstModule": "polydipsia_weight_loss_module"
+  },
+  {
+    "id": "drinking_more_and_weight_loss_004",
+    "category": "confusing_multi_symptom",
+    "complaintFamily": "drinking_more_and_weight_loss",
+    "pet": {
+      "species": "dog",
+      "breed": "Cocker Spaniel",
+      "ageYears": 3,
+      "weightLbs": 36,
+      "sexNeuter": "intact female"
+    },
+    "initialMessage": "My dog is drinking a lot more and losing weight.",
+    "symptomKeys": [
+      "drinking_more",
+      "weight_loss"
+    ],
+    "turnFocusSymptoms": [
+      "weight_loss"
+    ],
+    "expectedMustScreen": [
+      "collapse_or_weakness",
+      "repeated_vomiting",
+      "not_drinking",
+      "intact_female_discharge"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "endocrine_discrimination",
+      "weight_change",
+      "urination_change",
+      "spay_status_screen"
+    ],
+    "expectedUrgency": "prompt_veterinary_workup",
+    "recommendedFirstModule": "polydipsia_weight_loss_module"
+  },
+  {
+    "id": "drinking_more_and_weight_loss_005",
+    "category": "confusing_multi_symptom",
+    "complaintFamily": "drinking_more_and_weight_loss",
+    "pet": {
+      "species": "dog",
+      "breed": "Mixed Breed",
+      "ageYears": 4,
+      "weightLbs": 25,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog seems thirstier than usual and is getting thinner.",
+    "symptomKeys": [
+      "drinking_more",
+      "weight_loss"
+    ],
+    "turnFocusSymptoms": [
+      "drinking_more"
+    ],
+    "expectedMustScreen": [
+      "collapse_or_weakness",
+      "repeated_vomiting",
+      "not_drinking",
+      "intact_female_discharge"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "endocrine_discrimination",
+      "weight_change",
+      "urination_change",
+      "spay_status_screen"
+    ],
+    "expectedUrgency": "prompt_veterinary_workup",
+    "recommendedFirstModule": "polydipsia_weight_loss_module"
+  },
+  {
+    "id": "coughing_and_tiredness_001",
+    "category": "confusing_multi_symptom",
+    "complaintFamily": "coughing_and_tiredness",
+    "pet": {
+      "species": "dog",
+      "breed": "Rottweiler",
+      "ageYears": 5,
+      "weightLbs": 72,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog has been coughing and is more tired than usual.",
+    "symptomKeys": [
+      "coughing",
+      "lethargy"
+    ],
+    "turnFocusSymptoms": [
+      "coughing"
+    ],
+    "expectedMustScreen": [
+      "breathing_difficulty",
+      "pale_or_blue_gums",
+      "collapse_or_weakness",
+      "coughing_blood"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "respiratory_vs_systemic_split",
+      "breathing_distress_screen",
+      "cough_character",
+      "gum_color_screen"
+    ],
+    "expectedUrgency": "same_day_if_breathing_changes",
+    "recommendedFirstModule": "cough_lethargy_module"
+  },
+  {
+    "id": "coughing_and_tiredness_002",
+    "category": "confusing_multi_symptom",
+    "complaintFamily": "coughing_and_tiredness",
+    "pet": {
+      "species": "dog",
+      "breed": "Pug",
+      "ageYears": 7,
+      "weightLbs": 18,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog keeps coughing and seems worn out on walks.",
+    "symptomKeys": [
+      "coughing",
+      "lethargy"
+    ],
+    "turnFocusSymptoms": [
+      "lethargy"
+    ],
+    "expectedMustScreen": [
+      "breathing_difficulty",
+      "pale_or_blue_gums",
+      "collapse_or_weakness",
+      "coughing_blood"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "respiratory_vs_systemic_split",
+      "breathing_distress_screen",
+      "cough_character",
+      "gum_color_screen"
+    ],
+    "expectedUrgency": "same_day_if_breathing_changes",
+    "recommendedFirstModule": "cough_lethargy_module"
+  },
+  {
+    "id": "coughing_and_tiredness_003",
+    "category": "confusing_multi_symptom",
+    "complaintFamily": "coughing_and_tiredness",
+    "pet": {
+      "species": "dog",
+      "breed": "Labrador Retriever",
+      "ageYears": 8,
+      "weightLbs": 68,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog is coughing and acting lethargic compared with normal.",
+    "symptomKeys": [
+      "coughing",
+      "lethargy"
+    ],
+    "turnFocusSymptoms": [
+      "coughing"
+    ],
+    "expectedMustScreen": [
+      "breathing_difficulty",
+      "pale_or_blue_gums",
+      "collapse_or_weakness",
+      "coughing_blood"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "respiratory_vs_systemic_split",
+      "breathing_distress_screen",
+      "cough_character",
+      "gum_color_screen"
+    ],
+    "expectedUrgency": "same_day_if_breathing_changes",
+    "recommendedFirstModule": "cough_lethargy_module"
+  },
+  {
+    "id": "coughing_and_tiredness_004",
+    "category": "confusing_multi_symptom",
+    "complaintFamily": "coughing_and_tiredness",
+    "pet": {
+      "species": "dog",
+      "breed": "Golden Retriever",
+      "ageYears": 3,
+      "weightLbs": 80,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My dog has been coughing and is more tired than usual.",
+    "symptomKeys": [
+      "coughing",
+      "lethargy"
+    ],
+    "turnFocusSymptoms": [
+      "lethargy"
+    ],
+    "expectedMustScreen": [
+      "breathing_difficulty",
+      "pale_or_blue_gums",
+      "collapse_or_weakness",
+      "coughing_blood"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "respiratory_vs_systemic_split",
+      "breathing_distress_screen",
+      "cough_character",
+      "gum_color_screen"
+    ],
+    "expectedUrgency": "same_day_if_breathing_changes",
+    "recommendedFirstModule": "cough_lethargy_module"
+  },
+  {
+    "id": "coughing_and_tiredness_005",
+    "category": "confusing_multi_symptom",
+    "complaintFamily": "coughing_and_tiredness",
+    "pet": {
+      "species": "dog",
+      "breed": "German Shepherd",
+      "ageYears": 5,
+      "weightLbs": 60,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My dog keeps coughing and seems worn out on walks.",
+    "symptomKeys": [
+      "coughing",
+      "lethargy"
+    ],
+    "turnFocusSymptoms": [
+      "coughing"
+    ],
+    "expectedMustScreen": [
+      "breathing_difficulty",
+      "pale_or_blue_gums",
+      "collapse_or_weakness",
+      "coughing_blood"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "How old is your dog?",
+      "What breed is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "respiratory_vs_systemic_split",
+      "breathing_distress_screen",
+      "cough_character",
+      "gum_color_screen"
+    ],
+    "expectedUrgency": "same_day_if_breathing_changes",
+    "recommendedFirstModule": "cough_lethargy_module"
+  },
+  {
+    "id": "old_dog_vague_weakness_001",
+    "category": "confusing_multi_symptom",
+    "complaintFamily": "old_dog_vague_weakness",
+    "pet": {
+      "species": "dog",
+      "breed": "Rottweiler",
+      "ageYears": 10,
+      "weightLbs": 72,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My older dog just seems weak and not quite right.",
+    "symptomKeys": [
+      "unknown_concern"
+    ],
+    "turnFocusSymptoms": [
+      "unknown_concern"
+    ],
+    "expectedMustScreen": [
+      "collapse_or_weakness",
+      "breathing_difficulty",
+      "pale_or_blue_gums",
+      "not_drinking"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "vague_weakness_screen",
+      "gum_color_screen",
+      "breathing_distress_screen",
+      "last_normal"
+    ],
+    "expectedUrgency": "same_day_if_collapse_or_pale_gums",
+    "recommendedFirstModule": "senior_vague_weakness_module"
+  },
+  {
+    "id": "old_dog_vague_weakness_002",
+    "category": "confusing_multi_symptom",
+    "complaintFamily": "old_dog_vague_weakness",
+    "pet": {
+      "species": "dog",
+      "breed": "Pug",
+      "ageYears": 11,
+      "weightLbs": 18,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My older dog seems vaguely weak today.",
+    "symptomKeys": [
+      "unknown_concern"
+    ],
+    "turnFocusSymptoms": [
+      "unknown_concern"
+    ],
+    "expectedMustScreen": [
+      "collapse_or_weakness",
+      "breathing_difficulty",
+      "pale_or_blue_gums",
+      "not_drinking"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "vague_weakness_screen",
+      "gum_color_screen",
+      "breathing_distress_screen",
+      "last_normal"
+    ],
+    "expectedUrgency": "same_day_if_collapse_or_pale_gums",
+    "recommendedFirstModule": "senior_vague_weakness_module"
+  },
+  {
+    "id": "old_dog_vague_weakness_003",
+    "category": "confusing_multi_symptom",
+    "complaintFamily": "old_dog_vague_weakness",
+    "pet": {
+      "species": "dog",
+      "breed": "Labrador Retriever",
+      "ageYears": 12,
+      "weightLbs": 68,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My older dog seems off, weak, and not like normal.",
+    "symptomKeys": [
+      "unknown_concern"
+    ],
+    "turnFocusSymptoms": [
+      "unknown_concern"
+    ],
+    "expectedMustScreen": [
+      "collapse_or_weakness",
+      "breathing_difficulty",
+      "pale_or_blue_gums",
+      "not_drinking"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "vague_weakness_screen",
+      "gum_color_screen",
+      "breathing_distress_screen",
+      "last_normal"
+    ],
+    "expectedUrgency": "same_day_if_collapse_or_pale_gums",
+    "recommendedFirstModule": "senior_vague_weakness_module"
+  },
+  {
+    "id": "old_dog_vague_weakness_004",
+    "category": "confusing_multi_symptom",
+    "complaintFamily": "old_dog_vague_weakness",
+    "pet": {
+      "species": "dog",
+      "breed": "Golden Retriever",
+      "ageYears": 13,
+      "weightLbs": 80,
+      "sexNeuter": "spayed female"
+    },
+    "initialMessage": "My older dog just seems weak and not quite right.",
+    "symptomKeys": [
+      "unknown_concern"
+    ],
+    "turnFocusSymptoms": [
+      "unknown_concern"
+    ],
+    "expectedMustScreen": [
+      "collapse_or_weakness",
+      "breathing_difficulty",
+      "pale_or_blue_gums",
+      "not_drinking"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "vague_weakness_screen",
+      "gum_color_screen",
+      "breathing_distress_screen",
+      "last_normal"
+    ],
+    "expectedUrgency": "same_day_if_collapse_or_pale_gums",
+    "recommendedFirstModule": "senior_vague_weakness_module"
+  },
+  {
+    "id": "old_dog_vague_weakness_005",
+    "category": "confusing_multi_symptom",
+    "complaintFamily": "old_dog_vague_weakness",
+    "pet": {
+      "species": "dog",
+      "breed": "German Shepherd",
+      "ageYears": 14,
+      "weightLbs": 60,
+      "sexNeuter": "neutered male"
+    },
+    "initialMessage": "My older dog seems vaguely weak today.",
+    "symptomKeys": [
+      "unknown_concern"
+    ],
+    "turnFocusSymptoms": [
+      "unknown_concern"
+    ],
+    "expectedMustScreen": [
+      "collapse_or_weakness",
+      "breathing_difficulty",
+      "pale_or_blue_gums",
+      "not_drinking"
+    ],
+    "badFirstQuestions": [
+      "Can you tell me more?",
+      "What breed is your dog?",
+      "How old is your dog?"
+    ],
+    "idealQuestionCategories": [
+      "vague_weakness_screen",
+      "gum_color_screen",
+      "breathing_distress_screen",
+      "last_normal"
+    ],
+    "expectedUrgency": "same_day_if_collapse_or_pale_gums",
+    "recommendedFirstModule": "senior_vague_weakness_module"
+  }
+]

--- a/tests/question-quality-eval.test.ts
+++ b/tests/question-quality-eval.test.ts
@@ -1,0 +1,184 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const harness = require("../scripts/eval-question-quality.ts");
+
+const SAMPLE_CASES = [
+  {
+    id: "vomiting-basic",
+    symptomKeys: ["vomiting"],
+  },
+  {
+    id: "bloat-risk",
+    symptomKeys: ["vomiting", "swollen_abdomen"],
+    turnFocusSymptoms: ["swollen_abdomen"],
+    redFlags: ["unproductive_retching", "rapid_onset_distension"],
+    mustScreenEmergency: true,
+  },
+  {
+    id: "breathing-screen",
+    symptomKeys: ["difficulty_breathing"],
+    redFlags: ["blue_gums"],
+    mustScreenEmergency: true,
+  },
+  {
+    id: "limping-screen",
+    symptomKeys: ["limping"],
+    redFlags: ["non_weight_bearing"],
+    mustScreenEmergency: true,
+  },
+];
+
+const defaultFixturePath = harness.FIXTURE_PATH;
+const hadOriginalFixture = fs.existsSync(defaultFixturePath);
+const originalFixtureContents = hadOriginalFixture
+  ? fs.readFileSync(defaultFixturePath, "utf8")
+  : null;
+
+function restoreDefaultFixture() {
+  if (hadOriginalFixture && originalFixtureContents !== null) {
+    fs.mkdirSync(path.dirname(defaultFixturePath), { recursive: true });
+    fs.writeFileSync(defaultFixturePath, originalFixtureContents);
+    return;
+  }
+
+  if (fs.existsSync(defaultFixturePath)) {
+    fs.rmSync(defaultFixturePath);
+  }
+}
+
+function writeDefaultFixture(cases = SAMPLE_CASES) {
+  fs.mkdirSync(path.dirname(defaultFixturePath), { recursive: true });
+  fs.writeFileSync(defaultFixturePath, `${JSON.stringify(cases, null, 2)}\n`);
+}
+
+function writeTempFixture(cases = SAMPLE_CASES) {
+  const tempDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "pawvital-question-quality-")
+  );
+  const fixturePath = path.join(tempDir, "question-quality-cases.json");
+  fs.writeFileSync(fixturePath, `${JSON.stringify(cases, null, 2)}\n`);
+  return { tempDir, fixturePath };
+}
+
+describe("question-quality eval harness", () => {
+  afterEach(() => {
+    restoreDefaultFixture();
+  });
+
+  afterAll(() => {
+    restoreDefaultFixture();
+  });
+
+  it("loads and scores deterministic question-quality cases", async () => {
+    const { fixturePath, tempDir } = writeTempFixture();
+
+    try {
+      const report = await harness.runEvaluation({ fixturePath });
+
+      expect(report.fixturePath).toBe(fixturePath);
+      expect(report.summary.totalCases).toBe(4);
+      expect(report.summary.averageScore).toBeGreaterThan(0);
+      expect(report.caseResults).toHaveLength(4);
+      expect(Object.keys(report.summary.categoryScores)).toEqual(
+        harness.CATEGORY_KEYS
+      );
+      expect(report.caseResults.every((result: any) => result.questionId)).toBe(true);
+
+      const breathingCase = report.caseResults.find(
+        (result: any) => result.caseDefinition.id === "breathing-screen"
+      );
+      expect(breathingCase).toBeDefined();
+      expect(breathingCase.missedRedFlags).toContain("blue_gums");
+      expect(breathingCase.emergencyScreened).toBe(true);
+
+      const limpingCase = report.caseResults.find(
+        (result: any) => result.caseDefinition.id === "limping-screen"
+      );
+      expect(limpingCase).toBeDefined();
+      expect(limpingCase.repeated).toBe(false);
+
+      expect(
+        report.summary.recommendedModules.map((item: any) => item.moduleId)
+      ).toContain("red_flag_coverage");
+      expect(
+        report.summary.missedRedFlags.map((item: any) => item.redFlag)
+      ).toContain("blue_gums");
+
+      const summary = harness.formatSummary(report);
+      expect(summary).toContain("PAWVITAL QUESTION-QUALITY EVAL");
+      expect(summary).toContain("Total cases: 4");
+      expect(summary).toContain("Category scores:");
+      expect(summary).toContain("Generic rate:");
+      expect(summary).toContain("Emergency miss rate:");
+      expect(summary).toContain("Emergency-screen rate:");
+      expect(summary).toContain("Repeated rate:");
+      expect(summary).toContain("Top 20 weak patterns:");
+      expect(summary).toContain("Top 20 missed red flags:");
+      expect(summary).toContain("Recommended modules:");
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails fast when the fixture path is missing", () => {
+    const missingFixturePath = path.join(
+      os.tmpdir(),
+      `missing-question-quality-${Date.now()}.json`
+    );
+
+    expect(() => harness.loadCases(missingFixturePath)).toThrow(
+      /Question-quality fixture not found/
+    );
+  });
+
+  it("maps red-flag aliases to screening questions", () => {
+    expect(
+      harness.__private.questionScreensRedFlag(
+        "gum_color",
+        "What color are the gums?",
+        "blue_gums"
+      )
+    ).toBe(true);
+
+    expect(
+      harness.__private.questionScreensRedFlag(
+        "weight_bearing",
+        "Can he put weight on that leg?",
+        "non_weight_bearing"
+      )
+    ).toBe(true);
+
+    expect(
+      harness.__private.questionScreensRedFlag(
+        "vomit_duration",
+        "How long has the vomiting been going on?",
+        "blue_gums"
+      )
+    ).toBe(false);
+  });
+
+  it("runs from the required repo fixture path with plain node", () => {
+    writeDefaultFixture();
+
+    const result = spawnSync(process.execPath, ["scripts/eval-question-quality.ts"], {
+      cwd: path.resolve(__dirname, ".."),
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("PAWVITAL QUESTION-QUALITY EVAL");
+    expect(result.stdout).toContain("Total cases: 4");
+    expect(result.stdout).toContain("Average score:");
+    expect(result.stdout).toContain("Category scores:");
+    expect(result.stdout).toContain("Generic rate:");
+    expect(result.stdout).toContain("Emergency miss rate:");
+    expect(result.stdout).toContain("Emergency-screen rate:");
+    expect(result.stdout).toContain("Repeated rate:");
+    expect(result.stdout).toContain("Top 20 weak patterns:");
+    expect(result.stdout).toContain("Top 20 missed red flags:");
+    expect(result.stdout).toContain("Recommended modules:");
+  });
+});

--- a/tests/question-quality-eval.test.ts
+++ b/tests/question-quality-eval.test.ts
@@ -1,184 +1,122 @@
-import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const harness = require("../scripts/eval-question-quality.ts");
 
-const SAMPLE_CASES = [
-  {
-    id: "vomiting-basic",
-    symptomKeys: ["vomiting"],
-  },
-  {
-    id: "bloat-risk",
-    symptomKeys: ["vomiting", "swollen_abdomen"],
-    turnFocusSymptoms: ["swollen_abdomen"],
-    redFlags: ["unproductive_retching", "rapid_onset_distension"],
-    mustScreenEmergency: true,
-  },
-  {
-    id: "breathing-screen",
-    symptomKeys: ["difficulty_breathing"],
-    redFlags: ["blue_gums"],
-    mustScreenEmergency: true,
-  },
-  {
-    id: "limping-screen",
-    symptomKeys: ["limping"],
-    redFlags: ["non_weight_bearing"],
-    mustScreenEmergency: true,
-  },
-];
+type EvalFixtureCase = {
+  category: string;
+  complaintFamily: string;
+  pet: { species: string };
+  expectedMustScreen: string[];
+  badFirstQuestions: string[];
+  idealQuestionCategories: string[];
+};
 
-const defaultFixturePath = harness.FIXTURE_PATH;
-const hadOriginalFixture = fs.existsSync(defaultFixturePath);
-const originalFixtureContents = hadOriginalFixture
-  ? fs.readFileSync(defaultFixturePath, "utf8")
-  : null;
+type EvalReport = {
+  caseResults: unknown[];
+  summary: {
+    totalCases: number;
+    averageQuestionScore: number;
+    genericQuestionRate: number;
+    emergencyRedFlagMissRate: number;
+    firstQuestionEmergencyScreenRate: number;
+    repeatedQuestionRate: number;
+    categoryScores: Record<string, number>;
+    weakPatterns: Array<{ pattern: string }>;
+    missedRedFlagPatterns: Array<{ pattern: string }>;
+    recommendedFirstModules: Array<{ moduleId: string }>;
+    worstComplaintFamilies: Array<{ complaintFamily: string }>;
+  };
+};
 
-function restoreDefaultFixture() {
-  if (hadOriginalFixture && originalFixtureContents !== null) {
-    fs.mkdirSync(path.dirname(defaultFixturePath), { recursive: true });
-    fs.writeFileSync(defaultFixturePath, originalFixtureContents);
-    return;
-  }
+describe("question intelligence baseline eval harness", () => {
+  it("loads the committed 150-case dog-only fixture contract", () => {
+    const cases = harness.loadCases() as EvalFixtureCase[];
+    const categoryCounts = cases.reduce((counts: Record<string, number>, testCase) => {
+      counts[testCase.category] = (counts[testCase.category] ?? 0) + 1;
+      return counts;
+    }, {});
+    const complaintFamilies = new Set(cases.map((testCase) => testCase.complaintFamily));
 
-  if (fs.existsSync(defaultFixturePath)) {
-    fs.rmSync(defaultFixturePath);
-  }
-}
-
-function writeDefaultFixture(cases = SAMPLE_CASES) {
-  fs.mkdirSync(path.dirname(defaultFixturePath), { recursive: true });
-  fs.writeFileSync(defaultFixturePath, `${JSON.stringify(cases, null, 2)}\n`);
-}
-
-function writeTempFixture(cases = SAMPLE_CASES) {
-  const tempDir = fs.mkdtempSync(
-    path.join(os.tmpdir(), "pawvital-question-quality-")
-  );
-  const fixturePath = path.join(tempDir, "question-quality-cases.json");
-  fs.writeFileSync(fixturePath, `${JSON.stringify(cases, null, 2)}\n`);
-  return { tempDir, fixturePath };
-}
-
-describe("question-quality eval harness", () => {
-  afterEach(() => {
-    restoreDefaultFixture();
-  });
-
-  afterAll(() => {
-    restoreDefaultFixture();
-  });
-
-  it("loads and scores deterministic question-quality cases", async () => {
-    const { fixturePath, tempDir } = writeTempFixture();
-
-    try {
-      const report = await harness.runEvaluation({ fixturePath });
-
-      expect(report.fixturePath).toBe(fixturePath);
-      expect(report.summary.totalCases).toBe(4);
-      expect(report.summary.averageScore).toBeGreaterThan(0);
-      expect(report.caseResults).toHaveLength(4);
-      expect(Object.keys(report.summary.categoryScores)).toEqual(
-        harness.CATEGORY_KEYS
-      );
-      expect(report.caseResults.every((result: any) => result.questionId)).toBe(true);
-
-      const breathingCase = report.caseResults.find(
-        (result: any) => result.caseDefinition.id === "breathing-screen"
-      );
-      expect(breathingCase).toBeDefined();
-      expect(breathingCase.missedRedFlags).toContain("blue_gums");
-      expect(breathingCase.emergencyScreened).toBe(true);
-
-      const limpingCase = report.caseResults.find(
-        (result: any) => result.caseDefinition.id === "limping-screen"
-      );
-      expect(limpingCase).toBeDefined();
-      expect(limpingCase.repeated).toBe(false);
-
-      expect(
-        report.summary.recommendedModules.map((item: any) => item.moduleId)
-      ).toContain("red_flag_coverage");
-      expect(
-        report.summary.missedRedFlags.map((item: any) => item.redFlag)
-      ).toContain("blue_gums");
-
-      const summary = harness.formatSummary(report);
-      expect(summary).toContain("PAWVITAL QUESTION-QUALITY EVAL");
-      expect(summary).toContain("Total cases: 4");
-      expect(summary).toContain("Category scores:");
-      expect(summary).toContain("Generic rate:");
-      expect(summary).toContain("Emergency miss rate:");
-      expect(summary).toContain("Emergency-screen rate:");
-      expect(summary).toContain("Repeated rate:");
-      expect(summary).toContain("Top 20 weak patterns:");
-      expect(summary).toContain("Top 20 missed red flags:");
-      expect(summary).toContain("Recommended modules:");
-    } finally {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
-  });
-
-  it("fails fast when the fixture path is missing", () => {
-    const missingFixturePath = path.join(
-      os.tmpdir(),
-      `missing-question-quality-${Date.now()}.json`
-    );
-
-    expect(() => harness.loadCases(missingFixturePath)).toThrow(
-      /Question-quality fixture not found/
-    );
-  });
-
-  it("maps red-flag aliases to screening questions", () => {
+    expect(cases).toHaveLength(150);
+    expect(categoryCounts).toEqual({
+      emergency: 45,
+      urgent_same_day: 40,
+      routine_unclear: 40,
+      confusing_multi_symptom: 25,
+    });
+    expect(cases.every((testCase) => testCase.pet.species === "dog")).toBe(true);
+    expect(complaintFamilies.size).toBe(25);
+    expect(complaintFamilies.has("collapse_pale_gums")).toBe(true);
+    expect(complaintFamilies.has("urinary_blockage")).toBe(true);
+    expect(complaintFamilies.has("old_dog_vague_weakness")).toBe(true);
     expect(
-      harness.__private.questionScreensRedFlag(
-        "gum_color",
-        "What color are the gums?",
-        "blue_gums"
+      cases.every(
+        (testCase) =>
+          Array.isArray(testCase.expectedMustScreen) &&
+          testCase.expectedMustScreen.length > 0 &&
+          Array.isArray(testCase.badFirstQuestions) &&
+          testCase.badFirstQuestions.length > 0 &&
+          Array.isArray(testCase.idealQuestionCategories) &&
+          testCase.idealQuestionCategories.length > 0
       )
     ).toBe(true);
-
-    expect(
-      harness.__private.questionScreensRedFlag(
-        "weight_bearing",
-        "Can he put weight on that leg?",
-        "non_weight_bearing"
-      )
-    ).toBe(true);
-
-    expect(
-      harness.__private.questionScreensRedFlag(
-        "vomit_duration",
-        "How long has the vomiting been going on?",
-        "blue_gums"
-      )
-    ).toBe(false);
   });
 
-  it("runs from the required repo fixture path with plain node", () => {
-    writeDefaultFixture();
+  it("scores the real fixture and returns the required summary surfaces", async () => {
+    const report = (await harness.runEvaluation()) as EvalReport;
 
+    expect(report.summary.totalCases).toBe(150);
+    expect(report.caseResults).toHaveLength(150);
+    expect(report.summary.averageQuestionScore).toBeGreaterThanOrEqual(0);
+    expect(report.summary.averageQuestionScore).toBeLessThanOrEqual(3);
+    expect(report.summary.genericQuestionRate).toBeGreaterThanOrEqual(0);
+    expect(report.summary.genericQuestionRate).toBeLessThanOrEqual(1);
+    expect(report.summary.emergencyRedFlagMissRate).toBeGreaterThanOrEqual(0);
+    expect(report.summary.emergencyRedFlagMissRate).toBeLessThanOrEqual(1);
+    expect(report.summary.firstQuestionEmergencyScreenRate).toBeGreaterThanOrEqual(0);
+    expect(report.summary.firstQuestionEmergencyScreenRate).toBeLessThanOrEqual(1);
+    expect(report.summary.repeatedQuestionRate).toBeGreaterThanOrEqual(0);
+    expect(report.summary.repeatedQuestionRate).toBeLessThanOrEqual(1);
+    expect(Object.keys(report.summary.categoryScores)).toEqual(harness.CATEGORY_KEYS);
+    expect(report.summary.weakPatterns.length).toBeGreaterThan(0);
+    expect(report.summary.missedRedFlagPatterns.length).toBeGreaterThan(0);
+    expect(report.summary.recommendedFirstModules.length).toBeGreaterThan(0);
+    expect(report.summary.worstComplaintFamilies.length).toBeGreaterThan(0);
+
+    const summary = harness.formatSummary(report);
+    expect(summary).toContain("PAWVITAL QUESTION INTELLIGENCE BASELINE");
+    expect(summary).toContain("Total cases: 150");
+    expect(summary).toContain("Average question score:");
+    expect(summary).toContain("Generic question rate:");
+    expect(summary).toContain("Emergency red-flag miss rate:");
+    expect(summary).toContain("First-question emergency-screen rate:");
+    expect(summary).toContain("Repeated-question rate:");
+    expect(summary).toContain("Per-category scores:");
+    expect(summary).toContain("Top 20 generic or weak question patterns:");
+    expect(summary).toContain("Top 20 missed red-flag patterns:");
+    expect(summary).toContain("Recommended first complaint modules:");
+  });
+
+  it("runs from the CLI and prints the baseline report", () => {
     const result = spawnSync(process.execPath, ["scripts/eval-question-quality.ts"], {
       cwd: path.resolve(__dirname, ".."),
       encoding: "utf8",
     });
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain("PAWVITAL QUESTION-QUALITY EVAL");
-    expect(result.stdout).toContain("Total cases: 4");
-    expect(result.stdout).toContain("Average score:");
-    expect(result.stdout).toContain("Category scores:");
-    expect(result.stdout).toContain("Generic rate:");
-    expect(result.stdout).toContain("Emergency miss rate:");
-    expect(result.stdout).toContain("Emergency-screen rate:");
-    expect(result.stdout).toContain("Repeated rate:");
-    expect(result.stdout).toContain("Top 20 weak patterns:");
-    expect(result.stdout).toContain("Top 20 missed red flags:");
-    expect(result.stdout).toContain("Recommended modules:");
+    expect(result.stdout).toContain("PAWVITAL QUESTION INTELLIGENCE BASELINE");
+    expect(result.stdout).toContain("Total cases: 150");
+    expect(result.stdout).toContain("Average question score:");
+    expect(result.stdout).toContain("Generic question rate:");
+    expect(result.stdout).toContain("Emergency red-flag miss rate:");
+    expect(result.stdout).toContain("First-question emergency-screen rate:");
+    expect(result.stdout).toContain("Repeated-question rate:");
+    expect(result.stdout).toContain("Per-category scores:");
+    expect(result.stdout).toContain("Worst complaint families:");
+    expect(result.stdout).toContain("Top 20 generic or weak question patterns:");
+    expect(result.stdout).toContain("Top 20 missed red-flag patterns:");
+    expect(result.stdout).toContain("Recommended first complaint modules:");
   });
 });


### PR DESCRIPTION
VET-1399 complete

Branch: `codex/vet-1399-question-intelligence-baseline`  
Commit: `ed98937d63ca82b303eccd9cb51b02dd9301abf2`

Files:
- docs/clinical-intelligence-safety-contract.md
- docs/question-quality-rubric.md
- tests/fixtures/question-quality-cases.json
- scripts/eval-question-quality.ts
- tests/question-quality-eval.test.ts

What changed:
- Added the safety contract and scoring rubric docs.
- Added a 150-case dog-only baseline fixture with the required scenario mix and scoring metadata.
- Reworked the eval harness to run the current `createSession()` -> `addSymptoms()` -> `getNextQuestionAvoidingRepeat()` -> `getQuestionText()` path, score the first question across the requested dimensions, and print the baseline report.
- Added focused Jest coverage for the fixture contract, summary generation, and CLI output.
- No production behavior, clinical thresholds, prompts, RAG, routing, auth, or existing clinical logic were changed.

Baseline:
- total cases: `150`
- average score: `2.50 / 3.00`
- generic question rate: `3.0%`
- emergency red-flag miss rate: `56.0%`
- first-question emergency-screen rate: `44.0%`
- repeated-question rate: `0.0%`
- worst complaint families: `old_dog_vague_weakness`, `limping_and_lethargy`, `ear_scratching`, `coughing_and_tiredness`, `vomiting_and_lethargy`
- recommended first modules: `ear_scratching_module`, `vomiting_lethargy_module`, `limp_severity_module`, `itching_module`, `mild_limp_module`, `vomiting_module`, `reduced_appetite_module`, `major_trauma_screen`, `senior_vague_weakness_module`, `limping_lethargy_split_module`, `itching_vomiting_split_module`, `polydipsia_weight_loss_module`, `urinary_obstruction_screen`, `cough_lethargy_module`

Validation:
- lint: `PASS` via `npm run lint`
- build: `PASS` via `npm run build`
- tests: `PASS` via `npm test` (`117` suites passed, `1` skipped; `1317` tests passed, `4` skipped)
- dangerous benchmark: `PASS` on `tier_1_emergency` via the completed live harness run against `https://pawvital-ai.vercel.app` (`76` cases, `100.0%` expectation pass, `100.0%` emergency recall, `0.00%` unsafe downgrades)
- release gate: `PASS` via `npm run eval:benchmark:release-gate` (`226` frozen cases, `0` failures, `0` warnings)
- eval script: `PASS` via `node scripts/eval-question-quality.ts`
- focused eval test: `PASS` via `npm test -- --runTestsByPath tests/question-quality-eval.test.ts`

Notes:
- The dangerous benchmark package script falls back to `http://localhost:3000` unless `APP_BASE_URL` is set in the shell, so the live validation was run with an explicit production base URL.
- Existing emergency benchmark outputs remain green.
