### PR TITLE
VET-1441K — Shadow Planner Scenario Outcome Pack

### DIFF
--- a/docs/clinical-intelligence/shadow-planner-outcome-pack-kimi.md
+++ b/docs/clinical-intelligence/shadow-planner-outcome-pack-kimi.md
@@ -1,0 +1,98 @@
+# VET-1441K Shadow Planner Scenario Outcome Pack
+
+## Scope
+
+This package adds fixture, test, and documentation coverage only:
+
+- `tests/fixtures/clinical-intelligence/shadow-planner-expected-outcomes.json`
+- `tests/clinical-intelligence/shadow-planner-outcome-pack.test.ts`
+- `docs/clinical-intelligence/shadow-planner-outcome-pack-kimi.md`
+
+It does not change planner logic, adapter logic, question cards, complaint modules, runtime routes, UI, infrastructure, or workflow files.
+
+## Purpose
+
+The outcome pack turns the merged `shadow-planner-scenarios.json` fixture into a stable comparison target for future old-vs-shadow planner evaluation work. The pack keeps expected outcomes out of runtime code so later Codex integration can score behavior without inventing expectations inside the planner path.
+
+Each outcome row records:
+
+- expected complaint module ID
+- acceptable planned question IDs
+- acceptable `selectedBecause` values for the first-turn comparison
+- red flags that must stay visible to the comparison
+- whether the shadow choice should beat a generic question
+- whether the shadow choice should screen an emergency earlier
+- whether the shadow choice should avoid a repeated question
+- evaluator notes describing emergency status or acceptable ambiguity
+
+## Outcome Rules
+
+The pack is intentionally derived from the merged scenario fixture:
+
+- `caseId` matches one scenario row exactly
+- `expectedComplaintModuleId` matches the scenario module expectation
+- `acceptablePlannedQuestionIds` mirrors the scenario’s acceptable first-question set
+- `mustScreenRedFlags` mirrors the scenario’s must-screen red flags
+- `shouldBeatGenericQuestion` mirrors `shouldAvoidGenericQuestion`
+- `shouldScreenEmergencyEarlier` mirrors `shouldPreferEmergencyScreen`
+- `shouldAvoidRepeatedQuestion` is always `true` because repeat avoidance is a universal expectation for the shadow comparison layer
+
+`expectedSelectedBecause` is limited to first-turn comparison outcomes:
+
+- `emergency_screen` when at least one acceptable planned question is an emergency-screen card
+- `highest_information_gain` when at least one acceptable planned question is a non-emergency card
+
+This pack intentionally does not expect `clarification`, `urgency_changing`, or `report_value` because these scenarios are packaged as first-turn comparison cases, not repeat, worsening-trajectory, or report-completion cases.
+
+## Coverage Summary
+
+The fixture contains one row for every merged scenario case and represents:
+
+- heat
+- trauma
+- urinary
+- bloat
+- respiratory
+- collapse
+- seizure
+- toxin
+- GI
+- skin
+- limping
+
+Emergency or must-not-miss rows are marked two ways:
+
+- `shouldScreenEmergencyEarlier = true`
+- notes prefixed with `Emergency or must-not-miss:`
+
+Confusing multi-symptom rows add:
+
+- `Acceptable ambiguity: ...`
+
+This keeps clinically reasonable module overlap visible without forcing a single rigid first question in confuser cases.
+
+## Guardrails
+
+The test guard verifies that:
+
+- the pack stays 1:1 with `shadow-planner-scenarios.json`
+- every referenced module exists in the complaint-module registry
+- every referenced planned question exists in the question-card registry
+- `expectedSelectedBecause` stays aligned to real question-card reachability
+- emergency rows still have reachable emergency-screen cards
+- confusing multi-symptom rows remain explicitly marked for acceptable ambiguity
+- evaluator notes stay free of diagnosis or treatment claims
+
+## Intended Evaluation Use
+
+A future comparison runner can score old planner output versus shadow planner output against this pack by checking:
+
+- selected module against `expectedComplaintModuleId`
+- planned question against `acceptablePlannedQuestionIds`
+- `selectedBecause` against `expectedSelectedBecause`
+- screened red flags against `mustScreenRedFlags`
+- generic-question avoidance against `shouldBeatGenericQuestion`
+- emergency-earlier behavior against `shouldScreenEmergencyEarlier`
+- repeat avoidance against `shouldAvoidRepeatedQuestion`
+
+The pack is a scoring artifact only. It does not change owner-facing behavior and it does not authorize planner runtime edits.

