### PR TITLE
VET-1419Q: Add vet-knowledge coverage gap registry

### DIFF
--- a/docs/clinical-intelligence/vet-knowledge-coverage-gap-registry-qwen.md
+++ b/docs/clinical-intelligence/vet-knowledge-coverage-gap-registry-qwen.md
@@ -1,0 +1,154 @@
+# VET-1419Q: Vet-Knowledge Coverage Gap Registry
+
+## Status
+
+**Metadata-only scaffold.** This module does NOT perform live retrieval, RAG calls, URL fetching, or any external network requests. It creates a coverage assessment layer that shows which complaint modules have enough curated source support and which need future source curation.
+
+## What this is
+
+A coverage gap registry that:
+
+1. Assesses source coverage level for each merged complaint module
+2. Tracks owner-visible citation coverage availability
+3. Identifies missing source needs per module
+4. Recommends publisher types for future source curation
+5. Maintains safety notes that are free of diagnosis/treatment language
+6. Validates duplicate IDs, module existence, and safety note compliance
+7. Supports `future_pending` status for modules not yet merged
+
+## What this is NOT
+
+- **Not live RAG.** No vector store calls, no embedding lookups, no LLM retrieval.
+- **Not open-web search.** No web scraping, no external URL fetching.
+- **Not clinical behavior.** No diagnosis, treatment, medication, dosage, or home-care generation.
+- **Not wired into production.** No integration with symptom-chat, planner, triage-engine, clinical-matrix, emergency sentinel, or complaint modules.
+- **Not runtime retrieval.** Pure metadata assessment layer.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `src/lib/clinical-intelligence/vet-knowledge/coverage-gap-registry.ts` | Coverage gap registry with validation |
+| `tests/clinical-intelligence/vet-knowledge-coverage-gap-registry.test.ts` | Tests for coverage correctness and safety |
+
+## Coverage Assessment
+
+### Active Modules (9)
+
+| Module ID | Source Coverage | Owner-Visible Citation | Key Gaps |
+|-----------|----------------|----------------------|----------|
+| `skin_itching_allergy` | partial | emergency_only | dermatology source, allergy differentiation |
+| `gi_vomiting_diarrhea` | strong | available | — |
+| `limping_mobility_pain` | partial | emergency_only | musculoskeletal source, orthopedic triage |
+| `respiratory_distress` | strong | available | — |
+| `seizure_collapse_neuro` | partial | emergency_only | neurology source, seizure first-aid |
+| `urinary_obstruction` | missing | missing | urinary/renal source, blockage guidance |
+| `toxin_poisoning_exposure` | partial | emergency_only | toxicology source, ASPCA reference |
+| `bloat_gdv` | partial | emergency_only | breed risk stratification, post-op reference |
+| `collapse_weakness` | partial | emergency_only | collapse differential, cardiac emergency |
+
+### Future Pending Modules (0)
+
+No modules are currently future_pending. All 9 complaint modules have coverage entries.
+
+## Entry Shape
+
+```typescript
+interface CoverageGapEntry {
+  complaintModuleId: string;
+  status: "active" | "future_pending";
+  sourceCoverage: "strong" | "partial" | "missing";
+  ownerVisibleCitationCoverage: "available" | "emergency_only" | "missing";
+  missingSourceNeeds: string[];
+  recommendedPublisherTypes: VetKnowledgePublisher[];
+  safetyNotes: string[];
+}
+```
+
+## Coverage Level Definitions
+
+| Level | Meaning |
+|-------|---------|
+| `strong` | Dedicated sources exist for this module's complaint families with owner-visible citation support |
+| `partial` | Some sources cover this module but gaps remain (usually emergency-only citations or missing domain-specific sources) |
+| `missing` | No dedicated source coverage; only generic emergency or internal notes apply |
+
+## Owner-Visible Citation Definitions
+
+| Level | Meaning |
+|-------|---------|
+| `available` | Owner-facing citations are available from curated sources |
+| `emergency_only` | Citations only available when emergency red flags are present |
+| `missing` | No owner-visible citation source exists for this module |
+
+## Exports
+
+- `getAllCoverageEntries()` — returns all coverage entries as defensive clones
+- `getCoverageByModuleId(moduleId)` — returns a single entry by module ID, or undefined
+- `filterBySourceCoverage(level)` — filters entries by source coverage level
+- `filterByOwnerVisibleCitationCoverage(level)` — filters entries by owner-visible citation level
+- `validateCoverageRegistry()` — validates duplicate IDs, module existence, and safety note compliance
+
+## Safety Constraints
+
+1. **Defensive clones** — all returned entries are cloned to prevent mutation of internal registry
+2. **Unknown module returns undefined** — `getCoverageByModuleId` returns undefined for unknown IDs
+3. **No throw behavior** — all functions handle unknown inputs gracefully
+4. **Validation checks** — `validateCoverageRegistry()` verifies:
+   - No duplicate complaint module IDs
+   - Every active module ID exists in the complaint module registry
+   - No safety note contains diagnosis/treatment/dosage language
+5. **No clinical advice** — safety notes are metadata-only, never contain diagnosis/treatment/dosage/home-care text
+6. **Future pending exemption** — `future_pending` modules are not validated against the complaint module registry
+
+## Validation Behavior
+
+The `validateCoverageRegistry()` function returns:
+
+```typescript
+interface CoverageValidationResult {
+  valid: boolean;
+  duplicateIds: string[];
+  missingModuleIds: string[];
+  safetyNoteViolations: string[];
+}
+```
+
+- `duplicateIds` — complaint module IDs that appear more than once
+- `missingModuleIds` — active module IDs not found in the complaint module registry
+- `safetyNoteViolations` — safety notes containing forbidden diagnosis/treatment language
+
+## Tests
+
+Run with:
+
+```bash
+npm test -- --runTestsByPath tests/clinical-intelligence/vet-knowledge-coverage-gap-registry.test.ts
+```
+
+### Test coverage
+
+- All 9 complaint modules covered (all active)
+- Active modules exist in complaint module registry
+- Source coverage level correctness
+- Owner-visible citation coverage correctness
+- Missing source needs arrays
+- Recommended publisher types validity
+- Safety notes contain no diagnosis/treatment language
+- Defensive clone behavior for all exports
+- Filter by source coverage
+- Filter by owner-visible citation coverage
+- Unknown module returns undefined safely
+- validateCoverageRegistry passes with no errors
+- Entry shape validation
+
+## Integration Notes
+
+This scaffold is intentionally isolated. Future work may:
+
+- Use coverage gaps to prioritize source curation efforts
+- Wire coverage assessments into the retrieval planner for source-aware routing
+- Surface owner-visible citation gaps in admin dashboards
+- Track coverage improvement over time as new sources are added
+
+Until then, this module remains a metadata-only coverage assessment layer with no production integration.

