### PR TITLE
VET-1417C: Add shadow planner scaffold

### DIFF
--- a/docs/clinical-intelligence/shadow-planner-scaffold-codex.md
+++ b/docs/clinical-intelligence/shadow-planner-scaffold-codex.md
@@ -1,0 +1,88 @@
+# VET-1417C: Shadow Planner Scaffold and Telemetry Contract
+
+## Goal
+
+Provide a scaffold-only comparison layer that can later evaluate:
+
+- the existing owner-facing question path
+- the clinical-intelligence planner path
+
+This scaffold does not change runtime behavior. It builds pure comparison data and a telemetry-shaped wrapper only.
+
+## Files
+
+- `src/lib/clinical-intelligence/shadow-planner.ts`
+- `src/lib/clinical-intelligence/shadow-telemetry.ts`
+- `tests/clinical-intelligence/shadow-planner.test.ts`
+- `docs/clinical-intelligence/shadow-planner-scaffold-codex.md`
+
+## Comparison Result Shape
+
+`ShadowPlannerComparisonResult`
+
+- `existingQuestionId`
+- `plannedQuestionId`
+- `plannedShortReason`
+- `screenedRedFlags`
+- `selectedBecause`
+- `oldWasGeneric`
+- `newScreensEmergencyEarlier`
+- `repeatedQuestionAvoided`
+- `safetyNotes`
+
+## Pure Function Surface
+
+`shadow-planner.ts`
+
+- `createEmptyShadowPlannerComparisonResult()`
+- `buildShadowPlannerComparison()`
+- `isShadowPlannerComparisonReady()`
+
+`shadow-telemetry.ts`
+
+- `createEmptyShadowTelemetryRecord()`
+- `buildShadowTelemetryRecord()`
+
+All functions are pure:
+
+- no persistence
+- no route calls
+- no runtime planner execution
+- no symptom-chat wiring
+- no retrieval, RAG, or URL fetching
+
+## Input Contract
+
+The scaffold accepts existing repo metadata instead of inventing new runtime state:
+
+- existing question id from the current path
+- planned question metadata from `planNextClinicalQuestion()`
+- optional injected `lookupQuestionCard` from `question-card-registry.ts`
+- optional explicit `ClinicalQuestionCard` objects from registry callers
+- asked/answered/skipped question ids from existing case-state tracking
+- optional planner safety notes supplied by future non-owner-facing integration code
+
+## Safety Behavior
+
+- If the planned question input is incomplete, the scaffold returns a safe non-throwing result with empty planned fields.
+- The scaffold never generates owner text, diagnosis text, treatment advice, or new question content.
+- The telemetry wrapper marks `ownerFacingImpact: "none"` and only packages the comparison result.
+- Returned arrays are cloned so callers cannot mutate future shadow payloads by reference.
+
+## No-Runtime-Wiring Proof
+
+- No existing runtime file was edited.
+- No export was added to symptom chat, triage, symptom memory, complaint modules, or emergency sentinel code.
+- The new scaffold imports only existing planner and question-card types plus injected lookup metadata.
+- Outside the two scaffold files themselves, the only references to `shadow-planner` and `shadow-telemetry` should be this doc and the new focused test until a future explicit integration ticket wires them in.
+
+## Validation
+
+Run:
+
+```bash
+npm test -- --runTestsByPath tests/clinical-intelligence/shadow-planner.test.ts
+npm test -- --runTestsByPath tests/clinical-intelligence/next-question-planner.test.ts
+npm test -- --runTestsByPath tests/clinical-intelligence/question-card-registry.test.ts
+npm run build
+```

