### PR TITLE
VET-1412K: Add complaint module pack 2 scaffold

### DIFF
--- a/docs/clinical-intelligence/complaint-modules-pack2-notes-kimi.md
+++ b/docs/clinical-intelligence/complaint-modules-pack2-notes-kimi.md
@@ -1,0 +1,97 @@
+# Complaint Module Definition Pack 2 — Kimi 2.6
+
+## Purpose
+This document describes the second complaint-specific module definitions for Respiratory, Seizure/Collapse/Neuro, and Urinary so that a future planner can select symptom-specific, emergency-first question sequences.
+
+## Scope
+- **Metadata/scaffold only.** These modules are not wired into the live symptom checker.
+- No production behavior change.
+- No API route changes.
+- No UI changes.
+- No planner cutover.
+- No model/RAG changes.
+- No emergency threshold changes.
+
+## Design Principles
+1. **Emergency first.** Every module begins with an `emergency_screen` phase that asks red-flag questions before lower-value characterization questions.
+2. **Stop conditions.** Each module defines when to escalate to emergency, when enough information is gathered for a report, or when to continue asking questions.
+3. **Question-card IDs only.** Modules reference question cards by ID; they do not duplicate raw question strings.
+4. **No diagnosis/treatment language.** All text fields (triggers, aliases, safety notes) are checked for forbidden terms during validation.
+5. **Urgency guidance + vet handoff only.** These modules guide the conversation toward safe triage and a structured handoff to a veterinarian. They do not diagnose or prescribe.
+
+## Module Overview
+
+### respiratory_distress
+- **Triggers:** coughing, wheezing, sneezing, breathing difficulty, trouble breathing, choking, respiratory distress, labored breathing, gasping, etc.
+- **Emergency screen:** Checks for breathing difficulty, gum color changes, collapse/weakness, and global emergency signs before asking about toxin exposure or timeline.
+- **Key stop conditions:**
+  - `respiratory_breathing_difficulty_or_collapse` → emergency
+  - `respiratory_breathing_signal` → emergency
+  - `respiratory_enough_for_report` → ready_for_report
+- **Safety note:** Difficulty breathing or blue gums indicates a life-threatening emergency; escalate immediately.
+
+### seizure_collapse_neuro
+- **Triggers:** seizure, convulsion, twitching, shaking, collapse, fainted, unconscious, disoriented, circling, head tilt, neurological, tremor, etc.
+- **Emergency screen:** Checks for seizure activity, collapse/weakness, gum color changes, and global emergency signs before asking about seizure duration and clustering.
+- **Key stop conditions:**
+  - `seizure_prolonged_or_collapse` → emergency
+  - `seizure_neuro_signal` → emergency
+  - `seizure_enough_for_report` → ready_for_report
+- **Safety note:** Prolonged seizures or cluster seizures are a medical emergency; escalate immediately.
+
+### urinary_obstruction
+- **Triggers:** can't pee, not peeing, straining to pee, blood in urine, frequent urination, incontinence, urinary obstruction, etc.
+- **Emergency screen:** Checks for urinary blockage, gum color changes, collapse/weakness, and global emergency signs before asking about straining and output changes.
+- **Key stop conditions:**
+  - `urinary_blockage_or_no_urine` → emergency
+  - `urinary_obstruction_signal` → emergency
+  - `urinary_enough_for_report` → ready_for_report
+- **Safety note:** Inability to pass urine can become life-threatening within hours; escalate immediately.
+
+## API
+
+### `getComplaintModules(): ComplaintModule[]`
+Returns all defined complaint modules (now six total).
+
+### `getComplaintModuleById(id: string): ComplaintModule | undefined`
+Returns a single module by ID.
+
+### `findComplaintModulesForText(text: string): ComplaintModule[]`
+Lexical matching against triggers and aliases. Returns all modules that match the input text.
+
+### `getEmergencyScreenQuestionIdsForModule(moduleId: string): string[] | undefined`
+Returns the emergency-screen question IDs for a given module.
+
+### `validateComplaintModules(): Promise<ValidationResult>`
+Async validation that checks:
+- Unique module IDs
+- Triggers and aliases present
+- At least one emergency screen question per module
+- Every referenced question ID exists in the question-card registry (if available)
+- Stop conditions present
+- Report fields present
+- No diagnosis/treatment language
+- Valid phase IDs
+- Positive `maxQuestionsFromPhase`
+
+## Validation
+Run:
+```bash
+npm test -- --runTestsByPath tests/clinical-intelligence/complaint-modules-pack2.test.ts
+npm test -- --runTestsByPath tests/clinical-intelligence/complaint-modules-mvp.test.ts
+npx eslint src/lib/clinical-intelligence/complaint-modules tests/clinical-intelligence/complaint-modules-pack2.test.ts
+npm run build
+```
+
+## Integration Notes
+- These modules are isolated definitions only.
+- The planner will use `findComplaintModulesForText()` to select the appropriate module based on the owner complaint, then execute the `emergency_screen` phase first.
+- Stop conditions will be evaluated after each owner response to determine whether to escalate, continue, or hand off.
+
+## Files
+- `src/lib/clinical-intelligence/complaint-modules/respiratory.ts`
+- `src/lib/clinical-intelligence/complaint-modules/seizure-collapse.ts`
+- `src/lib/clinical-intelligence/complaint-modules/urinary.ts`
+- `src/lib/clinical-intelligence/complaint-modules/index.ts`
+- `tests/clinical-intelligence/complaint-modules-pack2.test.ts`
+- `docs/clinical-intelligence/complaint-modules-pack2-notes-kimi.md`