--- a/tests/clinical-intelligence/shadow-planner-outcome-pack.test.ts
+++ b/tests/clinical-intelligence/shadow-planner-outcome-pack.test.ts
@@ -1,0 +1,264 @@
+import outcomes from "../fixtures/clinical-intelligence/shadow-planner-expected-outcomes.json";
+import scenarios from "../fixtures/clinical-intelligence/shadow-planner-scenarios.json";
+
+import type { SelectedBecause } from "@/lib/clinical-intelligence/next-question-planner";
+import { getComplaintModules } from "@/lib/clinical-intelligence/complaint-modules";
+import {
+  getAllQuestionCards,
+  getQuestionCardById,
+} from "@/lib/clinical-intelligence/question-card-registry";
+
+type ShadowPlannerScenario = {
+  caseId: string;
+  ownerText: string;
+  expectedComplaintModuleId: string;
+  acceptableFirstQuestionIds: string[];
+  mustScreenRedFlags: string[];
+  whyThisCaseMatters: string;
+  shouldPreferEmergencyScreen: boolean;
+  shouldAvoidGenericQuestion: boolean;
+  isConfusingMultiSymptom: boolean;
+};
+
+type ShadowPlannerExpectedOutcome = {
+  caseId: string;
+  expectedComplaintModuleId: string;
+  acceptablePlannedQuestionIds: string[];
+  expectedSelectedBecause: SelectedBecause[];
+  mustScreenRedFlags: string[];
+  shouldBeatGenericQuestion: boolean;
+  shouldScreenEmergencyEarlier: boolean;
+  shouldAvoidRepeatedQuestion: boolean;
+  notes: string;
+};
+
+const REQUIRED_MODULE_IDS = [
+  "heatstroke_heat_exposure",
+  "trauma_bleeding_wound",
+  "urinary_obstruction",
+  "bloat_gdv",
+  "respiratory_distress",
+  "collapse_weakness",
+  "seizure_collapse_neuro",
+  "toxin_poisoning_exposure",
+  "gi_vomiting_diarrhea",
+  "skin_itching_allergy",
+  "limping_mobility_pain",
+] as const;
+
+const REQUIRED_OUTCOME_KEYS = [
+  "acceptablePlannedQuestionIds",
+  "caseId",
+  "expectedComplaintModuleId",
+  "expectedSelectedBecause",
+  "mustScreenRedFlags",
+  "notes",
+  "shouldAvoidRepeatedQuestion",
+  "shouldBeatGenericQuestion",
+  "shouldScreenEmergencyEarlier",
+].sort();
+
+const VALID_SELECTED_BECAUSE: readonly SelectedBecause[] = [
+  "emergency_screen",
+  "highest_information_gain",
+  "urgency_changing",
+  "report_value",
+  "clarification",
+];
+
+const OWNER_FACING_CLAIM_PATTERNS = [
+  /\bdiagnos(?:e|is|ed|ing)\b/i,
+  /\btreat(?:ment|ed|ing|s)?\b/i,
+  /\bcure(?:d|s)?\b/i,
+  /\bprescri(?:be|bed|ption)\b/i,
+  /\bantibiotic\b/i,
+  /\bsteroid\b/i,
+  /\bsurgery\b/i,
+  /\bdos(?:e|age)\b/i,
+];
+
+const fixture = outcomes as ShadowPlannerExpectedOutcome[];
+const scenarioFixture = scenarios as ShadowPlannerScenario[];
+
+function countByModule(
+  rows: readonly Pick<ShadowPlannerExpectedOutcome, "expectedComplaintModuleId">[]
+) {
+  const counts = new Map<string, number>();
+  for (const row of rows) {
+    counts.set(
+      row.expectedComplaintModuleId,
+      (counts.get(row.expectedComplaintModuleId) ?? 0) + 1
+    );
+  }
+  return counts;
+}
+
+function getScenarioByCaseId(caseId: string): ShadowPlannerScenario {
+  const scenario = scenarioFixture.find((item) => item.caseId === caseId);
+  if (!scenario) {
+    throw new Error(`Missing shadow-planner scenario for ${caseId}`);
+  }
+  return scenario;
+}
+
+function deriveExpectedSelectedBecause(
+  questionIds: readonly string[]
+): SelectedBecause[] {
+  const cards = questionIds.map((id) => {
+    const card = getQuestionCardById(id);
+    if (!card) {
+      throw new Error(`Missing question card ${id}`);
+    }
+    return card;
+  });
+
+  const values: SelectedBecause[] = [];
+
+  if (cards.some((card) => card.phase === "emergency_screen")) {
+    values.push("emergency_screen");
+  }
+
+  if (cards.some((card) => card.phase !== "emergency_screen")) {
+    values.push("highest_information_gain");
+  }
+
+  return values;
+}
+
+describe("shadow planner outcome pack", () => {
+  it("packages one expected outcome row for every merged shadow-planner scenario", () => {
+    expect(fixture).toHaveLength(33);
+    expect(fixture).toHaveLength(scenarioFixture.length);
+
+    const moduleCounts = countByModule(fixture);
+    expect([...moduleCounts.keys()].sort()).toEqual([...REQUIRED_MODULE_IDS].sort());
+
+    for (const moduleId of REQUIRED_MODULE_IDS) {
+      expect(moduleCounts.get(moduleId)).toBeGreaterThanOrEqual(3);
+    }
+  });
+
+  it("uses the required schema with unique case ids and non-empty comparison notes", () => {
+    const caseIds = new Set<string>();
+
+    for (const outcome of fixture) {
+      expect(Object.keys(outcome).sort()).toEqual(REQUIRED_OUTCOME_KEYS);
+      expect(outcome.caseId).toMatch(/^[a-z0-9_]+$/);
+      expect(caseIds.has(outcome.caseId)).toBe(false);
+      caseIds.add(outcome.caseId);
+
+      expect(outcome.acceptablePlannedQuestionIds.length).toBeGreaterThan(0);
+      expect(outcome.expectedSelectedBecause.length).toBeGreaterThan(0);
+      expect(outcome.notes.trim()).toBe(outcome.notes);
+      expect(outcome.notes.length).toBeGreaterThan(20);
+      expect(typeof outcome.shouldBeatGenericQuestion).toBe("boolean");
+      expect(typeof outcome.shouldScreenEmergencyEarlier).toBe("boolean");
+      expect(typeof outcome.shouldAvoidRepeatedQuestion).toBe("boolean");
+    }
+  });
+
+  it("stays locked to the merged scenario-pack expectations", () => {
+    for (const outcome of fixture) {
+      const scenario = getScenarioByCaseId(outcome.caseId);
+
+      expect(outcome.expectedComplaintModuleId).toBe(
+        scenario.expectedComplaintModuleId
+      );
+      expect(outcome.acceptablePlannedQuestionIds).toEqual(
+        scenario.acceptableFirstQuestionIds
+      );
+      expect(outcome.mustScreenRedFlags).toEqual(scenario.mustScreenRedFlags);
+      expect(outcome.shouldBeatGenericQuestion).toBe(
+        scenario.shouldAvoidGenericQuestion
+      );
+      expect(outcome.shouldScreenEmergencyEarlier).toBe(
+        scenario.shouldPreferEmergencyScreen
+      );
+    }
+  });
+
+  it("references only registered complaint modules and question cards", () => {
+    const registeredModuleIds = new Set(
+      getComplaintModules().map((module) => module.id)
+    );
+    const registeredQuestionIds = new Set(
+      getAllQuestionCards().map((card) => card.id)
+    );
+
+    for (const outcome of fixture) {
+      expect(registeredModuleIds.has(outcome.expectedComplaintModuleId)).toBe(
+        true
+      );
+
+      for (const questionId of outcome.acceptablePlannedQuestionIds) {
+        expect(registeredQuestionIds.has(questionId)).toBe(true);
+      }
+    }
+  });
+
+  it("keeps expected selectedBecause values aligned to first-turn shadow-planner reachability", () => {
+    for (const outcome of fixture) {
+      expect(outcome.expectedSelectedBecause).toEqual(
+        deriveExpectedSelectedBecause(outcome.acceptablePlannedQuestionIds)
+      );
+
+      for (const value of outcome.expectedSelectedBecause) {
+        expect(VALID_SELECTED_BECAUSE).toContain(value);
+      }
+
+      expect(outcome.expectedSelectedBecause).not.toContain("clarification");
+      expect(outcome.expectedSelectedBecause).not.toContain("urgency_changing");
+      expect(outcome.expectedSelectedBecause).not.toContain("report_value");
+    }
+  });
+
+  it("clearly marks emergency or must-not-miss cases and keeps emergency candidates reachable", () => {
+    const emergencyRows = fixture.filter(
+      (outcome) => outcome.shouldScreenEmergencyEarlier
+    );
+
+    expect(emergencyRows.length).toBeGreaterThanOrEqual(12);
+
+    for (const outcome of emergencyRows) {
+      expect(outcome.notes).toMatch(/^Emergency or must-not-miss:/);
+      expect(outcome.expectedSelectedBecause).toContain("emergency_screen");
+
+      const acceptableCards = outcome.acceptablePlannedQuestionIds.map((id) => {
+        const card = getQuestionCardById(id);
+        if (!card) {
+          throw new Error(`Missing question card ${id}`);
+        }
+        return card;
+      });
+
+      expect(
+        acceptableCards.some((card) => card.phase === "emergency_screen")
+      ).toBe(true);
+    }
+  });
+
+  it("flags multi-symptom ambiguity only on the confusing scenario set and expects repeat avoidance everywhere", () => {
+    const confusingCaseIds = new Set(
+      scenarioFixture
+        .filter((scenario) => scenario.isConfusingMultiSymptom)
+        .map((scenario) => scenario.caseId)
+    );
+
+    expect(confusingCaseIds.size).toBeGreaterThanOrEqual(8);
+
+    for (const outcome of fixture) {
+      expect(outcome.shouldAvoidRepeatedQuestion).toBe(true);
+
+      const hasAmbiguityMarker = outcome.notes.includes("Acceptable ambiguity:");
+      expect(hasAmbiguityMarker).toBe(confusingCaseIds.has(outcome.caseId));
+    }
+  });
+
+  it("keeps evaluator notes free of diagnosis or treatment claims", () => {
+    for (const outcome of fixture) {
+      for (const pattern of OWNER_FACING_CLAIM_PATTERNS) {
+        expect(outcome.notes).not.toMatch(pattern);
+      }
+    }
+  });
+});

