### PR TITLE
[codex] test: cover VET-1401Q urgency regression

### DIFF
--- a/tests/clinical-intelligence/case-state.test.ts
+++ b/tests/clinical-intelligence/case-state.test.ts
@@ -517,7 +517,7 @@ describe("Red flag helper functions", () => {
     expect(unknowns).not.toContain("collapse");
   });
 
-  it("hasAnyPositiveEmergencyRedFlags returns true when any positive flag exists", () => {
+  it("hasAnyPositiveEmergencyRedFlags returns true for positive emergency flags", () => {
     const updated = updateRedFlagStatus(state, "blue_gums", {
       status: "positive",
       source: "explicit_answer",
@@ -606,6 +606,21 @@ describe("Case state after each answer", () => {
 
     expect(state.currentUrgency).toBe("emergency");
     expect(state.redFlagStatus["blue_gums"].status).toBe("positive");
+  });
+
+  it("keeps urgency trajectory unknown when urgency remains unknown", () => {
+    const updated = updateRedFlagStatus(
+      createInitialClinicalCaseState(),
+      "mild_skin_irritation",
+      {
+        status: "positive",
+        source: "clinical_signal",
+        turn: 1,
+      }
+    );
+
+    expect(updated.currentUrgency).toBe("unknown");
+    expect(updated.urgencyTrajectory).toBe("unknown");
   });
 });
 


### PR DESCRIPTION
## What changed
Adds the missing regression coverage for the VET-1401Q urgency behavior already present on `master`.

## Why
The runtime fixes for the review findings are already on GitHub `master`, but the `unknown -> unknown` urgency-trajectory case did not yet have explicit focused coverage in the landed test file.

## Validation
- `git diff --check`
- `jest --runTestsByPath tests/clinical-intelligence/case-state.test.ts --runInBand` using the existing installed runner from the sibling PawVital worktree because the landing worktree hit disk-space limits during `npm ci`

## Notes
- This PR does not replay stale VET-1401Q or VET-1406Q branch history.
- It only lands the missing regression test on top of current `master`.