--- a/src/lib/clinical-intelligence/complaint-modules/index.ts
+++ b/src/lib/clinical-intelligence/complaint-modules/index.ts
@@ -2,11 +2,17 @@ import type { ComplaintModule } from "./types";
 import { skinItchingAllergyModule } from "./skin";
 import { giVomitingDiarrheaModule } from "./gi";
 import { limpingMobilityPainModule } from "./limping";
+import { respiratoryDistressModule } from "./respiratory";
+import { seizureCollapseNeuroModule } from "./seizure-collapse";
+import { urinaryObstructionModule } from "./urinary";
 
 const ALL_MODULES: ComplaintModule[] = [
   skinItchingAllergyModule,
   giVomitingDiarrheaModule,
   limpingMobilityPainModule,
+  respiratoryDistressModule,
+  seizureCollapseNeuroModule,
+  urinaryObstructionModule,
 ];
 
 const MODULE_BY_ID = new Map<string, ComplaintModule>();
@@ -197,4 +203,7 @@ export {
   skinItchingAllergyModule,
   giVomitingDiarrheaModule,
   limpingMobilityPainModule,
+  respiratoryDistressModule,
+  seizureCollapseNeuroModule,
+  urinaryObstructionModule,
 };

--- a/src/lib/clinical-intelligence/complaint-modules/respiratory.ts
+++ b/src/lib/clinical-intelligence/complaint-modules/respiratory.ts
@@ -1,0 +1,139 @@
+import type { ComplaintModule } from "./types";
+
+export const respiratoryDistressModule: ComplaintModule = {
+  id: "respiratory_distress",
+  displayNameForLogs: "Respiratory Distress / Coughing / Breathing Difficulty",
+  triggers: [
+    "coughing",
+    "cough",
+    "hacking",
+    "wheezing",
+    "sneezing",
+    "breathing difficulty",
+    "trouble breathing",
+    "short of breath",
+    "panting excessively",
+    "noisy breathing",
+    "choking",
+    "respiratory distress",
+    "labored breathing",
+    "difficulty breathing",
+    "gasping",
+  ],
+  aliases: [
+    "respiratory issue",
+    "breathing problem",
+    "airway concern",
+    "upper respiratory infection",
+  ],
+
+  emergencyScreenQuestionIds: [
+    "breathing_difficulty_check",
+    "gum_color_check",
+    "collapse_weakness_check",
+    "emergency_global_screen",
+  ],
+
+  phases: [
+    {
+      id: "emergency_screen",
+      questionIds: [
+        "breathing_difficulty_check",
+        "gum_color_check",
+        "collapse_weakness_check",
+        "emergency_global_screen",
+      ],
+      maxQuestionsFromPhase: 4,
+    },
+    {
+      id: "characterize",
+      questionIds: [
+        "breathing_difficulty_check",
+        "toxin_exposure_check",
+        "emergency_global_screen",
+        "gum_color_check",
+      ],
+      maxQuestionsFromPhase: 4,
+    },
+    {
+      id: "discriminate",
+      questionIds: [
+        "breathing_difficulty_check",
+        "toxin_exposure_check",
+        "emergency_global_screen",
+      ],
+      maxQuestionsFromPhase: 3,
+    },
+    {
+      id: "timeline",
+      questionIds: [
+        "emergency_global_screen",
+        "breathing_difficulty_check",
+        "gum_color_check",
+      ],
+      maxQuestionsFromPhase: 2,
+    },
+    {
+      id: "history",
+      questionIds: [
+        "gum_color_check",
+        "breathing_difficulty_check",
+        "toxin_exposure_check",
+        "emergency_global_screen",
+      ],
+      maxQuestionsFromPhase: 2,
+    },
+    {
+      id: "handoff",
+      questionIds: ["breathing_difficulty_check"],
+      maxQuestionsFromPhase: 1,
+    },
+  ],
+
+  stopConditions: [
+    {
+      id: "respiratory_breathing_difficulty_or_collapse",
+      ifRedFlagPositive: [
+        "breathing_difficulty",
+        "collapse",
+        "pale_gums",
+        "blue_gums",
+      ],
+      result: "emergency",
+    },
+    {
+      id: "respiratory_breathing_signal",
+      ifAnySignalPresent: ["possible_breathing_difficulty"],
+      result: "emergency",
+    },
+    {
+      id: "respiratory_enough_for_report",
+      ifEnoughInformation: [
+        "breathing_difficulty_check",
+        "gum_color_check",
+        "collapse_weakness_check",
+        "emergency_global_screen",
+      ],
+      result: "ready_for_report",
+    },
+    {
+      id: "respiratory_continue",
+      result: "continue",
+    },
+  ],
+
+  reportFields: [
+    "breathing_difficulty_check",
+    "gum_color_check",
+    "collapse_weakness_check",
+    "emergency_global_screen",
+    "toxin_exposure_check",
+  ],
+
+  safetyNotes: [
+    "Difficulty breathing or blue gums indicates a life-threatening emergency; escalate immediately to a veterinary professional.",
+    "Sudden onset of severe breathing difficulty requires immediate veterinary attention.",
+    "Collapse during a respiratory workup indicates severe compromise; escalate immediately to a veterinary clinic.",
+    "Known toxin exposure with breathing difficulty is an emergency regardless of severity; seek veterinary care.",
+  ],
+};

