### PR TITLE
VET-1445Q: Shadow Eval Threshold Readiness Guard

### DIFF
--- a/docs/clinical-intelligence/shadow-eval-threshold-readiness-guard-qwen.md
+++ b/docs/clinical-intelligence/shadow-eval-threshold-readiness-guard-qwen.md
@@ -1,0 +1,78 @@
+# Shadow Eval Threshold Readiness Guard (VET-1445Q)
+
+**Agent:** Qwen 3.6 Plus  
+**Branch:** qwen/vet-1445q-shadow-eval-threshold-readiness-guard  
+**Date:** 2026-05-04  
+**Scope:** Validation-only guard and documentation. No runtime wiring, no CI enforcement, no planner behavior changes.
+
+## Purpose
+
+This ticket defines the planned threshold field names for the shadow planner
+scenario eval so future CI gating can be added without renaming drift or
+accidental fail-closed behavior in the current phase.
+
+These threshold fields are report-only in this phase.
+
+## Planned Threshold Fields
+
+The planned threshold keys must stay aligned with the metric names already
+returned by `evaluateShadowPlannerScenarios(...)` in
+`src/lib/clinical-intelligence/shadow-planner-scenario-eval.ts`:
+
+- `complaintModuleMatchRate`
+- `acceptableQuestionRate`
+- `emergencyScreenAlignmentRate`
+- `repeatedQuestionAvoidanceRate`
+- `genericQuestionAvoidanceRate`
+- `redFlagScreenCoverageRate`
+
+These are naming contracts only in this ticket. No threshold values, threshold
+evaluators, or CI pass/fail rules are introduced here.
+
+## Current Phase Rules
+
+- No runtime files are touched by this guard.
+- No workflow file enforces these thresholds yet.
+- No CI fail-closed behavior is added in this ticket.
+- The current shadow planner scenario eval continues to report metrics and
+  failed cases only.
+- Any future fail-closed CI gate must land in a separate ticket.
+
+## Emergency Safety Constraint
+
+Threshold review must never downgrade emergency behavior or override emergency_handoff.
+
+Any future threshold gate must remain downstream of the existing emergency
+behavior contract. It cannot:
+
+- downgrade an already-emergency path
+- weaken emergency-screen expectations
+- suppress required red-flag coverage expectations
+- reinterpret report-only quality metrics as authority over runtime triage
+
+## No-Workflow-Enforcement Proof
+
+As of this ticket, the workflow directory `.github/workflows/` does not contain
+the six planned threshold field names and does not invoke any dedicated shadow
+eval threshold gate.
+
+That means the current repo state remains:
+
+- report-only summary generation in the eval harness
+- explicit local guard coverage in tests
+- no GitHub workflow threshold enforcement yet
+
+## Validation Contract
+
+The guard test verifies:
+
+1. the six planned threshold field names still exist on the current shadow eval
+   summary shape
+2. this document keeps the report-only and separate-ticket rules explicit
+3. workflow files remain free of threshold-enforcement wiring
+
+## Notes
+
+- Validation-only guard.
+- No runtime files touched.
+- No CI fail-closed behavior added.