--- a/src/lib/clinical-intelligence/shadow-planner.ts
+++ b/src/lib/clinical-intelligence/shadow-planner.ts
@@ -1,0 +1,188 @@
+import type { PlannedQuestion, SelectedBecause } from "./next-question-planner";
+import type { ClinicalQuestionCard } from "./question-card-types";
+
+export interface ShadowPlannerComparisonResult {
+  existingQuestionId: string | null;
+  plannedQuestionId: string | null;
+  plannedShortReason: string | null;
+  screenedRedFlags: string[];
+  selectedBecause: SelectedBecause | null;
+  oldWasGeneric: boolean;
+  newScreensEmergencyEarlier: boolean;
+  repeatedQuestionAvoided: boolean;
+  safetyNotes: string[];
+}
+
+export type ShadowPlannedQuestionInput = Pick<
+  PlannedQuestion,
+  "questionId" | "shortReason" | "screenedRedFlags" | "selectedBecause"
+>;
+
+export interface BuildShadowPlannerComparisonInput {
+  existingQuestionId?: string | null;
+  plannedQuestion?: ShadowPlannedQuestionInput | null;
+  askedQuestionIds?: readonly string[];
+  answeredQuestionIds?: readonly string[];
+  skippedQuestionIds?: readonly string[];
+  existingQuestionCard?: ClinicalQuestionCard | null;
+  plannedQuestionCard?: ClinicalQuestionCard | null;
+  lookupQuestionCard?: ((questionId: string) => ClinicalQuestionCard | undefined) | null;
+  plannerSafetyNotes?: readonly string[];
+}
+
+function cloneStrings(values: readonly string[] | undefined): string[] {
+  return values ? [...values] : [];
+}
+
+function dedupeStrings(values: readonly string[]): string[] {
+  return [...new Set(values.filter((value) => value.trim().length > 0))];
+}
+
+function resolveQuestionCard(
+  questionId: string | null,
+  providedCard: ClinicalQuestionCard | null | undefined,
+  lookupQuestionCard: BuildShadowPlannerComparisonInput["lookupQuestionCard"]
+): ClinicalQuestionCard | null {
+  if (!questionId) {
+    return null;
+  }
+
+  if (providedCard?.id === questionId) {
+    return providedCard;
+  }
+
+  return lookupQuestionCard?.(questionId) ?? null;
+}
+
+function isGenericQuestionCard(card: ClinicalQuestionCard | null): boolean {
+  if (!card) {
+    return false;
+  }
+
+  return (
+    card.complaintFamilies.includes("general") ||
+    card.complaintFamilies.includes("global") ||
+    card.phase === "timeline" ||
+    card.phase === "history" ||
+    card.phase === "handoff_detail"
+  );
+}
+
+function isEmergencyQuestionCard(
+  card: ClinicalQuestionCard | null,
+  selectedBecause: SelectedBecause | null
+): boolean {
+  return card?.phase === "emergency_screen" || selectedBecause === "emergency_screen";
+}
+
+function hasCompletePlannedQuestion(
+  plannedQuestion: ShadowPlannedQuestionInput | null | undefined
+): plannedQuestion is ShadowPlannedQuestionInput {
+  return Boolean(
+    plannedQuestion?.questionId &&
+    plannedQuestion.shortReason &&
+    plannedQuestion.selectedBecause
+  );
+}
+
+function buildSeenQuestionIdSet(
+  askedQuestionIds: readonly string[] | undefined,
+  answeredQuestionIds: readonly string[] | undefined,
+  skippedQuestionIds: readonly string[] | undefined
+): Set<string> {
+  return new Set([
+    ...cloneStrings(askedQuestionIds),
+    ...cloneStrings(answeredQuestionIds),
+    ...cloneStrings(skippedQuestionIds),
+  ]);
+}
+
+function collectSafetyNotes(
+  plannerSafetyNotes: readonly string[] | undefined,
+  existingQuestionCard: ClinicalQuestionCard | null,
+  plannedQuestionCard: ClinicalQuestionCard | null
+): string[] {
+  return dedupeStrings([
+    ...cloneStrings(plannerSafetyNotes),
+    ...cloneStrings(existingQuestionCard?.safetyNotes),
+    ...cloneStrings(plannedQuestionCard?.safetyNotes),
+  ]);
+}
+
+export function createEmptyShadowPlannerComparisonResult(
+  existingQuestionId: string | null = null
+): ShadowPlannerComparisonResult {
+  return {
+    existingQuestionId,
+    plannedQuestionId: null,
+    plannedShortReason: null,
+    screenedRedFlags: [],
+    selectedBecause: null,
+    oldWasGeneric: false,
+    newScreensEmergencyEarlier: false,
+    repeatedQuestionAvoided: false,
+    safetyNotes: [],
+  };
+}
+
+export function buildShadowPlannerComparison(
+  input: BuildShadowPlannerComparisonInput
+): ShadowPlannerComparisonResult {
+  const existingQuestionId = input.existingQuestionId ?? null;
+  const existingQuestionCard = resolveQuestionCard(
+    existingQuestionId,
+    input.existingQuestionCard,
+    input.lookupQuestionCard
+  );
+
+  // Shadow scaffolding must never invent plan data when the new planner input is incomplete.
+  if (!hasCompletePlannedQuestion(input.plannedQuestion)) {
+    return {
+      ...createEmptyShadowPlannerComparisonResult(existingQuestionId),
+      oldWasGeneric: isGenericQuestionCard(existingQuestionCard),
+    };
+  }
+
+  const plannedQuestionCard = resolveQuestionCard(
+    input.plannedQuestion.questionId,
+    input.plannedQuestionCard,
+    input.lookupQuestionCard
+  );
+  const seenQuestionIds = buildSeenQuestionIdSet(
+    input.askedQuestionIds,
+    input.answeredQuestionIds,
+    input.skippedQuestionIds
+  );
+
+  return {
+    existingQuestionId,
+    plannedQuestionId: input.plannedQuestion.questionId,
+    plannedShortReason: input.plannedQuestion.shortReason,
+    screenedRedFlags: dedupeStrings(input.plannedQuestion.screenedRedFlags),
+    selectedBecause: input.plannedQuestion.selectedBecause,
+    oldWasGeneric: isGenericQuestionCard(existingQuestionCard),
+    newScreensEmergencyEarlier:
+      isEmergencyQuestionCard(
+        plannedQuestionCard,
+        input.plannedQuestion.selectedBecause
+      ) && !isEmergencyQuestionCard(existingQuestionCard, null),
+    repeatedQuestionAvoided:
+      input.plannedQuestion.questionId !== existingQuestionId &&
+      !seenQuestionIds.has(input.plannedQuestion.questionId),
+    safetyNotes: collectSafetyNotes(
+      input.plannerSafetyNotes,
+      existingQuestionCard,
+      plannedQuestionCard
+    ),
+  };
+}
+
+export function isShadowPlannerComparisonReady(
+  comparison: ShadowPlannerComparisonResult
+): boolean {
+  return Boolean(
+    comparison.plannedQuestionId &&
+    comparison.plannedShortReason &&
+    comparison.selectedBecause
+  );
+}