--- a/src/lib/clinical-intelligence/complaint-modules/seizure-collapse.ts
+++ b/src/lib/clinical-intelligence/complaint-modules/seizure-collapse.ts
@@ -1,0 +1,146 @@
+import type { ComplaintModule } from "./types";
+
+export const seizureCollapseNeuroModule: ComplaintModule = {
+  id: "seizure_collapse_neuro",
+  displayNameForLogs: "Seizure / Collapse / Neurologic Emergency",
+  triggers: [
+    "seizure",
+    "seizures",
+    "convulsion",
+    "convulsions",
+    "twitching",
+    "shaking",
+    "fit",
+    "fits",
+    "collapse",
+    "fainted",
+    "passed out",
+    "unconscious",
+    "disoriented",
+    "circling",
+    "head tilt",
+    "neurologic",
+    "neurological",
+    "tremor",
+    "trembling",
+  ],
+  aliases: [
+    "neuro emergency",
+    "epileptic episode",
+    "convulsive episode",
+    "neurological event",
+  ],
+
+  emergencyScreenQuestionIds: [
+    "seizure_neuro_check",
+    "collapse_weakness_check",
+    "gum_color_check",
+    "emergency_global_screen",
+  ],
+
+  phases: [
+    {
+      id: "emergency_screen",
+      questionIds: [
+        "seizure_neuro_check",
+        "collapse_weakness_check",
+        "gum_color_check",
+        "emergency_global_screen",
+      ],
+      maxQuestionsFromPhase: 4,
+    },
+    {
+      id: "characterize",
+      questionIds: [
+        "seizure_neuro_check",
+        "neuro_seizure_duration",
+        "emergency_global_screen",
+        "gum_color_check",
+      ],
+      maxQuestionsFromPhase: 4,
+    },
+    {
+      id: "discriminate",
+      questionIds: [
+        "seizure_neuro_check",
+        "neuro_seizure_duration",
+        "emergency_global_screen",
+      ],
+      maxQuestionsFromPhase: 3,
+    },
+    {
+      id: "timeline",
+      questionIds: [
+        "emergency_global_screen",
+        "seizure_neuro_check",
+        "neuro_seizure_duration",
+      ],
+      maxQuestionsFromPhase: 2,
+    },
+    {
+      id: "history",
+      questionIds: [
+        "gum_color_check",
+        "seizure_neuro_check",
+        "neuro_seizure_duration",
+        "emergency_global_screen",
+      ],
+      maxQuestionsFromPhase: 2,
+    },
+    {
+      id: "handoff",
+      questionIds: ["seizure_neuro_check"],
+      maxQuestionsFromPhase: 1,
+    },
+  ],
+
+  stopConditions: [
+    {
+      id: "seizure_prolonged_or_collapse",
+      ifRedFlagPositive: [
+        "seizure_activity",
+        "seizure_prolonged",
+        "collapse",
+        "unresponsive",
+      ],
+      result: "emergency",
+    },
+    {
+      id: "seizure_neuro_signal",
+      ifAnySignalPresent: [
+        "possible_neuro_emergency",
+        "possible_collapse_or_weakness",
+      ],
+      result: "emergency",
+    },
+    {
+      id: "seizure_enough_for_report",
+      ifEnoughInformation: [
+        "seizure_neuro_check",
+        "neuro_seizure_duration",
+        "collapse_weakness_check",
+        "emergency_global_screen",
+      ],
+      result: "ready_for_report",
+    },
+    {
+      id: "seizure_continue",
+      result: "continue",
+    },
+  ],
+
+  reportFields: [
+    "seizure_neuro_check",
+    "neuro_seizure_duration",
+    "collapse_weakness_check",
+    "gum_color_check",
+    "emergency_global_screen",
+  ],
+
+  safetyNotes: [
+    "Prolonged seizures or cluster seizures are a medical emergency; escalate immediately to a veterinary professional.",
+    "Collapse or unresponsiveness during a neurologic workup requires immediate emergency routing to a veterinarian.",
+    "Pale or blue gums during a seizure workup indicate cardiovascular compromise; escalate immediately to a veterinary clinic.",
+    "Repeated seizures without full recovery between episodes require urgent veterinary evaluation.",
+  ],
+};