--- a/tests/clinical-intelligence/shadow-eval-threshold-readiness-guard.test.ts
+++ b/tests/clinical-intelligence/shadow-eval-threshold-readiness-guard.test.ts
@@ -39,7 +39,9 @@ function readGuardDoc(): string {
 function readWorkflowFiles(): Array<{ name: string; content: string }> {
   return fs
     .readdirSync(WORKFLOW_DIR)
-    .filter((entry) => entry.endsWith(".yml"))
+    .filter(
+      (entry) => entry.endsWith(".yml") || entry.endsWith(".yaml")
+    )
     .map((name) => ({
       name,
       content: fs.readFileSync(path.join(WORKFLOW_DIR, name), "utf8"),

--- a/tests/clinical-intelligence/shadow-eval-threshold-readiness-guard.test.ts
+++ b/tests/clinical-intelligence/shadow-eval-threshold-readiness-guard.test.ts
@@ -1,0 +1,97 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import outcomes from "../fixtures/clinical-intelligence/shadow-planner-expected-outcomes.json";
+import scenarios from "../fixtures/clinical-intelligence/shadow-planner-scenarios.json";
+
+import { evaluateShadowPlannerScenarios } from "@/lib/clinical-intelligence/shadow-planner-scenario-eval";
+
+const DOC_PATH = path.join(
+  process.cwd(),
+  "docs",
+  "clinical-intelligence",
+  "shadow-eval-threshold-readiness-guard-qwen.md"
+);
+
+const WORKFLOW_DIR = path.join(process.cwd(), ".github", "workflows");
+
+const EXPECTED_THRESHOLD_FIELDS = [
+  "complaintModuleMatchRate",
+  "acceptableQuestionRate",
+  "emergencyScreenAlignmentRate",
+  "repeatedQuestionAvoidanceRate",
+  "genericQuestionAvoidanceRate",
+  "redFlagScreenCoverageRate",
+] as const;
+
+const REQUIRED_DOC_LINES = [
+  "These threshold fields are report-only in this phase.",
+  "No workflow file enforces these thresholds yet.",
+  "No CI fail-closed behavior is added in this ticket.",
+  "Any future fail-closed CI gate must land in a separate ticket.",
+  "Threshold review must never downgrade emergency behavior or override emergency_handoff.",
+] as const;
+
+function readGuardDoc(): string {
+  return fs.readFileSync(DOC_PATH, "utf8");
+}
+
+function readWorkflowFiles(): Array<{ name: string; content: string }> {
+  return fs
+    .readdirSync(WORKFLOW_DIR)
+    .filter((entry) => entry.endsWith(".yml"))
+    .map((name) => ({
+      name,
+      content: fs.readFileSync(path.join(WORKFLOW_DIR, name), "utf8"),
+    }));
+}
+
+describe("shadow eval threshold readiness guard", () => {
+  it("keeps planned threshold names aligned with the shadow eval summary metrics", () => {
+    const report = evaluateShadowPlannerScenarios({
+      scenarios,
+      expectedOutcomes: outcomes,
+    });
+
+    const missingFields = EXPECTED_THRESHOLD_FIELDS.filter(
+      (field) => !(field in report.summary)
+    );
+    const nonNumericFields = EXPECTED_THRESHOLD_FIELDS.filter(
+      (field) => typeof report.summary[field] !== "number"
+    );
+
+    expect(missingFields).toEqual([]);
+    expect(nonNumericFields).toEqual([]);
+  });
+
+  it("documents the planned threshold contract as report-only", () => {
+    const doc = readGuardDoc();
+
+    for (const field of EXPECTED_THRESHOLD_FIELDS) {
+      expect(doc).toContain(`\`${field}\``);
+    }
+
+    for (const line of REQUIRED_DOC_LINES) {
+      expect(doc).toContain(line);
+    }
+  });
+
+  it("keeps workflow files free of threshold enforcement wiring", () => {
+    const workflowHits = readWorkflowFiles().flatMap(({ name, content }) => {
+      const thresholdFieldHits = EXPECTED_THRESHOLD_FIELDS.filter((field) =>
+        content.includes(field)
+      ).map((field) => `${name}:${field}`);
+
+      const harnessHits = [
+        "shadow-planner-scenario-eval",
+        "eval-shadow-planner-scenarios",
+      ]
+        .filter((pattern) => content.includes(pattern))
+        .map((pattern) => `${name}:${pattern}`);
+
+      return [...thresholdFieldHits, ...harnessHits];
+    });
+
+    expect(workflowHits).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a validation-only guard test for planned shadow eval threshold field readiness
- document the report-only threshold contract and future separate-ticket fail-closed rule
- confirm workflows do not enforce these threshold fields yet

## Validation
- npm test -- --runTestsByPath tests/clinical-intelligence/shadow-eval-threshold-readiness-guard.test.ts
- npm test -- --runTestsByPath tests/clinical-intelligence/shadow-planner-fixture-alignment-guard.test.ts
- npm run build