--- a/src/lib/clinical-intelligence/shadow-telemetry.ts
+++ b/src/lib/clinical-intelligence/shadow-telemetry.ts
@@ -1,0 +1,64 @@
+import {
+  createEmptyShadowPlannerComparisonResult,
+  isShadowPlannerComparisonReady,
+  type ShadowPlannerComparisonResult,
+} from "./shadow-planner";
+
+export const SHADOW_TELEMETRY_EVENT_NAME =
+  "clinical_intelligence.shadow_planner_comparison";
+export const SHADOW_TELEMETRY_CONTRACT_VERSION =
+  "shadow_planner_scaffold.v1";
+
+export interface ShadowTelemetryRecord {
+  eventName: typeof SHADOW_TELEMETRY_EVENT_NAME;
+  contractVersion: typeof SHADOW_TELEMETRY_CONTRACT_VERSION;
+  ownerFacingImpact: "none";
+  activeComplaintModule: string | null;
+  comparisonReady: boolean;
+  comparison: ShadowPlannerComparisonResult;
+}
+
+export interface BuildShadowTelemetryRecordInput {
+  activeComplaintModule?: string | null;
+  comparison?: ShadowPlannerComparisonResult | null;
+}
+
+function cloneComparison(
+  comparison: ShadowPlannerComparisonResult
+): ShadowPlannerComparisonResult {
+  return {
+    ...comparison,
+    screenedRedFlags: [...comparison.screenedRedFlags],
+    safetyNotes: [...comparison.safetyNotes],
+  };
+}
+
+export function createEmptyShadowTelemetryRecord(): ShadowTelemetryRecord {
+  const comparison = createEmptyShadowPlannerComparisonResult();
+
+  return {
+    eventName: SHADOW_TELEMETRY_EVENT_NAME,
+    contractVersion: SHADOW_TELEMETRY_CONTRACT_VERSION,
+    ownerFacingImpact: "none",
+    activeComplaintModule: null,
+    comparisonReady: false,
+    comparison,
+  };
+}
+
+export function buildShadowTelemetryRecord(
+  input: BuildShadowTelemetryRecordInput
+): ShadowTelemetryRecord {
+  const comparison = cloneComparison(
+    input.comparison ?? createEmptyShadowPlannerComparisonResult()
+  );
+
+  return {
+    eventName: SHADOW_TELEMETRY_EVENT_NAME,
+    contractVersion: SHADOW_TELEMETRY_CONTRACT_VERSION,
+    ownerFacingImpact: "none",
+    activeComplaintModule: input.activeComplaintModule ?? null,
+    comparisonReady: isShadowPlannerComparisonReady(comparison),
+    comparison,
+  };
+}