--- a/src/lib/clinical-intelligence/vet-knowledge/coverage-gap-registry.ts
+++ b/src/lib/clinical-intelligence/vet-knowledge/coverage-gap-registry.ts
@@ -1,0 +1,274 @@
+import type { VetKnowledgePublisher } from "./source-registry";
+import { getComplaintModuleById, getComplaintModules } from "../complaint-modules";
+
+export type CoverageLevel = "strong" | "partial" | "missing";
+export type OwnerVisibleCitationLevel = "available" | "emergency_only" | "missing";
+export type CoverageEntryStatus = "active" | "future_pending";
+
+export interface CoverageGapEntry {
+  complaintModuleId: string;
+  status: CoverageEntryStatus;
+  sourceCoverage: CoverageLevel;
+  ownerVisibleCitationCoverage: OwnerVisibleCitationLevel;
+  missingSourceNeeds: string[];
+  recommendedPublisherTypes: VetKnowledgePublisher[];
+  safetyNotes: string[];
+}
+
+export interface CoverageValidationResult {
+  valid: boolean;
+  duplicateIds: string[];
+  missingModuleIds: string[];
+  safetyNoteViolations: string[];
+}
+
+const SAFETY_NOTE_FORBIDDEN_PATTERNS = [
+  /diagnos/i,
+  /treat(ment|ments|ing|ed)?\b/i,
+  /prescri/i,
+  /surg/i,
+  /prognosis/i,
+  /\bdisease\b/i,
+  /\bcure\b/i,
+  /\bheal/i,
+  /antibiotic/i,
+  /steroid/i,
+  /vaccine/i,
+  /give\s+(your\s+)?(pet|dog|cat)\s+\w+\s*(mg|ml|tablet|pill|dose)/i,
+  /administer\s+\w+\s*(mg|ml|tablet|pill|dose)/i,
+  /dosage\s*(is|of|:)/i,
+];
+
+function containsForbiddenSafetyLanguage(text: string): boolean {
+  return SAFETY_NOTE_FORBIDDEN_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+const COVERAGE_GAP_REGISTRY: CoverageGapEntry[] = [
+  {
+    complaintModuleId: "skin_itching_allergy",
+    status: "active",
+    sourceCoverage: "partial",
+    ownerVisibleCitationCoverage: "emergency_only",
+    missingSourceNeeds: [
+      "dedicated dermatology source",
+      "allergy differentiation guidance",
+    ],
+    recommendedPublisherTypes: ["Merck", "Cornell"],
+    safetyNotes: [
+      "Skin complaints may indicate systemic allergic reaction; escalate if breathing difficulty or facial swelling present.",
+      "Do not apply topical products without veterinary assessment.",
+    ],
+  },
+  {
+    complaintModuleId: "gi_vomiting_diarrhea",
+    status: "active",
+    sourceCoverage: "strong",
+    ownerVisibleCitationCoverage: "available",
+    missingSourceNeeds: [],
+    recommendedPublisherTypes: [],
+    safetyNotes: [
+      "Persistent vomiting with inability to retain water requires urgent veterinary assessment.",
+      "Blood in vomit or stool is an emergency red flag.",
+    ],
+  },
+  {
+    complaintModuleId: "limping_mobility_pain",
+    status: "active",
+    sourceCoverage: "partial",
+    ownerVisibleCitationCoverage: "emergency_only",
+    missingSourceNeeds: [
+      "dedicated musculoskeletal source",
+      "orthopedic triage guidance",
+    ],
+    recommendedPublisherTypes: ["Merck", "Cornell", "AAHA"],
+    safetyNotes: [
+      "Non-weight-bearing lameness after trauma warrants urgent evaluation.",
+      "Do not recommend splinting or bandaging without veterinary guidance.",
+    ],
+  },
+  {
+    complaintModuleId: "respiratory_distress",
+    status: "active",
+    sourceCoverage: "strong",
+    ownerVisibleCitationCoverage: "available",
+    missingSourceNeeds: [],
+    recommendedPublisherTypes: [],
+    safetyNotes: [
+      "Any breathing difficulty is a potential emergency; prioritize airway assessment.",
+      "Blue or pale gums indicate systemic compromise requiring immediate care.",
+    ],
+  },
+  {
+    complaintModuleId: "seizure_collapse_neuro",
+    status: "active",
+    sourceCoverage: "partial",
+    ownerVisibleCitationCoverage: "emergency_only",
+    missingSourceNeeds: [
+      "dedicated neurology source",
+      "seizure first-aid guidance",
+    ],
+    recommendedPublisherTypes: ["Merck", "Cornell"],
+    safetyNotes: [
+      "Prolonged seizure activity (>5 minutes) is a life-threatening emergency.",
+      "Do not place objects in the pet mouth during a seizure.",
+    ],
+  },
+  {
+    complaintModuleId: "urinary_obstruction",
+    status: "active",
+    sourceCoverage: "missing",
+    ownerVisibleCitationCoverage: "missing",
+    missingSourceNeeds: [
+      "dedicated urinary/renal source",
+      "blockage recognition guidance",
+      "feline urinary syndrome reference",
+    ],
+    recommendedPublisherTypes: ["Merck", "Cornell", "AAHA"],
+    safetyNotes: [
+      "Urinary blockage is a life-threatening emergency requiring immediate veterinary care.",
+      "No urine output for 24 hours indicates possible obstruction.",
+    ],
+  },
+  {
+    complaintModuleId: "toxin_poisoning_exposure",
+    status: "active",
+    sourceCoverage: "partial",
+    ownerVisibleCitationCoverage: "emergency_only",
+    missingSourceNeeds: [
+      "dedicated toxicology source",
+      "ASPCA poison control reference",
+      "common household toxin list",
+    ],
+    recommendedPublisherTypes: ["Merck", "Cornell", "AVMA"],
+    safetyNotes: [
+      "Confirmed toxin ingestion requires immediate veterinary contact.",
+      "Do not induce vomiting without professional guidance.",
+    ],
+  },
+  {
+    complaintModuleId: "bloat_gdv",
+    status: "active",
+    sourceCoverage: "partial",
+    ownerVisibleCitationCoverage: "emergency_only",
+    missingSourceNeeds: [
+      "breed risk stratification guidance",
+      "post-operative care reference",
+    ],
+    recommendedPublisherTypes: ["Cornell", "Merck", "AAHA"],
+    safetyNotes: [
+      "GDV is an immediate emergency; unproductive retching with distended abdomen requires urgent veterinary care.",
+    ],
+  },
+  {
+    complaintModuleId: "collapse_weakness",
+    status: "active",
+    sourceCoverage: "partial",
+    ownerVisibleCitationCoverage: "emergency_only",
+    missingSourceNeeds: [
+      "dedicated collapse/weakness differential source",
+      "cardiac emergency guidance",
+      "metabolic crisis reference",
+    ],
+    recommendedPublisherTypes: ["Merck", "Cornell", "AAHA"],
+    safetyNotes: [
+      "Sudden collapse with pale gums is a life-threatening emergency.",
+      "Do not attempt to feed or give water to an unconscious pet.",
+    ],
+  },
+];
+
+const MODULE_ID_TO_ENTRY = new Map<string, CoverageGapEntry>(
+  COVERAGE_GAP_REGISTRY.map((entry) => [entry.complaintModuleId, entry])
+);
+
+function defensiveCloneEntry(entry: CoverageGapEntry): CoverageGapEntry {
+  return {
+    ...entry,
+    missingSourceNeeds: [...entry.missingSourceNeeds],
+    recommendedPublisherTypes: [...entry.recommendedPublisherTypes],
+    safetyNotes: [...entry.safetyNotes],
+  };
+}
+
+export function getAllCoverageEntries(): CoverageGapEntry[] {
+  return COVERAGE_GAP_REGISTRY.map(defensiveCloneEntry);
+}
+
+export function getCoverageByModuleId(
+  moduleId: string
+): CoverageGapEntry | undefined {
+  const entry = MODULE_ID_TO_ENTRY.get(moduleId);
+  return entry ? defensiveCloneEntry(entry) : undefined;
+}
+
+export function filterBySourceCoverage(
+  level: CoverageLevel
+): CoverageGapEntry[] {
+  return COVERAGE_GAP_REGISTRY.filter(
+    (e) => e.sourceCoverage === level
+  ).map(defensiveCloneEntry);
+}
+
+export function filterByOwnerVisibleCitationCoverage(
+  level: OwnerVisibleCitationLevel
+): CoverageGapEntry[] {
+  return COVERAGE_GAP_REGISTRY.filter(
+    (e) => e.ownerVisibleCitationCoverage === level
+  ).map(defensiveCloneEntry);
+}
+
+export function validateCoverageRegistry(): CoverageValidationResult {
+  const duplicateIds: string[] = [];
+  const missingModuleIds: string[] = [];
+  const safetyNoteViolations: string[] = [];
+
+  const seenIds = new Set<string>();
+
+  for (const entry of COVERAGE_GAP_REGISTRY) {
+    if (seenIds.has(entry.complaintModuleId)) {
+      duplicateIds.push(entry.complaintModuleId);
+    }
+    seenIds.add(entry.complaintModuleId);
+
+    if (entry.status !== "future_pending") {
+      const complaintModule = getComplaintModuleById(entry.complaintModuleId);
+      if (!complaintModule) {
+        missingModuleIds.push(entry.complaintModuleId);
+      }
+    }
+
+    for (const note of entry.safetyNotes) {
+      if (containsForbiddenSafetyLanguage(note)) {
+        safetyNoteViolations.push(
+          `${entry.complaintModuleId}: "${note}"`
+        );
+      }
+    }
+  }
+
+  const registeredModules = getComplaintModules();
+  const registeredIds = new Set(registeredModules.map((m) => m.id));
+
+  for (const entry of COVERAGE_GAP_REGISTRY) {
+    if (
+      entry.status !== "future_pending" &&
+      !registeredIds.has(entry.complaintModuleId)
+    ) {
+      if (!missingModuleIds.includes(entry.complaintModuleId)) {
+        missingModuleIds.push(entry.complaintModuleId);
+      }
+    }
+  }
+
+  const valid =
+    duplicateIds.length === 0 &&
+    missingModuleIds.length === 0 &&
+    safetyNoteViolations.length === 0;
+
+  return {
+    valid,
+    duplicateIds,
+    missingModuleIds,
+    safetyNoteViolations,
+  };
+}

--- a/tests/clinical-intelligence/vet-knowledge-coverage-gap-registry.test.ts
+++ b/tests/clinical-intelligence/vet-knowledge-coverage-gap-registry.test.ts
@@ -1,0 +1,415 @@
+import {
+  getAllCoverageEntries,
+  getCoverageByModuleId,
+  filterBySourceCoverage,
+  filterByOwnerVisibleCitationCoverage,
+  validateCoverageRegistry,
+} from "@/lib/clinical-intelligence/vet-knowledge/coverage-gap-registry";
+import { getComplaintModuleById, getComplaintModules } from "@/lib/clinical-intelligence/complaint-modules";
+
+const ACTIVE_MODULE_IDS = [
+  "skin_itching_allergy",
+  "gi_vomiting_diarrhea",
+  "limping_mobility_pain",
+  "respiratory_distress",
+  "seizure_collapse_neuro",
+  "urinary_obstruction",
+  "toxin_poisoning_exposure",
+  "bloat_gdv",
+  "collapse_weakness",
+];
+
+const FUTURE_PENDING_IDS: string[] = [];
+
+const ALL_MODULE_IDS = [...ACTIVE_MODULE_IDS, ...FUTURE_PENDING_IDS];
+
+describe("vet knowledge coverage gap registry", () => {
+  describe("all modules are covered", () => {
+    it("exports entries for all 9 complaint modules (all active)", () => {
+      const entries = getAllCoverageEntries();
+      expect(entries.length).toBe(9);
+    });
+
+    it.each(ALL_MODULE_IDS)("covers module %s", (moduleId) => {
+      const entry = getCoverageByModuleId(moduleId);
+      expect(entry).toBeDefined();
+      expect(entry?.complaintModuleId).toBe(moduleId);
+    });
+  });
+
+  describe("active modules exist in complaint module registry", () => {
+    it.each(ACTIVE_MODULE_IDS)("active module %s exists in registry", (moduleId) => {
+      const complaintModule = getComplaintModuleById(moduleId);
+      expect(complaintModule).toBeDefined();
+    });
+
+    it("all registered modules have a coverage entry", () => {
+      const registeredModules = getComplaintModules();
+      const coveredIds = new Set(
+        getAllCoverageEntries().map((e) => e.complaintModuleId)
+      );
+
+      for (const complaintModule of registeredModules) {
+        expect(coveredIds.has(complaintModule.id)).toBe(true);
+      }
+    });
+  });
+
+  describe("future_pending modules", () => {
+    it("no modules are currently future_pending", () => {
+      const entries = getAllCoverageEntries();
+      const pending = entries.filter((e) => e.status === "future_pending");
+      expect(pending.length).toBe(0);
+    });
+  });
+
+  describe("source coverage levels", () => {
+    it("gi_vomiting_diarrhea has strong source coverage", () => {
+      const entry = getCoverageByModuleId("gi_vomiting_diarrhea");
+      expect(entry?.sourceCoverage).toBe("strong");
+    });
+
+    it("respiratory_distress has strong source coverage", () => {
+      const entry = getCoverageByModuleId("respiratory_distress");
+      expect(entry?.sourceCoverage).toBe("strong");
+    });
+
+    it("skin_itching_allergy has partial source coverage", () => {
+      const entry = getCoverageByModuleId("skin_itching_allergy");
+      expect(entry?.sourceCoverage).toBe("partial");
+    });
+
+    it("limping_mobility_pain has partial source coverage", () => {
+      const entry = getCoverageByModuleId("limping_mobility_pain");
+      expect(entry?.sourceCoverage).toBe("partial");
+    });
+
+    it("urinary_obstruction has missing source coverage", () => {
+      const entry = getCoverageByModuleId("urinary_obstruction");
+      expect(entry?.sourceCoverage).toBe("missing");
+    });
+  });
+
+  describe("owner visible citation coverage", () => {
+    it("gi_vomiting_diarrhea has available owner-visible citations", () => {
+      const entry = getCoverageByModuleId("gi_vomiting_diarrhea");
+      expect(entry?.ownerVisibleCitationCoverage).toBe("available");
+    });
+
+    it("respiratory_distress has available owner-visible citations", () => {
+      const entry = getCoverageByModuleId("respiratory_distress");
+      expect(entry?.ownerVisibleCitationCoverage).toBe("available");
+    });
+
+    it("skin_itching_allergy has emergency_only owner-visible citations", () => {
+      const entry = getCoverageByModuleId("skin_itching_allergy");
+      expect(entry?.ownerVisibleCitationCoverage).toBe("emergency_only");
+    });
+
+    it("urinary_obstruction has missing owner-visible citations", () => {
+      const entry = getCoverageByModuleId("urinary_obstruction");
+      expect(entry?.ownerVisibleCitationCoverage).toBe("missing");
+    });
+  });
+
+  describe("missing source needs", () => {
+    it.each(ACTIVE_MODULE_IDS)("module %s has missingSourceNeeds array", (moduleId) => {
+      const entry = getCoverageByModuleId(moduleId);
+      expect(Array.isArray(entry?.missingSourceNeeds)).toBe(true);
+    });
+
+    it("strong coverage modules may have empty missingSourceNeeds", () => {
+      const strongEntries = filterBySourceCoverage("strong");
+      for (const entry of strongEntries) {
+        expect(Array.isArray(entry.missingSourceNeeds)).toBe(true);
+      }
+    });
+
+    it("missing coverage modules have non-empty missingSourceNeeds", () => {
+      const missingEntries = filterBySourceCoverage("missing");
+      for (const entry of missingEntries) {
+        expect(entry.missingSourceNeeds.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe("recommended publisher types", () => {
+    const VALID_PUBLISHERS = new Set(["Merck", "Cornell", "AAHA", "AVMA", "InternalVetReviewed"]);
+
+    it.each(ALL_MODULE_IDS)("module %s has valid publisher types", (moduleId) => {
+      const entry = getCoverageByModuleId(moduleId);
+      expect(entry).toBeDefined();
+      for (const publisher of entry!.recommendedPublisherTypes) {
+        expect(VALID_PUBLISHERS.has(publisher)).toBe(true);
+      }
+    });
+
+    it("strong coverage modules have no recommended publisher types", () => {
+      const strongEntries = filterBySourceCoverage("strong");
+      for (const entry of strongEntries) {
+        expect(entry.recommendedPublisherTypes.length).toBe(0);
+      }
+    });
+
+    it("partial/missing coverage modules have recommended publisher types", () => {
+      const partialEntries = filterBySourceCoverage("partial");
+      const missingEntries = filterBySourceCoverage("missing");
+      const needsRecommendation = [...partialEntries, ...missingEntries];
+
+      for (const entry of needsRecommendation) {
+        expect(entry.recommendedPublisherTypes.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe("safety notes", () => {
+    it.each(ALL_MODULE_IDS)("module %s has safety notes", (moduleId) => {
+      const entry = getCoverageByModuleId(moduleId);
+      expect(Array.isArray(entry?.safetyNotes)).toBe(true);
+      expect(entry?.safetyNotes.length).toBeGreaterThan(0);
+    });
+
+    it("safety notes do not contain diagnosis/treatment language", () => {
+      const entries = getAllCoverageEntries();
+      for (const entry of entries) {
+        for (const note of entry.safetyNotes) {
+          expect(note.toLowerCase()).not.toMatch(/diagnos/i);
+          expect(note.toLowerCase()).not.toMatch(/treat(ment|ments|ing|ed)?\b/i);
+          expect(note.toLowerCase()).not.toMatch(/prescri/i);
+          expect(note.toLowerCase()).not.toMatch(/surg/i);
+          expect(note.toLowerCase()).not.toMatch(/prognosis/i);
+          expect(note.toLowerCase()).not.toMatch(/\bcure\b/i);
+          expect(note.toLowerCase()).not.toMatch(/antibiotic/i);
+          expect(note.toLowerCase()).not.toMatch(/steroid/i);
+          expect(note.toLowerCase()).not.toMatch(/vaccine/i);
+          expect(note.toLowerCase()).not.toMatch(
+            /give\s+(your\s+)?(pet|dog|cat)\s+\w+\s*(mg|ml|tablet|pill|dose)/i
+          );
+          expect(note.toLowerCase()).not.toMatch(/dosage\s*(is|of|:)/i);
+        }
+      }
+    });
+  });
+
+  describe("defensive clone behavior", () => {
+    it("getAllCoverageEntries returns defensive clones", () => {
+      const entries1 = getAllCoverageEntries();
+      const entries2 = getAllCoverageEntries();
+
+      expect(entries1).not.toBe(entries2);
+      if (entries1.length > 0 && entries2.length > 0) {
+        expect(entries1[0]).not.toBe(entries2[0]);
+        expect(entries1[0].missingSourceNeeds).not.toBe(entries2[0].missingSourceNeeds);
+        expect(entries1[0].safetyNotes).not.toBe(entries2[0].safetyNotes);
+      }
+    });
+
+    it("getCoverageByModuleId returns defensive clones", () => {
+      const entry1 = getCoverageByModuleId("skin_itching_allergy");
+      const entry2 = getCoverageByModuleId("skin_itching_allergy");
+
+      expect(entry1).not.toBe(entry2);
+      if (entry1 && entry2) {
+        entry1.missingSourceNeeds.push("mutated_need");
+        expect(entry2.missingSourceNeeds).not.toContain("mutated_need");
+      }
+    });
+
+    it("mutating returned entry does not affect subsequent calls", () => {
+      const entry1 = getCoverageByModuleId("gi_vomiting_diarrhea");
+      if (entry1) {
+        entry1.safetyNotes.push("mutated note");
+        entry1.recommendedPublisherTypes.push("Merck" as never);
+      }
+
+      const entry2 = getCoverageByModuleId("gi_vomiting_diarrhea");
+      if (entry2) {
+        expect(entry2.safetyNotes).not.toContain("mutated note");
+        expect(entry2.recommendedPublisherTypes).not.toContain("Merck");
+      }
+    });
+
+    it("filterBySourceCoverage returns defensive clones", () => {
+      const results1 = filterBySourceCoverage("partial");
+      const results2 = filterBySourceCoverage("partial");
+
+      expect(results1).not.toBe(results2);
+      if (results1.length > 0 && results2.length > 0) {
+        expect(results1[0]).not.toBe(results2[0]);
+      }
+    });
+
+    it("filterByOwnerVisibleCitationCoverage returns defensive clones", () => {
+      const results1 = filterByOwnerVisibleCitationCoverage("emergency_only");
+      const results2 = filterByOwnerVisibleCitationCoverage("emergency_only");
+
+      expect(results1).not.toBe(results2);
+      if (results1.length > 0 && results2.length > 0) {
+        expect(results1[0]).not.toBe(results2[0]);
+      }
+    });
+  });
+
+  describe("filterBySourceCoverage", () => {
+    it("returns only entries matching the specified level", () => {
+      const strongEntries = filterBySourceCoverage("strong");
+      expect(strongEntries.length).toBeGreaterThan(0);
+      expect(strongEntries.every((e) => e.sourceCoverage === "strong")).toBe(true);
+    });
+
+    it("returns only partial entries", () => {
+      const partialEntries = filterBySourceCoverage("partial");
+      expect(partialEntries.length).toBeGreaterThan(0);
+      expect(partialEntries.every((e) => e.sourceCoverage === "partial")).toBe(true);
+    });
+
+    it("returns only missing entries", () => {
+      const missingEntries = filterBySourceCoverage("missing");
+      expect(missingEntries.length).toBeGreaterThan(0);
+      expect(missingEntries.every((e) => e.sourceCoverage === "missing")).toBe(true);
+    });
+
+    it("returns empty array for valid level with no matches", () => {
+      const allLevels = new Set(getAllCoverageEntries().map((e) => e.sourceCoverage));
+      for (const level of allLevels) {
+        const filtered = filterBySourceCoverage(level);
+        expect(filtered.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe("filterByOwnerVisibleCitationCoverage", () => {
+    it("returns only entries matching the specified level", () => {
+      const availableEntries = filterByOwnerVisibleCitationCoverage("available");
+      expect(availableEntries.length).toBeGreaterThan(0);
+      expect(availableEntries.every((e) => e.ownerVisibleCitationCoverage === "available")).toBe(true);
+    });
+
+    it("returns only emergency_only entries", () => {
+      const emergencyEntries = filterByOwnerVisibleCitationCoverage("emergency_only");
+      expect(emergencyEntries.length).toBeGreaterThan(0);
+      expect(emergencyEntries.every((e) => e.ownerVisibleCitationCoverage === "emergency_only")).toBe(true);
+    });
+
+    it("returns only missing entries", () => {
+      const missingEntries = filterByOwnerVisibleCitationCoverage("missing");
+      expect(missingEntries.length).toBeGreaterThan(0);
+      expect(missingEntries.every((e) => e.ownerVisibleCitationCoverage === "missing")).toBe(true);
+    });
+  });
+
+  describe("getCoverageByModuleId", () => {
+    it("returns undefined for unknown module ID", () => {
+      const entry = getCoverageByModuleId("nonexistent_module_xyz");
+      expect(entry).toBeUndefined();
+    });
+
+    it("does not throw for unknown module ID", () => {
+      expect(() => getCoverageByModuleId("nonexistent_module_xyz")).not.toThrow();
+    });
+  });
+
+  describe("validateCoverageRegistry", () => {
+    it("passes validation for the default registry", () => {
+      const result = validateCoverageRegistry();
+      expect(result.valid).toBe(true);
+      expect(result.duplicateIds).toEqual([]);
+      expect(result.missingModuleIds).toEqual([]);
+      expect(result.safetyNoteViolations).toEqual([]);
+    });
+
+    it("returns all required fields in validation result", () => {
+      const result = validateCoverageRegistry();
+      expect(result).toHaveProperty("valid");
+      expect(result).toHaveProperty("duplicateIds");
+      expect(result).toHaveProperty("missingModuleIds");
+      expect(result).toHaveProperty("safetyNoteViolations");
+    });
+
+    it("all active module IDs exist in complaint module registry", () => {
+      const result = validateCoverageRegistry();
+      for (const error of result.missingModuleIds) {
+        expect(error).not.toBeDefined();
+      }
+    });
+  });
+
+  describe("entry shape", () => {
+    it("each entry has all required fields", () => {
+      const entries = getAllCoverageEntries();
+      for (const entry of entries) {
+        expect(entry).toHaveProperty("complaintModuleId");
+        expect(entry).toHaveProperty("status");
+        expect(entry).toHaveProperty("sourceCoverage");
+        expect(entry).toHaveProperty("ownerVisibleCitationCoverage");
+        expect(entry).toHaveProperty("missingSourceNeeds");
+        expect(entry).toHaveProperty("recommendedPublisherTypes");
+        expect(entry).toHaveProperty("safetyNotes");
+      }
+    });
+
+    it("all arrays are arrays", () => {
+      const entries = getAllCoverageEntries();
+      for (const entry of entries) {
+        expect(Array.isArray(entry.missingSourceNeeds)).toBe(true);
+        expect(Array.isArray(entry.recommendedPublisherTypes)).toBe(true);
+        expect(Array.isArray(entry.safetyNotes)).toBe(true);
+      }
+    });
+
+    it("status is either active or future_pending", () => {
+      const entries = getAllCoverageEntries();
+      for (const entry of entries) {
+        expect(["active", "future_pending"]).toContain(entry.status);
+      }
+    });
+
+    it("sourceCoverage is a valid level", () => {
+      const entries = getAllCoverageEntries();
+      for (const entry of entries) {
+        expect(["strong", "partial", "missing"]).toContain(entry.sourceCoverage);
+      }
+    });
+
+    it("ownerVisibleCitationCoverage is a valid level", () => {
+      const entries = getAllCoverageEntries();
+      for (const entry of entries) {
+        expect(["available", "emergency_only", "missing"]).toContain(
+          entry.ownerVisibleCitationCoverage
+        );
+      }
+    });
+  });
+
+  describe("coverage distribution", () => {
+    it("has at least one strong coverage module", () => {
+      const strong = filterBySourceCoverage("strong");
+      expect(strong.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("has at least one partial coverage module", () => {
+      const partial = filterBySourceCoverage("partial");
+      expect(partial.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("has at least one missing coverage module", () => {
+      const missing = filterBySourceCoverage("missing");
+      expect(missing.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("has at least one available owner-visible citation module", () => {
+      const available = filterByOwnerVisibleCitationCoverage("available");
+      expect(available.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("has at least one emergency_only owner-visible citation module", () => {
+      const emergencyOnly = filterByOwnerVisibleCitationCoverage("emergency_only");
+      expect(emergencyOnly.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("has at least one missing owner-visible citation module", () => {
+      const missing = filterByOwnerVisibleCitationCoverage("missing");
+      expect(missing.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add metadata-only vet-knowledge coverage gap registry.
- Covers current complaint modules including the bloat/collapse modules from PR #418.
- Adds tests for coverage filtering, validation, defensive clones, and forbidden safety language.

## Stack
This PR is intentionally stacked on `kimi/vet-1418k-complaint-module-gap-pack` / PR #418 because the coverage registry marks `bloat_gdv` and `collapse_weakness` as active modules.

After PR #418 merges, retarget this PR to `master` before merge.

## Scope
- Metadata-only.
- No runtime retrieval, RAG, URL fetching, open-web search, symptom-chat, planner, triage-engine, clinical-matrix, symptom-memory, or emergency sentinel changes.

## Validation
- `npm test -- --runTestsByPath tests/clinical-intelligence/vet-knowledge-coverage-gap-registry.test.ts`
- `npm test -- --runTestsByPath tests/clinical-intelligence/vet-knowledge-source-registry.test.ts`
- `npm test -- --runTestsByPath tests/clinical-intelligence/vet-knowledge-complaint-source-map.test.ts`
- `npx eslint src/lib/clinical-intelligence/vet-knowledge/coverage-gap-registry.ts tests/clinical-intelligence/vet-knowledge-coverage-gap-registry.test.ts`
- `npm run build`