--- a/tests/fixtures/clinical-intelligence/shadow-planner-expected-outcomes.json
+++ b/tests/fixtures/clinical-intelligence/shadow-planner-expected-outcomes.json
@@ -1,0 +1,713 @@
+[
+  {
+    "caseId": "heatstroke_heat_exposure_01_hot_car_collapse",
+    "expectedComplaintModuleId": "heatstroke_heat_exposure",
+    "acceptablePlannedQuestionIds": [
+      "panting_excess_check",
+      "emergency_global_screen",
+      "breathing_difficulty_check",
+      "collapse_weakness_check"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen"
+    ],
+    "mustScreenRedFlags": [
+      "heatstroke_signs",
+      "collapse",
+      "dyspnea"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": true,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Emergency or must-not-miss: Emergency heat exposure with weakness should prefer a heat or global emergency screen before generic history."
+  },
+  {
+    "caseId": "heatstroke_heat_exposure_02_brachy_panting_after_walk",
+    "expectedComplaintModuleId": "heatstroke_heat_exposure",
+    "acceptablePlannedQuestionIds": [
+      "panting_excess_check",
+      "breathing_difficulty_check",
+      "brachycephalic_breed_check",
+      "heat_exposure_check"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen",
+      "highest_information_gain"
+    ],
+    "mustScreenRedFlags": [
+      "heatstroke_signs",
+      "brachycephalic_heat",
+      "dyspnea"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": true,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Emergency or must-not-miss: Short-nosed dog heat risk can be missed if the planner asks a broad timing question first."
+  },
+  {
+    "caseId": "heatstroke_heat_exposure_03_heat_plus_vomit_confuser",
+    "expectedComplaintModuleId": "heatstroke_heat_exposure",
+    "acceptablePlannedQuestionIds": [
+      "panting_excess_check",
+      "heat_exposure_check",
+      "emergency_global_screen",
+      "gi_vomiting_frequency"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen",
+      "highest_information_gain"
+    ],
+    "mustScreenRedFlags": [
+      "heatstroke_signs",
+      "persistent_vomiting"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": true,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Emergency or must-not-miss: Confusing multi-symptom case where vomiting should not pull the first question away from heat screening. Acceptable ambiguity: mixed wording may justify multiple registry-backed first questions as long as safety-critical screening remains in front."
+  },
+  {
+    "caseId": "trauma_bleeding_wound_01_hit_by_car_pale",
+    "expectedComplaintModuleId": "trauma_bleeding_wound",
+    "acceptablePlannedQuestionIds": [
+      "emergency_global_screen",
+      "gum_color_check",
+      "bleeding_volume_check",
+      "trauma_mechanism_check"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen",
+      "highest_information_gain"
+    ],
+    "mustScreenRedFlags": [
+      "possible_trauma",
+      "pale_gums",
+      "large_blood_volume"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": true,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Emergency or must-not-miss: Trauma with gum-color concern should screen for shock-like red flags before wound detail."
+  },
+  {
+    "caseId": "trauma_bleeding_wound_02_bite_puncture_drip",
+    "expectedComplaintModuleId": "trauma_bleeding_wound",
+    "acceptablePlannedQuestionIds": [
+      "bleeding_volume_check",
+      "wound_characterization_check",
+      "trauma_mechanism_check",
+      "emergency_global_screen"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen",
+      "highest_information_gain"
+    ],
+    "mustScreenRedFlags": [
+      "wound_deep_bleeding",
+      "large_blood_volume"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": false,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Bite wound wording should map to trauma and ask a high-value bleeding or wound question."
+  },
+  {
+    "caseId": "trauma_bleeding_wound_03_limping_after_fall_confuser",
+    "expectedComplaintModuleId": "trauma_bleeding_wound",
+    "acceptablePlannedQuestionIds": [
+      "trauma_mechanism_check",
+      "bleeding_volume_check",
+      "limping_weight_bearing",
+      "emergency_global_screen"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen",
+      "highest_information_gain"
+    ],
+    "mustScreenRedFlags": [
+      "possible_trauma",
+      "large_blood_volume"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": false,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Confusing multi-symptom trauma plus limping should keep accident and bleeding candidates ahead of generic mobility follow-up. Acceptable ambiguity: mixed wording may justify multiple registry-backed first questions as long as safety-critical screening remains in front."
+  },
+  {
+    "caseId": "urinary_obstruction_01_straining_no_output",
+    "expectedComplaintModuleId": "urinary_obstruction",
+    "acceptablePlannedQuestionIds": [
+      "urinary_blockage_check",
+      "urinary_straining_output",
+      "emergency_global_screen"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen",
+      "highest_information_gain"
+    ],
+    "mustScreenRedFlags": [
+      "urinary_obstruction",
+      "anuria",
+      "stranguria"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": true,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Emergency or must-not-miss: Little or no urine output is must-not-miss and should not be handled like routine accidents."
+  },
+  {
+    "caseId": "urinary_obstruction_02_accidents_blood_straining",
+    "expectedComplaintModuleId": "urinary_obstruction",
+    "acceptablePlannedQuestionIds": [
+      "urinary_straining_output",
+      "urinary_blockage_check",
+      "emergency_global_screen"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen",
+      "highest_information_gain"
+    ],
+    "mustScreenRedFlags": [
+      "stranguria",
+      "hematuria",
+      "urinary_obstruction"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": false,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Mixed accident and blood language should still screen for output and straining. Acceptable ambiguity: mixed wording may justify multiple registry-backed first questions as long as safety-critical screening remains in front."
+  },
+  {
+    "caseId": "urinary_obstruction_03_vomit_and_no_pee_confuser",
+    "expectedComplaintModuleId": "urinary_obstruction",
+    "acceptablePlannedQuestionIds": [
+      "urinary_blockage_check",
+      "urinary_straining_output",
+      "emergency_global_screen",
+      "gi_vomiting_frequency"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen",
+      "highest_information_gain"
+    ],
+    "mustScreenRedFlags": [
+      "urinary_obstruction",
+      "anuria",
+      "persistent_vomiting"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": true,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Emergency or must-not-miss: Confusing multi-symptom urinary plus GI case where no urine output must outrank a generic vomiting question. Acceptable ambiguity: mixed wording may justify multiple registry-backed first questions as long as safety-critical screening remains in front."
+  },
+  {
+    "caseId": "bloat_gdv_01_retching_swollen_belly",
+    "expectedComplaintModuleId": "bloat_gdv",
+    "acceptablePlannedQuestionIds": [
+      "bloat_retching_abdomen_check",
+      "emergency_global_screen",
+      "gi_vomiting_frequency"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen",
+      "highest_information_gain"
+    ],
+    "mustScreenRedFlags": [
+      "gastric_dilatation_volvulus",
+      "unproductive_retching",
+      "abdominal_distension"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": true,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Emergency or must-not-miss: Classic retching plus tight belly should go straight to the bloat screen."
+  },
+  {
+    "caseId": "bloat_gdv_02_pacing_drooling_belly",
+    "expectedComplaintModuleId": "bloat_gdv",
+    "acceptablePlannedQuestionIds": [
+      "bloat_retching_abdomen_check",
+      "emergency_global_screen",
+      "gi_vomiting_frequency"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen",
+      "highest_information_gain"
+    ],
+    "mustScreenRedFlags": [
+      "abdominal_distension",
+      "gastric_dilatation_volvulus"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": true,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Emergency or must-not-miss: Less explicit bloat language still needs an abdomen and retching discriminator."
+  },
+  {
+    "caseId": "bloat_gdv_03_diarrhea_plus_retching_confuser",
+    "expectedComplaintModuleId": "bloat_gdv",
+    "acceptablePlannedQuestionIds": [
+      "bloat_retching_abdomen_check",
+      "emergency_global_screen",
+      "gi_blood_check",
+      "gi_vomiting_frequency"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen",
+      "highest_information_gain"
+    ],
+    "mustScreenRedFlags": [
+      "unproductive_retching",
+      "abdominal_distension",
+      "gastric_dilatation_volvulus"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": true,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Emergency or must-not-miss: Confusing multi-symptom GI wording should still prioritize bloat red-flag screening. Acceptable ambiguity: mixed wording may justify multiple registry-backed first questions as long as safety-critical screening remains in front."
+  },
+  {
+    "caseId": "respiratory_distress_01_open_mouth_breathing",
+    "expectedComplaintModuleId": "respiratory_distress",
+    "acceptablePlannedQuestionIds": [
+      "breathing_difficulty_check",
+      "emergency_global_screen",
+      "gum_color_check"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen"
+    ],
+    "mustScreenRedFlags": [
+      "dyspnea",
+      "open_mouth_breathing",
+      "tachypnea"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": true,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Emergency or must-not-miss: Clear breathing distress should prefer emergency respiratory screening."
+  },
+  {
+    "caseId": "respiratory_distress_02_cough_and_blue_tongue",
+    "expectedComplaintModuleId": "respiratory_distress",
+    "acceptablePlannedQuestionIds": [
+      "gum_color_check",
+      "breathing_difficulty_check",
+      "emergency_global_screen"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen"
+    ],
+    "mustScreenRedFlags": [
+      "cyanosis",
+      "dyspnea"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": true,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Emergency or must-not-miss: Cough language with color change must not get a routine cough follow-up first. Acceptable ambiguity: mixed wording may justify multiple registry-backed first questions as long as safety-critical screening remains in front."
+  },
+  {
+    "caseId": "respiratory_distress_03_fast_breathing_after_heat_confuser",
+    "expectedComplaintModuleId": "respiratory_distress",
+    "acceptablePlannedQuestionIds": [
+      "breathing_difficulty_check",
+      "emergency_global_screen",
+      "panting_excess_check",
+      "heat_exposure_check"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen",
+      "highest_information_gain"
+    ],
+    "mustScreenRedFlags": [
+      "tachypnea",
+      "dyspnea",
+      "heatstroke_signs"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": true,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Emergency or must-not-miss: Confusing multi-symptom respiratory plus heat case should still screen current breathing first. Acceptable ambiguity: mixed wording may justify multiple registry-backed first questions as long as safety-critical screening remains in front."
+  },
+  {
+    "caseId": "collapse_weakness_01_fainted_and_weak",
+    "expectedComplaintModuleId": "collapse_weakness",
+    "acceptablePlannedQuestionIds": [
+      "collapse_weakness_check",
+      "emergency_global_screen",
+      "gum_color_check"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen"
+    ],
+    "mustScreenRedFlags": [
+      "collapse",
+      "syncope",
+      "acute_weakness"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": true,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Emergency or must-not-miss: Collapse should be screened as must-not-miss even if the dog is awake now."
+  },
+  {
+    "caseId": "collapse_weakness_02_wobbly_pale",
+    "expectedComplaintModuleId": "collapse_weakness",
+    "acceptablePlannedQuestionIds": [
+      "gum_color_check",
+      "collapse_weakness_check",
+      "emergency_global_screen"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen"
+    ],
+    "mustScreenRedFlags": [
+      "pale_gums",
+      "acute_weakness",
+      "collapse"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": true,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Emergency or must-not-miss: Weakness with pale gums should prioritize circulation red flags."
+  },
+  {
+    "caseId": "collapse_weakness_03_vomit_then_weak_confuser",
+    "expectedComplaintModuleId": "collapse_weakness",
+    "acceptablePlannedQuestionIds": [
+      "collapse_weakness_check",
+      "emergency_global_screen",
+      "gum_color_check",
+      "gi_vomiting_frequency"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen",
+      "highest_information_gain"
+    ],
+    "mustScreenRedFlags": [
+      "acute_weakness",
+      "collapse",
+      "persistent_vomiting"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": true,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Emergency or must-not-miss: Confusing multi-symptom vomiting plus weakness should not start with a generic GI-only question. Acceptable ambiguity: mixed wording may justify multiple registry-backed first questions as long as safety-critical screening remains in front."
+  },
+  {
+    "caseId": "seizure_collapse_neuro_01_long_shaking",
+    "expectedComplaintModuleId": "seizure_collapse_neuro",
+    "acceptablePlannedQuestionIds": [
+      "seizure_neuro_check",
+      "neuro_seizure_duration",
+      "emergency_global_screen"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen",
+      "highest_information_gain"
+    ],
+    "mustScreenRedFlags": [
+      "seizure",
+      "status_epilepticus"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": true,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Emergency or must-not-miss: Long shaking episode should screen seizure duration and emergency neuro flags."
+  },
+  {
+    "caseId": "seizure_collapse_neuro_02_multiple_episodes",
+    "expectedComplaintModuleId": "seizure_collapse_neuro",
+    "acceptablePlannedQuestionIds": [
+      "seizure_neuro_check",
+      "neuro_seizure_duration",
+      "collapse_weakness_check",
+      "emergency_global_screen"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen",
+      "highest_information_gain"
+    ],
+    "mustScreenRedFlags": [
+      "cluster_seizures",
+      "seizure",
+      "acute_weakness"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": true,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Emergency or must-not-miss: Multiple neuro episodes need clustering and collapse red-flag screening. Acceptable ambiguity: mixed wording may justify multiple registry-backed first questions as long as safety-critical screening remains in front."
+  },
+  {
+    "caseId": "seizure_collapse_neuro_03_collapse_or_seizure_unclear",
+    "expectedComplaintModuleId": "seizure_collapse_neuro",
+    "acceptablePlannedQuestionIds": [
+      "seizure_neuro_check",
+      "collapse_weakness_check",
+      "neuro_seizure_duration",
+      "emergency_global_screen"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen",
+      "highest_information_gain"
+    ],
+    "mustScreenRedFlags": [
+      "seizure",
+      "collapse",
+      "syncope"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": true,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Emergency or must-not-miss: Confusing collapse versus seizure wording should still choose neuro or collapse emergency discriminators. Acceptable ambiguity: mixed wording may justify multiple registry-backed first questions as long as safety-critical screening remains in front."
+  },
+  {
+    "caseId": "toxin_poisoning_exposure_01_chocolate_and_vomit",
+    "expectedComplaintModuleId": "toxin_poisoning_exposure",
+    "acceptablePlannedQuestionIds": [
+      "toxin_exposure_check",
+      "emergency_global_screen",
+      "gi_vomiting_frequency"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen",
+      "highest_information_gain"
+    ],
+    "mustScreenRedFlags": [
+      "known_toxin_ingestion",
+      "suspected_toxin",
+      "persistent_vomiting"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": true,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Emergency or must-not-miss: Known exposure should keep toxin screening ahead of routine vomiting characterization. Acceptable ambiguity: mixed wording may justify multiple registry-backed first questions as long as safety-critical screening remains in front."
+  },
+  {
+    "caseId": "toxin_poisoning_exposure_02_rodent_bait_possible",
+    "expectedComplaintModuleId": "toxin_poisoning_exposure",
+    "acceptablePlannedQuestionIds": [
+      "toxin_exposure_check",
+      "emergency_global_screen"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen"
+    ],
+    "mustScreenRedFlags": [
+      "suspected_toxin",
+      "known_toxin_ingestion"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": true,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Emergency or must-not-miss: Uncertain amount of suspected toxin should still screen exposure first."
+  },
+  {
+    "caseId": "toxin_poisoning_exposure_03_plant_and_wobbly_confuser",
+    "expectedComplaintModuleId": "toxin_poisoning_exposure",
+    "acceptablePlannedQuestionIds": [
+      "toxin_exposure_check",
+      "collapse_weakness_check",
+      "emergency_global_screen"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen"
+    ],
+    "mustScreenRedFlags": [
+      "suspected_toxin",
+      "acute_weakness"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": true,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Emergency or must-not-miss: Confusing multi-symptom exposure plus neuro-like signs should keep toxin exposure in the first screen set. Acceptable ambiguity: mixed wording may justify multiple registry-backed first questions as long as safety-critical screening remains in front."
+  },
+  {
+    "caseId": "gi_vomiting_diarrhea_01_repeated_vomiting",
+    "expectedComplaintModuleId": "gi_vomiting_diarrhea",
+    "acceptablePlannedQuestionIds": [
+      "gi_vomiting_frequency",
+      "gi_keep_water_down_check",
+      "emergency_global_screen"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen",
+      "highest_information_gain"
+    ],
+    "mustScreenRedFlags": [
+      "persistent_vomiting",
+      "unable_to_retain_water"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": false,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Repeated vomiting should ask frequency or hydration stability before a broad intake question."
+  },
+  {
+    "caseId": "gi_vomiting_diarrhea_02_bloody_diarrhea",
+    "expectedComplaintModuleId": "gi_vomiting_diarrhea",
+    "acceptablePlannedQuestionIds": [
+      "gi_blood_check",
+      "gi_vomiting_frequency",
+      "emergency_global_screen"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen",
+      "highest_information_gain"
+    ],
+    "mustScreenRedFlags": [
+      "hematochezia",
+      "persistent_vomiting"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": false,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Blood in stool should be captured as a GI red flag rather than buried after generic duration. Acceptable ambiguity: mixed wording may justify multiple registry-backed first questions as long as safety-critical screening remains in front."
+  },
+  {
+    "caseId": "gi_vomiting_diarrhea_03_water_comes_back_up",
+    "expectedComplaintModuleId": "gi_vomiting_diarrhea",
+    "acceptablePlannedQuestionIds": [
+      "gi_keep_water_down_check",
+      "gi_vomiting_frequency",
+      "gi_blood_check"
+    ],
+    "expectedSelectedBecause": [
+      "highest_information_gain"
+    ],
+    "mustScreenRedFlags": [
+      "unable_to_retain_water",
+      "persistent_vomiting"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": false,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Inability to keep water down is a high-value first question candidate in GI cases."
+  },
+  {
+    "caseId": "skin_itching_allergy_01_hives_after_sting",
+    "expectedComplaintModuleId": "skin_itching_allergy",
+    "acceptablePlannedQuestionIds": [
+      "skin_emergency_allergy_screen",
+      "emergency_global_screen",
+      "breathing_difficulty_check"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen"
+    ],
+    "mustScreenRedFlags": [
+      "urticaria",
+      "anaphylaxis",
+      "angioedema"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": true,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Emergency or must-not-miss: Spreading hives after a sting should screen allergy emergency flags before routine skin location."
+  },
+  {
+    "caseId": "skin_itching_allergy_02_paws_belly_itching",
+    "expectedComplaintModuleId": "skin_itching_allergy",
+    "acceptablePlannedQuestionIds": [
+      "skin_location_distribution",
+      "skin_changes_check",
+      "skin_exposure_check"
+    ],
+    "expectedSelectedBecause": [
+      "highest_information_gain"
+    ],
+    "mustScreenRedFlags": [],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": false,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Routine itchy skin should prefer localizing and appearance questions, not a generic wellness prompt."
+  },
+  {
+    "caseId": "skin_itching_allergy_03_face_swelling_and_vomit_confuser",
+    "expectedComplaintModuleId": "skin_itching_allergy",
+    "acceptablePlannedQuestionIds": [
+      "skin_emergency_allergy_screen",
+      "breathing_difficulty_check",
+      "emergency_global_screen",
+      "gi_vomiting_frequency"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen",
+      "highest_information_gain"
+    ],
+    "mustScreenRedFlags": [
+      "angioedema",
+      "urticaria",
+      "anaphylaxis",
+      "persistent_vomiting"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": true,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Emergency or must-not-miss: Confusing multi-symptom allergy plus GI case must screen facial swelling and hives first. Acceptable ambiguity: mixed wording may justify multiple registry-backed first questions as long as safety-critical screening remains in front."
+  },
+  {
+    "caseId": "limping_mobility_pain_01_non_weight_bearing",
+    "expectedComplaintModuleId": "limping_mobility_pain",
+    "acceptablePlannedQuestionIds": [
+      "limping_weight_bearing",
+      "limping_trauma_onset",
+      "emergency_global_screen"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen",
+      "highest_information_gain"
+    ],
+    "mustScreenRedFlags": [
+      "non_weight_bearing"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": false,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Non-weight-bearing lameness should ask the weight-bearing discriminator first."
+  },
+  {
+    "caseId": "limping_mobility_pain_02_sudden_after_jump",
+    "expectedComplaintModuleId": "limping_mobility_pain",
+    "acceptablePlannedQuestionIds": [
+      "limping_weight_bearing",
+      "limping_trauma_onset",
+      "trauma_mechanism_check"
+    ],
+    "expectedSelectedBecause": [
+      "highest_information_gain"
+    ],
+    "mustScreenRedFlags": [
+      "post_trauma_lameness",
+      "non_weight_bearing"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": false,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Sudden onset after a jump needs mobility and trauma-onset candidates."
+  },
+  {
+    "caseId": "limping_mobility_pain_03_limping_with_wound_confuser",
+    "expectedComplaintModuleId": "limping_mobility_pain",
+    "acceptablePlannedQuestionIds": [
+      "limping_weight_bearing",
+      "limping_trauma_onset",
+      "wound_characterization_check",
+      "bleeding_volume_check"
+    ],
+    "expectedSelectedBecause": [
+      "emergency_screen",
+      "highest_information_gain"
+    ],
+    "mustScreenRedFlags": [
+      "post_trauma_lameness",
+      "non_weight_bearing",
+      "wound_deep_bleeding"
+    ],
+    "shouldBeatGenericQuestion": true,
+    "shouldScreenEmergencyEarlier": false,
+    "shouldAvoidRepeatedQuestion": true,
+    "notes": "Confusing multi-symptom lameness plus wound should avoid a generic pain question and keep mobility first. Acceptable ambiguity: mixed wording may justify multiple registry-backed first questions as long as safety-critical screening remains in front."
+  }
+]


### PR DESCRIPTION
## Summary
- add a shadow planner expected-outcomes fixture for the merged scenario pack
- add a guard test that locks the outcome pack to the scenario fixture and current registries
- document how future old-vs-shadow scoring should consume the package

## Validation
- npm test -- --runTestsByPath tests/clinical-intelligence/shadow-planner-outcome-pack.test.ts
- npm test -- --runTestsByPath tests/clinical-intelligence/shadow-planner-scenario-pack.test.ts
- npm test -- --runTestsByPath tests/clinical-intelligence/question-card-registry.test.ts
- npm run build