### PR TITLE
VET-1381: Fix symptom-checker hydration mismatch

### DIFF
--- a/smoke/browser-mobile/browser-mobile.smoke.pw.ts
+++ b/smoke/browser-mobile/browser-mobile.smoke.pw.ts
@@ -5,6 +5,8 @@ const PET_ONBOARDING_DISMISSED_KEY = "pawvital_pet_onboarding_dismissed";
 const SMOKE_SEED_STORAGE_KEY = "pawvital_browser_mobile_smoke_seeded";
 const TESTER_CONSENT_STORAGE_KEY = "pawvital_tester_acknowledgements";
 const TESTER_CONSENT_VERSION = "2026-04-private-tester-rc-v1";
+const HYDRATION_WARNING_PATTERN =
+  /hydration|did not match|server rendered html|text content does not match/i;
 
 const DEMO_DOG = {
   age_months: 0,
@@ -101,6 +103,23 @@ async function seedDemoState(page: Page, options: { consent: boolean }) {
       version: TESTER_CONSENT_VERSION,
     }
   );
+}
+
+function trackHydrationWarnings(page: Page) {
+  const warnings: string[] = [];
+
+  page.on("console", (message) => {
+    if (message.type() !== "warning" && message.type() !== "error") {
+      return;
+    }
+
+    const text = message.text();
+    if (HYDRATION_WARNING_PATTERN.test(text)) {
+      warnings.push(text);
+    }
+  });
+
+  return warnings;
 }
 
 async function installEmergencyMocks(page: Page) {
@@ -243,6 +262,7 @@ async function installMildMocks(page: Page) {
 test("tester onboarding smoke shows the boundary once and skips it for returning users", async ({
   page,
 }) => {
+  const hydrationWarnings = trackHydrationWarnings(page);
   await seedDemoState(page, { consent: false });
   await page.goto("/symptom-checker");
 
@@ -271,11 +291,14 @@ test("tester onboarding smoke shows the boundary once and skips it for returning
   await expect(
     page.getByText("Tell me what's going on with Buddy")
   ).toBeVisible();
+
+  expect(hydrationWarnings).toEqual([]);
 });
 
 test("emergency result-flow smoke shows urgency, opens a non-demo report, and submits feedback", async ({
   page,
 }) => {
+  const hydrationWarnings = trackHydrationWarnings(page);
   const feedbackSubmissions = await installEmergencyMocks(page);
   await seedDemoState(page, { consent: true });
   await page.goto("/symptom-checker");
@@ -320,11 +343,13 @@ test("emergency result-flow smoke shows urgency, opens a non-demo report, and su
     symptomCheckId: "smoke-emergency-report",
     surface: "result_page",
   });
+  expect(hydrationWarnings).toEqual([]);
 });
 
 test("mild result-flow smoke keeps the question flow understandable and submits feedback", async ({
   page,
 }) => {
+  const hydrationWarnings = trackHydrationWarnings(page);
   const feedbackSubmissions = await installMildMocks(page);
   await seedDemoState(page, { consent: true });
   await page.goto("/symptom-checker");
@@ -372,4 +397,5 @@ test("mild result-flow smoke keeps the question flow understandable and submits 
     symptomCheckId: "smoke-mild-report",
     surface: "result_page",
   });
+  expect(hydrationWarnings).toEqual([]);
 });

--- a/src/app/(dashboard)/symptom-checker/page.tsx
+++ b/src/app/(dashboard)/symptom-checker/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useSyncExternalStore } from "react";
 import {
   Stethoscope,
   AlertTriangle,
@@ -90,6 +90,10 @@ const quickSymptoms = [
   "Blood in stool",
   "Swollen abdomen",
 ];
+
+function subscribeToHydration() {
+  return () => {};
+}
 
 // --- Components ---
 
@@ -213,7 +217,11 @@ function ChatBubble({
 
 export default function SymptomCheckerPage() {
   const { activePet } = useAppStore();
-  const [hasHydrated, setHasHydrated] = useState(false);
+  const hasHydrated = useSyncExternalStore(
+    subscribeToHydration,
+    () => true,
+    () => false,
+  );
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
@@ -256,10 +264,6 @@ export default function SymptomCheckerPage() {
   const displayPetBreed = hasHydrated ? pet.breed : "Unknown";
   const displayPetAgeYears = hasHydrated ? pet.age_years : 4;
   const displayPetWeight = hasHydrated ? pet.weight : 50;
-
-  useEffect(() => {
-    setHasHydrated(true);
-  }, []);
 
   useEffect(() => {
     chatEndRef.current?.scrollIntoView({ behavior: "smooth" });

--- a/src/app/(dashboard)/symptom-checker/page.tsx
+++ b/src/app/(dashboard)/symptom-checker/page.tsx
@@ -213,6 +213,7 @@ function ChatBubble({
 
 export default function SymptomCheckerPage() {
   const { activePet } = useAppStore();
+  const [hasHydrated, setHasHydrated] = useState(false);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
@@ -251,6 +252,14 @@ export default function SymptomCheckerPage() {
     weight: 50,
     existing_conditions: [],
   };
+  const displayPetName = hasHydrated ? pet.name : "your dog";
+  const displayPetBreed = hasHydrated ? pet.breed : "Unknown";
+  const displayPetAgeYears = hasHydrated ? pet.age_years : 4;
+  const displayPetWeight = hasHydrated ? pet.weight : 50;
+
+  useEffect(() => {
+    setHasHydrated(true);
+  }, []);
 
   useEffect(() => {
     chatEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -752,7 +761,7 @@ export default function SymptomCheckerPage() {
               </div>
               <div>
                 <h2 className="font-semibold text-gray-900">
-                  Tell me what&apos;s going on with {pet.name}
+                  Tell me what&apos;s going on with {displayPetName}
                 </h2>
                 <p className="text-sm text-gray-500">
                   I&apos;ll guide a dog-only symptom check, ask focused follow-up
@@ -794,7 +803,9 @@ export default function SymptomCheckerPage() {
                   <button
                     key={s}
                     onClick={() =>
-                      sendMessage(`${pet.name} has been ${s.toLowerCase()}`)
+                      sendMessage(
+                        `${hasHydrated ? pet.name : "My dog"} has been ${s.toLowerCase()}`,
+                      )
                     }
                     className="px-3 py-1.5 text-xs rounded-full border border-gray-200 text-gray-600 hover:bg-purple-50 hover:border-purple-200 hover:text-purple-700 transition-colors"
                   >
@@ -816,10 +827,10 @@ export default function SymptomCheckerPage() {
               </div>
               <div className="min-w-0">
                 <p className="text-sm font-semibold text-gray-900">
-                  Dog symptom check for {pet.name}
+                  Dog symptom check for {displayPetName}
                 </p>
                 <p className="text-xs text-gray-500">
-                  {pet.breed}, {pet.age_years}y, {pet.weight} lbs
+                  {displayPetBreed}, {displayPetAgeYears}y, {displayPetWeight} lbs
                 </p>
               </div>
               {!report && (
@@ -964,7 +975,7 @@ export default function SymptomCheckerPage() {
                       onKeyDown={handleKeyDown}
                       placeholder={
                         messages.length === 0
-                          ? `Describe what's going on with ${pet.name} or attach a photo...`
+                          ? `Describe what's going on with ${displayPetName} or attach a photo...`
                           : "Type your answer or attach a photo..."
                       }
                       rows={2}
@@ -1038,7 +1049,7 @@ export default function SymptomCheckerPage() {
                   value={input}
                   onChange={(e) => setInput(e.target.value)}
                   onKeyDown={handleKeyDown}
-                  placeholder={`Describe what's going on with ${pet.name} or attach a photo...`}
+                  placeholder={`Describe what's going on with ${displayPetName} or attach a photo...`}
                   rows={2}
                   className="min-w-0 flex-1 resize-none rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
                 />

--- a/src/components/tester-onboarding/tester-onboarding-gate.tsx
+++ b/src/components/tester-onboarding/tester-onboarding-gate.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useSyncExternalStore } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
 import Card from "@/components/ui/card";
 import { isSupabaseConfigured } from "@/lib/supabase";
 import { hasTesterConsent, recordTesterConsent } from "@/lib/tester-consent";
@@ -28,15 +28,20 @@ export default function TesterOnboardingGate({
   children,
 }: TesterOnboardingGateProps) {
   const { activePet, user, userDataLoaded } = useAppStore();
+  const [hasHydrated, setHasHydrated] = useState(false);
   const [acknowledgedSubjectId, setAcknowledgedSubjectId] = useState<
     string | null
   >(null);
+
+  useEffect(() => {
+    setHasHydrated(true);
+  }, []);
 
   const consentSubjectId = getConsentSubjectId(user?.id);
   const ready = !isSupabaseConfigured || userDataLoaded;
   const storedAcknowledged = useSyncExternalStore(
     subscribeToTesterConsent,
-    () => (ready ? hasTesterConsent(user?.id) : false),
+    () => (ready && hasHydrated ? hasTesterConsent(user?.id) : false),
     () => false
   );
 
@@ -61,7 +66,7 @@ export default function TesterOnboardingGate({
     return (
       <div className="mx-auto max-w-5xl">
         <TesterBoundaryCard
-          petName={activePet?.name ?? "your dog"}
+          petName={hasHydrated ? activePet?.name ?? "your dog" : "your dog"}
           onAcknowledge={handleAcknowledge}
         />
       </div>

--- a/src/components/tester-onboarding/tester-onboarding-gate.tsx
+++ b/src/components/tester-onboarding/tester-onboarding-gate.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useSyncExternalStore } from "react";
+import { useState, useSyncExternalStore } from "react";
 import Card from "@/components/ui/card";
 import { isSupabaseConfigured } from "@/lib/supabase";
 import { hasTesterConsent, recordTesterConsent } from "@/lib/tester-consent";
@@ -24,18 +24,22 @@ function subscribeToTesterConsent() {
   return () => {};
 }
 
+function subscribeToHydration() {
+  return () => {};
+}
+
 export default function TesterOnboardingGate({
   children,
 }: TesterOnboardingGateProps) {
   const { activePet, user, userDataLoaded } = useAppStore();
-  const [hasHydrated, setHasHydrated] = useState(false);
+  const hasHydrated = useSyncExternalStore(
+    subscribeToHydration,
+    () => true,
+    () => false
+  );
   const [acknowledgedSubjectId, setAcknowledgedSubjectId] = useState<
     string | null
   >(null);
-
-  useEffect(() => {
-    setHasHydrated(true);
-  }, []);
 
   const consentSubjectId = getConsentSubjectId(user?.id);
   const ready = !isSupabaseConfigured || userDataLoaded;


### PR DESCRIPTION
## Summary
- Issue: #343
- Issue link: https://github.com/kandamukeshkumar4-cmyk/pawvital-ai/issues/343

## Files changed
- `src/app/(dashboard)/symptom-checker/page.tsx`
- `src/components/tester-onboarding/tester-onboarding-gate.tsx`
- `smoke/browser-mobile/browser-mobile.smoke.pw.ts`

## Hydration guard summary
- Stabilizes symptom-checker pet-specific copy until after the first client hydration pass so the server and initial client render stay aligned.
- Applies the same hydration-safe fallback for the tester onboarding gate so stored consent and pet-name rendering do not diverge during bootstrap.
- Keeps the fix scoped to UI/rendering surfaces only; no clinical logic changes.

## Smoke regression guard summary
- Adds a browser/mobile smoke assertion that fails if hydration mismatch warnings appear in the page console.
- Covers the onboarding, emergency result-flow, and mild result-flow symptom-checker paths.

## Validation
- `npm test`
- `npm run build`
- `npm run smoke:browser-mobile`