--- a/src/lib/clinical-intelligence/complaint-modules/urinary.ts
+++ b/src/lib/clinical-intelligence/complaint-modules/urinary.ts
@@ -1,0 +1,136 @@
+import type { ComplaintModule } from "./types";
+
+export const urinaryObstructionModule: ComplaintModule = {
+  id: "urinary_obstruction",
+  displayNameForLogs: "Urinary Obstruction / Urination Problems",
+  triggers: [
+    "can't pee",
+    "not peeing",
+    "straining to pee",
+    "straining to urinate",
+    "blood in urine",
+    "frequent urination",
+    "peeing a lot",
+    "accident in house",
+    "incontinence",
+    "leaking urine",
+    "urinary tract",
+    "painful urination",
+    "crying when peeing",
+    "blocked",
+    "urinary obstruction",
+    "difficulty urinating",
+    "urination problems",
+  ],
+  aliases: [
+    "urinary issue",
+    "urination problem",
+    "bladder concern",
+    "uti",
+  ],
+
+  emergencyScreenQuestionIds: [
+    "urinary_blockage_check",
+    "gum_color_check",
+    "collapse_weakness_check",
+    "emergency_global_screen",
+  ],
+
+  phases: [
+    {
+      id: "emergency_screen",
+      questionIds: [
+        "urinary_blockage_check",
+        "gum_color_check",
+        "collapse_weakness_check",
+        "emergency_global_screen",
+      ],
+      maxQuestionsFromPhase: 4,
+    },
+    {
+      id: "characterize",
+      questionIds: [
+        "urinary_blockage_check",
+        "urinary_straining_output",
+        "emergency_global_screen",
+        "gum_color_check",
+      ],
+      maxQuestionsFromPhase: 4,
+    },
+    {
+      id: "discriminate",
+      questionIds: [
+        "urinary_blockage_check",
+        "urinary_straining_output",
+        "emergency_global_screen",
+      ],
+      maxQuestionsFromPhase: 3,
+    },
+    {
+      id: "timeline",
+      questionIds: [
+        "emergency_global_screen",
+        "urinary_blockage_check",
+        "urinary_straining_output",
+      ],
+      maxQuestionsFromPhase: 2,
+    },
+    {
+      id: "history",
+      questionIds: [
+        "gum_color_check",
+        "urinary_blockage_check",
+        "urinary_straining_output",
+        "emergency_global_screen",
+      ],
+      maxQuestionsFromPhase: 2,
+    },
+    {
+      id: "handoff",
+      questionIds: ["urinary_blockage_check"],
+      maxQuestionsFromPhase: 1,
+    },
+  ],
+
+  stopConditions: [
+    {
+      id: "urinary_blockage_or_no_urine",
+      ifRedFlagPositive: ["urinary_blockage", "no_urine_24h"],
+      result: "emergency",
+    },
+    {
+      id: "urinary_obstruction_signal",
+      ifAnySignalPresent: ["possible_urinary_obstruction"],
+      result: "emergency",
+    },
+    {
+      id: "urinary_enough_for_report",
+      ifEnoughInformation: [
+        "urinary_blockage_check",
+        "urinary_straining_output",
+        "emergency_global_screen",
+        "gum_color_check",
+      ],
+      result: "ready_for_report",
+    },
+    {
+      id: "urinary_continue",
+      result: "continue",
+    },
+  ],
+
+  reportFields: [
+    "urinary_blockage_check",
+    "urinary_straining_output",
+    "emergency_global_screen",
+    "gum_color_check",
+    "collapse_weakness_check",
+  ],
+
+  safetyNotes: [
+    "Inability to pass urine can become life-threatening within hours; escalate immediately to a veterinary professional.",
+    "Straining to urinate with little or no output is an emergency requiring immediate veterinary attention.",
+    "Collapse during a urinary workup indicates severe systemic compromise; escalate immediately to a veterinary clinic.",
+    "Blood in urine with straining suggests obstruction or serious urinary tract injury; seek prompt veterinary evaluation.",
+  ],
+};