--- a/tests/clinical-intelligence/shadow-planner.test.ts
+++ b/tests/clinical-intelligence/shadow-planner.test.ts
@@ -1,0 +1,162 @@
+import { getQuestionCardById } from "@/lib/clinical-intelligence/question-card-registry";
+import {
+  buildShadowPlannerComparison,
+  createEmptyShadowPlannerComparisonResult,
+  isShadowPlannerComparisonReady,
+  type ShadowPlannedQuestionInput,
+} from "@/lib/clinical-intelligence/shadow-planner";
+import {
+  buildShadowTelemetryRecord,
+  createEmptyShadowTelemetryRecord,
+  SHADOW_TELEMETRY_CONTRACT_VERSION,
+  SHADOW_TELEMETRY_EVENT_NAME,
+} from "@/lib/clinical-intelligence/shadow-telemetry";
+
+const lookupQuestionCard = (questionId: string) => getQuestionCardById(questionId);
+
+function makePlannedQuestion(
+  questionId: string,
+  overrides?: Partial<ShadowPlannedQuestionInput>
+): ShadowPlannedQuestionInput {
+  const card = getQuestionCardById(questionId);
+
+  if (!card) {
+    throw new Error(`Expected question card "${questionId}" to exist`);
+  }
+
+  return {
+    questionId: card.id,
+    shortReason: card.shortReason,
+    screenedRedFlags: [...card.screensRedFlags],
+    selectedBecause: "emergency_screen",
+    ...overrides,
+  };
+}
+
+describe("shadow planner comparison scaffold", () => {
+  it("creates a safe empty result by default", () => {
+    expect(createEmptyShadowPlannerComparisonResult()).toEqual({
+      existingQuestionId: null,
+      plannedQuestionId: null,
+      plannedShortReason: null,
+      screenedRedFlags: [],
+      selectedBecause: null,
+      oldWasGeneric: false,
+      newScreensEmergencyEarlier: false,
+      repeatedQuestionAvoided: false,
+      safetyNotes: [],
+    });
+  });
+
+  it("returns a safe partial result when planned question input is incomplete", () => {
+    const result = buildShadowPlannerComparison({
+      existingQuestionId: "gi_vomiting_frequency",
+      lookupQuestionCard,
+    });
+
+    expect(result.existingQuestionId).toBe("gi_vomiting_frequency");
+    expect(result.plannedQuestionId).toBeNull();
+    expect(result.plannedShortReason).toBeNull();
+    expect(result.oldWasGeneric).toBe(false);
+    expect(isShadowPlannerComparisonReady(result)).toBe(false);
+  });
+
+  it("marks the existing global screen as generic and preserves planner notes", () => {
+    const result = buildShadowPlannerComparison({
+      existingQuestionId: "emergency_global_screen",
+      plannedQuestion: makePlannedQuestion("toxin_exposure_check"),
+      askedQuestionIds: ["emergency_global_screen"],
+      lookupQuestionCard,
+      plannerSafetyNotes: [
+        "shadow-only comparison; do not change owner-facing output",
+      ],
+    });
+
+    expect(result.existingQuestionId).toBe("emergency_global_screen");
+    expect(result.plannedQuestionId).toBe("toxin_exposure_check");
+    expect(result.oldWasGeneric).toBe(true);
+    expect(result.newScreensEmergencyEarlier).toBe(false);
+    expect(result.repeatedQuestionAvoided).toBe(true);
+    expect(result.screenedRedFlags).toEqual(
+      expect.arrayContaining(["known_toxin_ingestion", "suspected_toxin"])
+    );
+    expect(result.safetyNotes).toContain(
+      "shadow-only comparison; do not change owner-facing output"
+    );
+    expect(isShadowPlannerComparisonReady(result)).toBe(true);
+  });
+
+  it("flags when the shadow plan would screen emergency earlier than the existing path", () => {
+    const result = buildShadowPlannerComparison({
+      existingQuestionId: "gi_vomiting_frequency",
+      plannedQuestion: makePlannedQuestion("toxin_exposure_check"),
+      askedQuestionIds: ["gi_vomiting_frequency"],
+      answeredQuestionIds: ["gi_vomiting_frequency"],
+      lookupQuestionCard,
+    });
+
+    expect(result.oldWasGeneric).toBe(false);
+    expect(result.newScreensEmergencyEarlier).toBe(true);
+    expect(result.repeatedQuestionAvoided).toBe(true);
+  });
+
+  it("does not claim repetition avoidance when the planned question was already asked", () => {
+    const result = buildShadowPlannerComparison({
+      existingQuestionId: "gi_vomiting_frequency",
+      plannedQuestion: makePlannedQuestion("toxin_exposure_check"),
+      askedQuestionIds: ["toxin_exposure_check"],
+      lookupQuestionCard,
+    });
+
+    expect(result.repeatedQuestionAvoided).toBe(false);
+  });
+});
+
+describe("shadow telemetry contract scaffold", () => {
+  it("creates an empty telemetry record with no runtime effect", () => {
+    const record = createEmptyShadowTelemetryRecord();
+
+    expect(record.eventName).toBe(SHADOW_TELEMETRY_EVENT_NAME);
+    expect(record.contractVersion).toBe(
+      SHADOW_TELEMETRY_CONTRACT_VERSION
+    );
+    expect(record.ownerFacingImpact).toBe("none");
+    expect(record.activeComplaintModule).toBeNull();
+    expect(record.comparisonReady).toBe(false);
+    expect(record.comparison.plannedQuestionId).toBeNull();
+  });
+
+  it("wraps a comparison result in the telemetry contract without mutating caller arrays", () => {
+    const comparison = buildShadowPlannerComparison({
+      existingQuestionId: "gi_vomiting_frequency",
+      plannedQuestion: makePlannedQuestion("toxin_exposure_check"),
+      lookupQuestionCard,
+      plannerSafetyNotes: ["planner metadata note"],
+    });
+
+    const record = buildShadowTelemetryRecord({
+      activeComplaintModule: "toxin_poisoning_exposure",
+      comparison,
+    });
+
+    expect(record.eventName).toBe(SHADOW_TELEMETRY_EVENT_NAME);
+    expect(record.contractVersion).toBe(
+      SHADOW_TELEMETRY_CONTRACT_VERSION
+    );
+    expect(record.ownerFacingImpact).toBe("none");
+    expect(record.activeComplaintModule).toBe("toxin_poisoning_exposure");
+    expect(record.comparisonReady).toBe(true);
+    expect(record.comparison.plannedQuestionId).toBe("toxin_exposure_check");
+
+    record.comparison.screenedRedFlags.push("mutated");
+    record.comparison.safetyNotes.push("mutated");
+
+    const secondRecord = buildShadowTelemetryRecord({
+      activeComplaintModule: "toxin_poisoning_exposure",
+      comparison,
+    });
+
+    expect(secondRecord.comparison.screenedRedFlags).not.toContain("mutated");
+    expect(secondRecord.comparison.safetyNotes).not.toContain("mutated");
+  });
+});


### PR DESCRIPTION
## Summary
- Add scaffold-only shadow planner comparison helpers and telemetry contract.
- Keep owner-facing impact as `none`; no runtime wiring or production behavior change.
- Add focused tests and implementation notes.

## Scope
- No symptom-chat changes.
- No triage-engine, clinical-matrix, symptom-memory, emergency sentinel, complaint-module, or vet-knowledge runtime wiring changes.
- No RAG or retrieval integration.

## Validation
- `npm test -- --runTestsByPath tests/clinical-intelligence/shadow-planner.test.ts`
- `npm test -- --runTestsByPath tests/clinical-intelligence/next-question-planner.test.ts`
- `npm test -- --runTestsByPath tests/clinical-intelligence/question-card-registry.test.ts`
- `npm run build`