--- a/tests/clinical-intelligence/complaint-modules-pack2.test.ts
+++ b/tests/clinical-intelligence/complaint-modules-pack2.test.ts
@@ -1,0 +1,424 @@
+import {
+  getComplaintModules,
+  getComplaintModuleById,
+  findComplaintModulesForText,
+  getEmergencyScreenQuestionIdsForModule,
+  validateComplaintModules,
+  respiratoryDistressModule,
+  seizureCollapseNeuroModule,
+  urinaryObstructionModule,
+} from "@/lib/clinical-intelligence/complaint-modules";
+
+import { getAllQuestionCards } from "@/lib/clinical-intelligence/question-card-registry";
+import { EMERGENCY_RED_FLAG_IDS } from "@/lib/clinical-intelligence/emergency-red-flags";
+import * as fs from "fs";
+import * as path from "path";
+
+describe("Complaint Modules Pack 2", () => {
+  describe("1. All three new modules exist", () => {
+    it("should export respiratory_distress", () => {
+      expect(respiratoryDistressModule).toBeDefined();
+      expect(respiratoryDistressModule.id).toBe("respiratory_distress");
+    });
+
+    it("should export seizure_collapse_neuro", () => {
+      expect(seizureCollapseNeuroModule).toBeDefined();
+      expect(seizureCollapseNeuroModule.id).toBe("seizure_collapse_neuro");
+    });
+
+    it("should export urinary_obstruction", () => {
+      expect(urinaryObstructionModule).toBeDefined();
+      expect(urinaryObstructionModule.id).toBe("urinary_obstruction");
+    });
+  });
+
+  describe("2. Module IDs remain unique across all modules", () => {
+    it("should return unique module IDs from getComplaintModules", () => {
+      const modules = getComplaintModules();
+      const ids = modules.map((m) => m.id);
+      const uniqueIds = new Set(ids);
+      expect(uniqueIds.size).toBe(ids.length);
+    });
+  });
+
+  describe("3. Each new module has emergency-screen question IDs", () => {
+    it("respiratory module has emergency screen questions", () => {
+      expect(respiratoryDistressModule.emergencyScreenQuestionIds.length).toBeGreaterThan(0);
+    });
+
+    it("seizure module has emergency screen questions", () => {
+      expect(seizureCollapseNeuroModule.emergencyScreenQuestionIds.length).toBeGreaterThan(0);
+    });
+
+    it("urinary module has emergency screen questions", () => {
+      expect(urinaryObstructionModule.emergencyScreenQuestionIds.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("4. Each new module has stop conditions", () => {
+    it("respiratory module has stop conditions", () => {
+      expect(respiratoryDistressModule.stopConditions.length).toBeGreaterThan(0);
+    });
+
+    it("seizure module has stop conditions", () => {
+      expect(seizureCollapseNeuroModule.stopConditions.length).toBeGreaterThan(0);
+    });
+
+    it("urinary module has stop conditions", () => {
+      expect(urinaryObstructionModule.stopConditions.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("5. New modules reference only known question-card IDs", () => {
+    it("should validate without errors against real question-card registry", async () => {
+      const knownIds = getAllQuestionCards().map((c) => c.id);
+      const result = await validateComplaintModules(knownIds);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+
+  describe("6. Respiratory module asks breathing difficulty before characterization", () => {
+    it("first phase is emergency_screen", () => {
+      expect(respiratoryDistressModule.phases[0].id).toBe("emergency_screen");
+    });
+
+    it("emergency phase includes breathing_difficulty_check", () => {
+      expect(respiratoryDistressModule.phases[0].questionIds).toContain("breathing_difficulty_check");
+    });
+
+    it("second phase is characterize with toxin exposure", () => {
+      expect(respiratoryDistressModule.phases[1].id).toBe("characterize");
+      expect(respiratoryDistressModule.phases[1].questionIds).toContain("toxin_exposure_check");
+    });
+  });
+
+  describe("7. Seizure module asks seizure neuro check before duration", () => {
+    it("first phase is emergency_screen", () => {
+      expect(seizureCollapseNeuroModule.phases[0].id).toBe("emergency_screen");
+    });
+
+    it("emergency phase starts with seizure_neuro_check", () => {
+      expect(seizureCollapseNeuroModule.phases[0].questionIds[0]).toBe("seizure_neuro_check");
+    });
+
+    it("emergency phase includes collapse_weakness_check", () => {
+      expect(seizureCollapseNeuroModule.phases[0].questionIds).toContain("collapse_weakness_check");
+    });
+  });
+
+  describe("8. Urinary module prioritizes blockage check and straining output", () => {
+    it("first phase is emergency_screen", () => {
+      expect(urinaryObstructionModule.phases[0].id).toBe("emergency_screen");
+    });
+
+    it("emergency phase starts with urinary_blockage_check", () => {
+      expect(urinaryObstructionModule.phases[0].questionIds[0]).toBe("urinary_blockage_check");
+    });
+
+    it("characterize phase includes urinary_straining_output", () => {
+      expect(urinaryObstructionModule.phases[1].questionIds).toContain("urinary_straining_output");
+    });
+  });
+
+  describe("9. Trigger matching finds respiratory cases", () => {
+    it("matches 'my dog is coughing a lot'", () => {
+      const matches = findComplaintModulesForText("my dog is coughing a lot");
+      expect(matches.map((m) => m.id)).toContain("respiratory_distress");
+    });
+
+    it("matches 'difficulty breathing after walk'", () => {
+      const matches = findComplaintModulesForText("difficulty breathing after walk");
+      expect(matches.map((m) => m.id)).toContain("respiratory_distress");
+    });
+
+    it("matches 'gasping and wheezing'", () => {
+      const matches = findComplaintModulesForText("gasping and wheezing");
+      expect(matches.map((m) => m.id)).toContain("respiratory_distress");
+    });
+
+    it("matches 'breathing problem' via alias", () => {
+      const matches = findComplaintModulesForText("seems to have a breathing problem");
+      expect(matches.map((m) => m.id)).toContain("respiratory_distress");
+    });
+  });
+
+  describe("10. Trigger matching finds seizure/collapse/neuro cases", () => {
+    it("matches 'had a seizure this morning'", () => {
+      const matches = findComplaintModulesForText("had a seizure this morning");
+      expect(matches.map((m) => m.id)).toContain("seizure_collapse_neuro");
+    });
+
+    it("matches 'collapsed and fainted'", () => {
+      const matches = findComplaintModulesForText("collapsed and fainted");
+      expect(matches.map((m) => m.id)).toContain("seizure_collapse_neuro");
+    });
+
+    it("matches 'trembling and disoriented'", () => {
+      const matches = findComplaintModulesForText("trembling and disoriented");
+      expect(matches.map((m) => m.id)).toContain("seizure_collapse_neuro");
+    });
+
+    it("matches 'neurological event' via alias", () => {
+      const matches = findComplaintModulesForText("looks like a neurological event");
+      expect(matches.map((m) => m.id)).toContain("seizure_collapse_neuro");
+    });
+  });
+
+  describe("11. Trigger matching finds urinary cases", () => {
+    it("matches 'straining to pee with no output'", () => {
+      const matches = findComplaintModulesForText("straining to pee with no output");
+      expect(matches.map((m) => m.id)).toContain("urinary_obstruction");
+    });
+
+    it("matches 'blood in urine'", () => {
+      const matches = findComplaintModulesForText("blood in urine");
+      expect(matches.map((m) => m.id)).toContain("urinary_obstruction");
+    });
+
+    it("matches 'not peeing since yesterday'", () => {
+      const matches = findComplaintModulesForText("not peeing since yesterday");
+      expect(matches.map((m) => m.id)).toContain("urinary_obstruction");
+    });
+
+    it("matches 'urination problem' via alias", () => {
+      const matches = findComplaintModulesForText("having a urination problem");
+      expect(matches.map((m) => m.id)).toContain("urinary_obstruction");
+    });
+  });
+
+  describe("12. Boundary-aware matching rejects short triggers inside unrelated words", () => {
+    it("does not match 'cough' inside 'scoffing'", () => {
+      const matches = findComplaintModulesForText("scoffing at the idea");
+      expect(matches.map((m) => m.id)).not.toContain("respiratory_distress");
+    });
+
+    it("does not match 'fit' inside 'benefit'", () => {
+      const matches = findComplaintModulesForText("benefit of the doubt");
+      expect(matches.map((m) => m.id)).not.toContain("seizure_collapse_neuro");
+    });
+
+    it("does not match 'uti' inside 'cuticle'", () => {
+      const matches = findComplaintModulesForText("cuticle injury");
+      expect(matches.map((m) => m.id)).not.toContain("urinary_obstruction");
+    });
+
+    it("does not match 'pee' inside 'speed'", () => {
+      const matches = findComplaintModulesForText("running at full speed");
+      expect(matches.map((m) => m.id)).not.toContain("urinary_obstruction");
+    });
+  });
+
+  describe("13. No diagnosis or treatment language appears in new module metadata", () => {
+    it("validation reports no diagnosis/treatment language errors", async () => {
+      const result = await validateComplaintModules();
+      const diagErrors = result.errors.filter((e) => e.includes("diagnosis/treatment"));
+      expect(diagErrors).toHaveLength(0);
+    });
+  });
+
+  describe("14. New module docs explain urgency guidance + vet handoff only", () => {
+    it("respiratory module has safety notes about vet handoff", () => {
+      expect(respiratoryDistressModule.safetyNotes.length).toBeGreaterThan(0);
+      const combined = respiratoryDistressModule.safetyNotes.join(" ").toLowerCase();
+      expect(combined).toContain("veterinary");
+    });
+
+    it("seizure module has safety notes about vet handoff", () => {
+      expect(seizureCollapseNeuroModule.safetyNotes.length).toBeGreaterThan(0);
+      const combined = seizureCollapseNeuroModule.safetyNotes.join(" ").toLowerCase();
+      expect(combined).toContain("veterinary");
+    });
+
+    it("urinary module has safety notes about vet handoff", () => {
+      expect(urinaryObstructionModule.safetyNotes.length).toBeGreaterThan(0);
+      const combined = urinaryObstructionModule.safetyNotes.join(" ").toLowerCase();
+      expect(combined).toContain("veterinary");
+    });
+  });
+
+  describe("15. Respiratory emergency stop conditions cover breathing difficulty and collapse", () => {
+    it("has emergency stop for breathing difficulty or collapse", () => {
+      const condition = respiratoryDistressModule.stopConditions.find(
+        (c) => c.id === "respiratory_breathing_difficulty_or_collapse"
+      );
+      expect(condition).toBeDefined();
+      expect(condition!.result).toBe("emergency");
+      const flags = condition!.ifRedFlagPositive || [];
+      expect(flags).toContain("breathing_difficulty");
+      expect(flags).toContain("collapse");
+    });
+
+    it("has signal-based stop for possible breathing difficulty", () => {
+      const condition = respiratoryDistressModule.stopConditions.find(
+        (c) => c.id === "respiratory_breathing_signal"
+      );
+      expect(condition).toBeDefined();
+      expect(condition!.result).toBe("emergency");
+      const signals = condition!.ifAnySignalPresent || [];
+      expect(signals).toContain("possible_breathing_difficulty");
+    });
+  });
+
+  describe("16. Seizure emergency stop conditions cover seizure activity and collapse", () => {
+    it("has emergency stop for prolonged seizure or collapse", () => {
+      const condition = seizureCollapseNeuroModule.stopConditions.find(
+        (c) => c.id === "seizure_prolonged_or_collapse"
+      );
+      expect(condition).toBeDefined();
+      expect(condition!.result).toBe("emergency");
+      const flags = condition!.ifRedFlagPositive || [];
+      expect(flags).toContain("seizure_activity");
+      expect(flags).toContain("seizure_prolonged");
+      expect(flags).toContain("collapse");
+    });
+
+    it("has signal-based stop for neuro emergency or collapse", () => {
+      const condition = seizureCollapseNeuroModule.stopConditions.find(
+        (c) => c.id === "seizure_neuro_signal"
+      );
+      expect(condition).toBeDefined();
+      expect(condition!.result).toBe("emergency");
+      const signals = condition!.ifAnySignalPresent || [];
+      expect(signals).toContain("possible_neuro_emergency");
+      expect(signals).toContain("possible_collapse_or_weakness");
+    });
+  });
+
+  describe("17. Urinary emergency stop conditions cover blockage and no urine", () => {
+    it("has emergency stop for urinary blockage or no urine", () => {
+      const condition = urinaryObstructionModule.stopConditions.find(
+        (c) => c.id === "urinary_blockage_or_no_urine"
+      );
+      expect(condition).toBeDefined();
+      expect(condition!.result).toBe("emergency");
+      const flags = condition!.ifRedFlagPositive || [];
+      expect(flags).toContain("urinary_blockage");
+      expect(flags).toContain("no_urine_24h");
+    });
+
+    it("has signal-based stop for possible urinary obstruction", () => {
+      const condition = urinaryObstructionModule.stopConditions.find(
+        (c) => c.id === "urinary_obstruction_signal"
+      );
+      expect(condition).toBeDefined();
+      expect(condition!.result).toBe("emergency");
+      const signals = condition!.ifAnySignalPresent || [];
+      expect(signals).toContain("possible_urinary_obstruction");
+    });
+  });
+
+  describe("18. Stop-condition IDs are validated against real emitted or canonical flags", () => {
+    it("no new module references a fake red-flag or signal ID", () => {
+      const allCards = getAllQuestionCards();
+      const emittedRedFlags = new Set<string>();
+      for (const card of allCards) {
+        for (const flag of card.screensRedFlags) {
+          emittedRedFlags.add(flag);
+        }
+      }
+      const canonicalRedFlags = new Set<string>(EMERGENCY_RED_FLAG_IDS);
+      const validRedFlags = new Set([...emittedRedFlags, ...canonicalRedFlags]);
+
+      const detectorPath = path.join(
+        process.cwd(),
+        "src/lib/clinical-intelligence/clinical-signal-detector.ts"
+      );
+      const detectorSource = fs.readFileSync(detectorPath, "utf-8");
+      const signalIds = new Set<string>();
+      const signalRegex = /id:\s*"([^"]+)"/g;
+      let match: RegExpExecArray | null;
+      while ((match = signalRegex.exec(detectorSource)) !== null) {
+        signalIds.add(match[1]);
+      }
+
+      const invalids: string[] = [];
+      for (const mod of [respiratoryDistressModule, seizureCollapseNeuroModule, urinaryObstructionModule]) {
+        for (const condition of mod.stopConditions) {
+          for (const flag of condition.ifRedFlagPositive || []) {
+            if (!validRedFlags.has(flag)) {
+              invalids.push(`${mod.id}.${condition.id} redFlag: ${flag}`);
+            }
+          }
+          for (const signal of condition.ifAnySignalPresent || []) {
+            if (!signalIds.has(signal)) {
+              invalids.push(`${mod.id}.${condition.id} signal: ${signal}`);
+            }
+          }
+        }
+      }
+
+      expect(invalids).toHaveLength(0);
+    });
+
+    it("no new stop condition references the non-canonical facial_swelling ID", () => {
+      for (const mod of [respiratoryDistressModule, seizureCollapseNeuroModule, urinaryObstructionModule]) {
+        for (const condition of mod.stopConditions) {
+          for (const flag of condition.ifRedFlagPositive || []) {
+            expect(flag).not.toBe("facial_swelling");
+          }
+        }
+      }
+    });
+  });
+
+  describe("19. New modules have report fields and valid phases", () => {
+    it("respiratory module has report fields", () => {
+      expect(respiratoryDistressModule.reportFields.length).toBeGreaterThan(0);
+    });
+
+    it("seizure module has report fields", () => {
+      expect(seizureCollapseNeuroModule.reportFields.length).toBeGreaterThan(0);
+    });
+
+    it("urinary module has report fields", () => {
+      expect(urinaryObstructionModule.reportFields.length).toBeGreaterThan(0);
+    });
+
+    it("all phases in new modules have valid IDs and positive maxQuestionsFromPhase", () => {
+      const validPhaseIds = new Set([
+        "emergency_screen",
+        "characterize",
+        "discriminate",
+        "timeline",
+        "history",
+        "handoff",
+      ]);
+      for (const mod of [respiratoryDistressModule, seizureCollapseNeuroModule, urinaryObstructionModule]) {
+        for (const phase of mod.phases) {
+          expect(validPhaseIds.has(phase.id)).toBe(true);
+          expect(phase.maxQuestionsFromPhase).toBeGreaterThan(0);
+        }
+      }
+    });
+  });
+
+  describe("Helper functions", () => {
+    it("getComplaintModuleById returns correct new modules", () => {
+      expect(getComplaintModuleById("respiratory_distress")?.id).toBe("respiratory_distress");
+      expect(getComplaintModuleById("seizure_collapse_neuro")?.id).toBe("seizure_collapse_neuro");
+      expect(getComplaintModuleById("urinary_obstruction")?.id).toBe("urinary_obstruction");
+    });
+
+    it("getEmergencyScreenQuestionIdsForModule returns correct IDs for respiratory", () => {
+      const ids = getEmergencyScreenQuestionIdsForModule("respiratory_distress");
+      expect(ids).toContain("breathing_difficulty_check");
+    });
+
+    it("getEmergencyScreenQuestionIdsForModule returns correct IDs for seizure", () => {
+      const ids = getEmergencyScreenQuestionIdsForModule("seizure_collapse_neuro");
+      expect(ids).toContain("seizure_neuro_check");
+    });
+
+    it("getEmergencyScreenQuestionIdsForModule returns correct IDs for urinary", () => {
+      const ids = getEmergencyScreenQuestionIdsForModule("urinary_obstruction");
+      expect(ids).toContain("urinary_blockage_check");
+    });
+
+    it("validateComplaintModules passes structural checks with all six modules", async () => {
+      const knownIds = getAllQuestionCards().map((c) => c.id);
+      const result = await validateComplaintModules(knownIds);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- restack Kimi's uncommitted VET-1412K complaint-module pack 2 changes onto a clean branch from origin/master
- add metadata-only complaint modules for respiratory distress, seizure/collapse/neuro, and urinary obstruction
- export the new modules from the complaint-module index and add pack-2 regression coverage plus the design note

## Scope / safety
- metadata/scaffold only; no symptom-chat, triage-engine, clinical-matrix, symptom-memory, planner cutover, API, UI, RAG, or emergency-threshold changes
- files changed are limited to complaint-module definitions, the complaint-module index, one focused test file, and the accompanying note

## Files changed
- `docs/clinical-intelligence/complaint-modules-pack2-notes-kimi.md`
- `src/lib/clinical-intelligence/complaint-modules/index.ts`
- `src/lib/clinical-intelligence/complaint-modules/respiratory.ts`
- `src/lib/clinical-intelligence/complaint-modules/seizure-collapse.ts`
- `src/lib/clinical-intelligence/complaint-modules/urinary.ts`
- `tests/clinical-intelligence/complaint-modules-pack2.test.ts`

## Validation
- `npm test -- --runTestsByPath tests/clinical-intelligence/complaint-modules-pack2.test.ts`
- `npm test -- --runTestsByPath tests/clinical-intelligence/complaint-modules-mvp.test.ts`
- `npx eslint src/lib/clinical-intelligence/complaint-modules tests/clinical-intelligence/complaint-modules-pack2.test.ts`
- `npm run build`
