### PR TITLE
VET-1450K: publish expected outcome normalization pack

### DIFF
--- a/docs/clinical-intelligence/shadow-planner-expected-outcome-normalization-kimi.md
+++ b/docs/clinical-intelligence/shadow-planner-expected-outcome-normalization-kimi.md
@@ -1,0 +1,95 @@
+# VET-1450K Shadow Eval Expected Outcome Normalization Pack
+
+## Scope
+
+This package adds fixture, test, and documentation coverage only:
+
+- `tests/fixtures/clinical-intelligence/shadow-planner-expected-outcome-normalization.json`
+- `tests/clinical-intelligence/shadow-planner-expected-outcome-normalization-pack.test.ts`
+- `docs/clinical-intelligence/shadow-planner-expected-outcome-normalization-kimi.md`
+
+It does not change eval code, planner behavior, complaint adapter behavior, question cards, complaint modules, runtime routes, UI, infrastructure, or workflow files.
+
+## Purpose
+
+The normalization pack adds a reviewable layer on top of `shadow-planner-expected-outcomes.json` so future eval reporting can separate true quality misses from clinically acceptable ambiguity.
+
+Each normalization row records:
+
+- accepted complaint-module alternatives for ambiguous wording
+- whether ambiguity stays strict, same-module-only, or allows module alternatives
+- whether emergency-screen alignment alone is enough
+- whether red-flag coverage should be interpreted as complete or partial
+- whether the row should count toward generic-question scoring yet
+- evaluator notes that explain the normalization decision without diagnosis or treatment instructions
+
+## Normalization Rules
+
+The pack stays fully derived from the merged expected-outcome fixture:
+
+- `caseId` matches one expected-outcome row exactly
+- `acceptableModuleIds` always includes the primary expected complaint module
+- confusing multi-symptom rows may add registry-backed module alternatives
+- emergency alignment uses `alignment_only_ok` only when the outcome fixture already marks `shouldScreenEmergencyEarlier = true`
+- red-flag coverage is `partial` when `emergency_global_screen` is already an accepted planned question
+- generic-question scoring is `exclude_for_now` on the same `emergency_global_screen` rows so future quality reports do not over-penalize emergency-first cases
+
+This keeps the pack report-only. It does not alter evaluator logic or authorize planner runtime changes.
+
+## Coverage Summary
+
+- cases covered: 33
+- ambiguity cases: 15
+- emergency-alignment-only cases: 23
+- partial red-flag coverage cases: 28
+- generic-metric excluded cases: 28
+
+The ambiguity split is intentional:
+
+- `strict_primary` for non-confuser rows
+- `same_module_only` for mixed wording that should still stay inside the primary module
+- `allow_module_alternatives` for mixed symptom rows where a different registry-backed module remains clinically acceptable
+
+## Ambiguity Guidance
+
+The pack explicitly opens alternate complaint modules only where the merged fixture wording supports real overlap, for example:
+
+- heat plus vomiting can remain heat-first while still accepting `gi_vomiting_diarrhea`
+- trauma plus limping can remain trauma-first while still accepting `limping_mobility_pain`
+- facial swelling plus vomiting can remain skin-first while still accepting respiratory or GI module matches
+- collapse or seizure wording can accept either neuro-first or collapse-first framing
+
+Rows that stay `same_module_only` still acknowledge mixed symptom language, but they do not yet justify a different module expectation.
+
+## Emergency And Red-Flag Interpretation
+
+Some rows should not require the exact same planned question to count as a good result. When the outcome fixture already expects earlier emergency screening, `alignment_only_ok` means any accepted emergency-first path is sufficient even if the chosen question card differs.
+
+Rows that already accept `emergency_global_screen` are normalized as:
+
+- `redFlagCoverageExpectation = partial`
+- `genericQuestionScoring = exclude_for_now`
+
+That combination is deliberate. A global emergency screen can preserve safe red-flag coverage without giving enough signal to score generic-question avoidance fairly. Those rows should stay visible in reports, but they should not yet be treated as clean generic-question comparisons.
+
+## Guardrails
+
+The normalization pack test verifies that:
+
+- the fixture stays 1:1 with `shadow-planner-expected-outcomes.json`
+- every accepted module exists in the complaint-module registry
+- ambiguity counts and spot-check alternatives remain stable
+- emergency-alignment-only rows track the existing emergency expectation exactly
+- partial red-flag coverage and generic-metric exclusion stay tied to `emergency_global_screen`
+- notes stay free of diagnosis or treatment instructions
+
+## Intended Evaluation Use
+
+Future report-only eval work can combine this pack with the outcome pack to:
+
+- distinguish acceptable module ambiguity from true module misses
+- avoid over-counting exact-question misses when emergency alignment is clinically enough
+- separate partial emergency-screen coverage from complete direct-comparison coverage
+- defer generic-question scoring on rows where the accepted answer is already a broad emergency screen
+
+This package is fixture normalization only. No runtime files are touched.

--- a/docs/clinical-intelligence/shadow-planner-expected-outcome-normalization-kimi.md
+++ b/docs/clinical-intelligence/shadow-planner-expected-outcome-normalization-kimi.md
@@ -12,7 +12,12 @@ It does not change eval code, planner behavior, complaint adapter behavior, ques
 
 ## Purpose
 
-The normalization pack adds a reviewable layer on top of `shadow-planner-expected-outcomes.json` so future eval reporting can separate true quality misses from clinically acceptable ambiguity.
+The normalization pack adds a reviewable layer on top of the merged shadow-planner eval surface so future report-only evaluation can separate true quality misses from clinically acceptable ambiguity.
+
+The pack now covers both:
+
+- `shadow-planner-expected-outcomes.json` for the 33 base cases
+- `shadow-planner-edge-case-scenarios.json` for the 24 edge cases introduced into the combined eval run after VET-1444C
 
 Each normalization row records:
 
@@ -25,12 +30,13 @@ Each normalization row records:
 
 ## Normalization Rules
 
-The pack stays fully derived from the merged expected-outcome fixture:
+The pack stays fully derived from the merged source fixtures:
 
-- `caseId` matches one expected-outcome row exactly
-- `acceptableModuleIds` always includes the primary expected complaint module
+- `caseId` matches either one expected-outcome row or one edge-case scenario row exactly
+- base rows always include the primary expected complaint module from `shadow-planner-expected-outcomes.json`
+- edge rows mirror the accepted complaint-module set already carried by `expectedPrimaryComplaintModuleIds`
 - confusing multi-symptom rows may add registry-backed module alternatives
-- emergency alignment uses `alignment_only_ok` only when the outcome fixture already marks `shouldScreenEmergencyEarlier = true`
+- emergency alignment uses `alignment_only_ok` only when the source fixture already expects earlier emergency screening
 - red-flag coverage is `partial` when `emergency_global_screen` is already an accepted planned question
 - generic-question scoring is `exclude_for_now` on the same `emergency_global_screen` rows so future quality reports do not over-penalize emergency-first cases
 
@@ -38,32 +44,34 @@ This keeps the pack report-only. It does not alter evaluator logic or authorize 
 
 ## Coverage Summary
 
-- cases covered: 33
-- ambiguity cases: 15
-- emergency-alignment-only cases: 23
-- partial red-flag coverage cases: 28
-- generic-metric excluded cases: 28
+- cases covered: 57
+- ambiguity cases: 31
+- emergency-alignment-only cases: 39
+- partial red-flag coverage cases: 46
+- generic-metric excluded cases: 46
 
 The ambiguity split is intentional:
 
-- `strict_primary` for non-confuser rows
+- `strict_primary` for rows that still keep one module only
 - `same_module_only` for mixed wording that should still stay inside the primary module
-- `allow_module_alternatives` for mixed symptom rows where a different registry-backed module remains clinically acceptable
+- `allow_module_alternatives` for rows where a different registry-backed module remains clinically acceptable
 
 ## Ambiguity Guidance
 
 The pack explicitly opens alternate complaint modules only where the merged fixture wording supports real overlap, for example:
 
-- heat plus vomiting can remain heat-first while still accepting `gi_vomiting_diarrhea`
-- trauma plus limping can remain trauma-first while still accepting `limping_mobility_pain`
-- facial swelling plus vomiting can remain skin-first while still accepting respiratory or GI module matches
-- collapse or seizure wording can accept either neuro-first or collapse-first framing
+- heat plus breathing ambiguity can keep both `heatstroke_heat_exposure` and `respiratory_distress` acceptable
+- trauma plus limping can keep both `trauma_bleeding_wound` and `limping_mobility_pain` acceptable
+- collapse and seizure uncertainty can keep both `collapse_weakness` and `seizure_collapse_neuro` acceptable
+- multi-symptom emergency blends can keep toxin, collapse, heat, and GI module matches simultaneously acceptable
+
+Most ambiguity cases are the 31 rows marked `isConfusingMultiSymptom` across the base and edge packs. One additional edge row, `edge_limping_sore_vs_no_weight`, stays non-confuser by fixture label but still allows both `limping_mobility_pain` and `trauma_bleeding_wound` because the merged edge-case pack already treats either framing as acceptable.
 
 Rows that stay `same_module_only` still acknowledge mixed symptom language, but they do not yet justify a different module expectation.
 
 ## Emergency And Red-Flag Interpretation
 
-Some rows should not require the exact same planned question to count as a good result. When the outcome fixture already expects earlier emergency screening, `alignment_only_ok` means any accepted emergency-first path is sufficient even if the chosen question card differs.
+Some rows should not require the exact same planned question to count as a good result. When the merged source already expects earlier emergency screening, `alignment_only_ok` means any accepted emergency-first path is sufficient even if the chosen question card differs.
 
 Rows that already accept `emergency_global_screen` are normalized as:
 
@@ -76,16 +84,16 @@ That combination is deliberate. A global emergency screen can preserve safe red-
 
 The normalization pack test verifies that:
 
-- the fixture stays 1:1 with `shadow-planner-expected-outcomes.json`
+- the fixture stays 1:1 with the 33 base expected-outcome rows plus the 24 edge-case scenario rows
 - every accepted module exists in the complaint-module registry
-- ambiguity counts and spot-check alternatives remain stable
+- ambiguity counts and spot-check alternatives remain stable across the combined 57-case surface
 - emergency-alignment-only rows track the existing emergency expectation exactly
 - partial red-flag coverage and generic-metric exclusion stay tied to `emergency_global_screen`
 - notes stay free of diagnosis or treatment instructions
 
 ## Intended Evaluation Use
 
-Future report-only eval work can combine this pack with the outcome pack to:
+Future report-only eval work can combine this pack with the existing base and edge fixture packs to:
 
 - distinguish acceptable module ambiguity from true module misses
 - avoid over-counting exact-question misses when emergency alignment is clinically enough

--- a/tests/clinical-intelligence/shadow-planner-expected-outcome-normalization-pack.test.ts
+++ b/tests/clinical-intelligence/shadow-planner-expected-outcome-normalization-pack.test.ts
@@ -1,3 +1,4 @@
+import edgeCases from "../fixtures/clinical-intelligence/shadow-planner-edge-case-scenarios.json";
 import normalizationRows from "../fixtures/clinical-intelligence/shadow-planner-expected-outcome-normalization.json";
 import outcomes from "../fixtures/clinical-intelligence/shadow-planner-expected-outcomes.json";
 import scenarios from "../fixtures/clinical-intelligence/shadow-planner-scenarios.json";
@@ -29,6 +30,18 @@ type ShadowPlannerExpectedOutcome = {
   expectedComplaintModuleId: string;
   acceptablePlannedQuestionIds: string[];
   shouldScreenEmergencyEarlier: boolean;
+};
+
+type ShadowPlannerEdgeCaseScenario = {
+  caseId: string;
+  expectedPrimaryComplaintModuleIds: string[];
+  acceptablePlannedQuestionIds: string[];
+  shouldPreferEmergencyScreen: boolean;
+  repeatedQuestionSetup: {
+    askedQuestionIds: string[];
+    answeredQuestionIds: string[];
+  } | null;
+  isConfusingMultiSymptom: boolean;
 };
 
 type ShadowPlannerExpectedOutcomeNormalization = {
@@ -64,23 +77,22 @@ const OWNER_FACING_CLAIM_PATTERNS = [
 
 const scenarioFixture = scenarios as ShadowPlannerScenario[];
 const outcomeFixture = outcomes as ShadowPlannerExpectedOutcome[];
+const edgeScenarioFixture = edgeCases as ShadowPlannerEdgeCaseScenario[];
 const normalizationFixture =
   normalizationRows as ShadowPlannerExpectedOutcomeNormalization[];
 
-function getScenarioByCaseId(caseId: string): ShadowPlannerScenario {
-  const scenario = scenarioFixture.find((row) => row.caseId === caseId);
-  if (!scenario) {
-    throw new Error(`Missing scenario for ${caseId}`);
-  }
-  return scenario;
+function getScenarioByCaseId(caseId: string): ShadowPlannerScenario | null {
+  return scenarioFixture.find((row) => row.caseId === caseId) ?? null;
 }
 
-function getOutcomeByCaseId(caseId: string): ShadowPlannerExpectedOutcome {
-  const outcome = outcomeFixture.find((row) => row.caseId === caseId);
-  if (!outcome) {
-    throw new Error(`Missing expected outcome for ${caseId}`);
-  }
-  return outcome;
+function getOutcomeByCaseId(caseId: string): ShadowPlannerExpectedOutcome | null {
+  return outcomeFixture.find((row) => row.caseId === caseId) ?? null;
+}
+
+function getEdgeScenarioByCaseId(
+  caseId: string
+): ShadowPlannerEdgeCaseScenario | null {
+  return edgeScenarioFixture.find((row) => row.caseId === caseId) ?? null;
 }
 
 function getNormalizationRow(
@@ -93,10 +105,68 @@ function getNormalizationRow(
   return row;
 }
 
+function getExpectedModuleIds(caseId: string): string[] {
+  const outcome = getOutcomeByCaseId(caseId);
+  if (outcome) {
+    return [outcome.expectedComplaintModuleId];
+  }
+
+  const edgeScenario = getEdgeScenarioByCaseId(caseId);
+  if (edgeScenario) {
+    return edgeScenario.expectedPrimaryComplaintModuleIds;
+  }
+
+  throw new Error(`Missing source fixture row for ${caseId}`);
+}
+
+function getAcceptableQuestionIds(caseId: string): string[] {
+  const outcome = getOutcomeByCaseId(caseId);
+  if (outcome) {
+    return outcome.acceptablePlannedQuestionIds;
+  }
+
+  const edgeScenario = getEdgeScenarioByCaseId(caseId);
+  if (edgeScenario) {
+    return edgeScenario.acceptablePlannedQuestionIds;
+  }
+
+  throw new Error(`Missing source fixture row for ${caseId}`);
+}
+
+function shouldPreferEmergency(caseId: string): boolean {
+  const outcome = getOutcomeByCaseId(caseId);
+  if (outcome) {
+    return outcome.shouldScreenEmergencyEarlier;
+  }
+
+  const edgeScenario = getEdgeScenarioByCaseId(caseId);
+  if (edgeScenario) {
+    return edgeScenario.shouldPreferEmergencyScreen;
+  }
+
+  throw new Error(`Missing source fixture row for ${caseId}`);
+}
+
+function isConfusingMultiSymptom(caseId: string): boolean {
+  const scenario = getScenarioByCaseId(caseId);
+  if (scenario) {
+    return scenario.isConfusingMultiSymptom;
+  }
+
+  const edgeScenario = getEdgeScenarioByCaseId(caseId);
+  if (edgeScenario) {
+    return edgeScenario.isConfusingMultiSymptom;
+  }
+
+  throw new Error(`Missing source fixture row for ${caseId}`);
+}
+
 describe("shadow planner expected outcome normalization pack", () => {
-  it("packages one normalization row for every expected outcome row", () => {
-    expect(normalizationFixture).toHaveLength(33);
-    expect(normalizationFixture).toHaveLength(outcomeFixture.length);
+  it("packages one normalization row for every base expected outcome row and edge-case scenario row", () => {
+    expect(normalizationFixture).toHaveLength(57);
+    expect(normalizationFixture).toHaveLength(
+      outcomeFixture.length + edgeScenarioFixture.length
+    );
 
     const caseIds = new Set<string>();
     const registeredModuleIds = new Set(
@@ -109,12 +179,18 @@ describe("shadow planner expected outcome normalization pack", () => {
       expect(caseIds.has(row.caseId)).toBe(false);
       caseIds.add(row.caseId);
 
-      const outcome = getOutcomeByCaseId(row.caseId);
+      const expectedModuleIds = getExpectedModuleIds(row.caseId);
 
       expect(row.acceptableModuleIds.length).toBeGreaterThan(0);
-      expect(row.acceptableModuleIds).toContain(outcome.expectedComplaintModuleId);
+      expect(row.acceptableModuleIds).toEqual(
+        expect.arrayContaining(expectedModuleIds)
+      );
       expect(row.notes.trim()).toBe(row.notes);
       expect(row.notes.length).toBeGreaterThan(20);
+
+      if (row.caseId.startsWith("edge_")) {
+        expect(row.acceptableModuleIds).toEqual(expectedModuleIds);
+      }
 
       for (const moduleId of row.acceptableModuleIds) {
         expect(registeredModuleIds.has(moduleId)).toBe(true);
@@ -122,39 +198,32 @@ describe("shadow planner expected outcome normalization pack", () => {
     }
   });
 
-  it("normalizes every confusing multi-symptom row and preserves strict primary handling for non-confusers", () => {
-    const confuserRows = normalizationFixture.filter((row) => {
-      const scenario = getScenarioByCaseId(row.caseId);
-      return scenario.isConfusingMultiSymptom;
-    });
+  it("normalizes ambiguity across the merged 57-case eval surface without collapsing valid edge-case alternatives", () => {
+    const confuserRows = normalizationFixture.filter((row) =>
+      isConfusingMultiSymptom(row.caseId)
+    );
     const strictPrimaryRows = normalizationFixture.filter(
       (row) => row.ambiguityDisposition === "strict_primary"
     );
+    const allowAlternativeRows = normalizationFixture.filter(
+      (row) => row.ambiguityDisposition === "allow_module_alternatives"
+    );
 
-    expect(confuserRows).toHaveLength(15);
+    expect(confuserRows).toHaveLength(31);
+    expect(allowAlternativeRows).toHaveLength(29);
 
     for (const row of confuserRows) {
       expect(row.ambiguityDisposition).not.toBe("strict_primary");
     }
 
     for (const row of strictPrimaryRows) {
-      const scenario = getScenarioByCaseId(row.caseId);
-      expect(scenario.isConfusingMultiSymptom).toBe(false);
-      expect(row.acceptableModuleIds).toEqual([
-        getOutcomeByCaseId(row.caseId).expectedComplaintModuleId,
-      ]);
+      expect(isConfusingMultiSymptom(row.caseId)).toBe(false);
+      expect(row.acceptableModuleIds).toEqual(getExpectedModuleIds(row.caseId));
     }
 
     expect(
-      normalizationFixture.filter(
-        (row) => row.ambiguityDisposition === "allow_module_alternatives"
-      )
-    ).toHaveLength(12);
-
-    expect(
-      getNormalizationRow(
-        "heatstroke_heat_exposure_03_heat_plus_vomit_confuser"
-      ).acceptableModuleIds
+      getNormalizationRow("heatstroke_heat_exposure_03_heat_plus_vomit_confuser")
+        .acceptableModuleIds
     ).toEqual(
       expect.arrayContaining([
         "heatstroke_heat_exposure",
@@ -194,9 +263,8 @@ describe("shadow planner expected outcome normalization pack", () => {
     );
 
     expect(
-      getNormalizationRow(
-        "urinary_obstruction_02_accidents_blood_straining"
-      ).ambiguityDisposition
+      getNormalizationRow("urinary_obstruction_02_accidents_blood_straining")
+        .ambiguityDisposition
     ).toBe("same_module_only");
     expect(
       getNormalizationRow("respiratory_distress_02_cough_and_blue_tongue")
@@ -206,26 +274,68 @@ describe("shadow planner expected outcome normalization pack", () => {
       getNormalizationRow("gi_vomiting_diarrhea_02_bloody_diarrhea")
         .ambiguityDisposition
     ).toBe("same_module_only");
+
+    expect(
+      getNormalizationRow("edge_heat_not_sure_breathing_or_panting")
+        .acceptableModuleIds
+    ).toEqual(
+      expect.arrayContaining([
+        "heatstroke_heat_exposure",
+        "respiratory_distress",
+      ])
+    );
+    expect(
+      getNormalizationRow("edge_multi_vomit_weak_heat_toxin")
+        .acceptableModuleIds
+    ).toEqual(
+      expect.arrayContaining([
+        "toxin_poisoning_exposure",
+        "collapse_weakness",
+        "heatstroke_heat_exposure",
+        "gi_vomiting_diarrhea",
+      ])
+    );
+
+    const limpingEdgeScenario = getEdgeScenarioByCaseId(
+      "edge_limping_sore_vs_no_weight"
+    );
+    if (!limpingEdgeScenario) {
+      throw new Error("Missing edge_limping_sore_vs_no_weight");
+    }
+
+    expect(limpingEdgeScenario.isConfusingMultiSymptom).toBe(false);
+    expect(
+      getNormalizationRow("edge_limping_sore_vs_no_weight")
+        .ambiguityDisposition
+    ).toBe("allow_module_alternatives");
+    expect(
+      getNormalizationRow("edge_limping_sore_vs_no_weight")
+        .acceptableModuleIds
+    ).toEqual(
+      expect.arrayContaining([
+        "limping_mobility_pain",
+        "trauma_bleeding_wound",
+      ])
+    );
   });
 
-  it("marks emergency-alignment-only rows directly from the expected outcome emergency signal", () => {
+  it("marks emergency-alignment-only rows directly from the merged emergency preference signal", () => {
     const alignmentOnlyRows = normalizationFixture.filter(
       (row) => row.emergencyAlignmentDisposition === "alignment_only_ok"
     );
 
-    expect(alignmentOnlyRows).toHaveLength(23);
+    expect(alignmentOnlyRows).toHaveLength(39);
 
     for (const row of normalizationFixture) {
-      const outcome = getOutcomeByCaseId(row.caseId);
       expect(row.emergencyAlignmentDisposition).toBe(
-        outcome.shouldScreenEmergencyEarlier
+        shouldPreferEmergency(row.caseId)
           ? "alignment_only_ok"
           : "question_match_required"
       );
     }
   });
 
-  it("marks partial red-flag coverage and generic scoring exclusions only where the canonical global emergency screen is already acceptable", () => {
+  it("marks partial red-flag coverage and generic scoring exclusions only where the merged source already accepts the global emergency screen", () => {
     const partialRows = normalizationFixture.filter(
       (row) => row.redFlagCoverageExpectation === "partial"
     );
@@ -233,13 +343,12 @@ describe("shadow planner expected outcome normalization pack", () => {
       (row) => row.genericQuestionScoring === "exclude_for_now"
     );
 
-    expect(partialRows).toHaveLength(28);
-    expect(excludedGenericRows).toHaveLength(28);
+    expect(partialRows).toHaveLength(46);
+    expect(excludedGenericRows).toHaveLength(46);
 
     for (const row of normalizationFixture) {
-      const outcome = getOutcomeByCaseId(row.caseId);
       const acceptsGlobalEmergencyScreen =
-        outcome.acceptablePlannedQuestionIds.includes("emergency_global_screen");
+        getAcceptableQuestionIds(row.caseId).includes("emergency_global_screen");
 
       expect(row.redFlagCoverageExpectation).toBe(
         acceptsGlobalEmergencyScreen ? "partial" : "complete"

--- a/tests/clinical-intelligence/shadow-planner-expected-outcome-normalization-pack.test.ts
+++ b/tests/clinical-intelligence/shadow-planner-expected-outcome-normalization-pack.test.ts
@@ -1,0 +1,260 @@
+import normalizationRows from "../fixtures/clinical-intelligence/shadow-planner-expected-outcome-normalization.json";
+import outcomes from "../fixtures/clinical-intelligence/shadow-planner-expected-outcomes.json";
+import scenarios from "../fixtures/clinical-intelligence/shadow-planner-scenarios.json";
+
+import { getComplaintModules } from "@/lib/clinical-intelligence/complaint-modules";
+
+type AmbiguityDisposition =
+  | "strict_primary"
+  | "same_module_only"
+  | "allow_module_alternatives";
+
+type EmergencyAlignmentDisposition =
+  | "question_match_required"
+  | "alignment_only_ok";
+
+type RedFlagCoverageExpectation = "complete" | "partial";
+
+type GenericQuestionScoring = "include" | "exclude_for_now";
+
+type ShadowPlannerScenario = {
+  caseId: string;
+  expectedComplaintModuleId: string;
+  acceptableFirstQuestionIds: string[];
+  isConfusingMultiSymptom: boolean;
+};
+
+type ShadowPlannerExpectedOutcome = {
+  caseId: string;
+  expectedComplaintModuleId: string;
+  acceptablePlannedQuestionIds: string[];
+  shouldScreenEmergencyEarlier: boolean;
+};
+
+type ShadowPlannerExpectedOutcomeNormalization = {
+  caseId: string;
+  acceptableModuleIds: string[];
+  ambiguityDisposition: AmbiguityDisposition;
+  emergencyAlignmentDisposition: EmergencyAlignmentDisposition;
+  redFlagCoverageExpectation: RedFlagCoverageExpectation;
+  genericQuestionScoring: GenericQuestionScoring;
+  notes: string;
+};
+
+const REQUIRED_KEYS = [
+  "acceptableModuleIds",
+  "ambiguityDisposition",
+  "caseId",
+  "emergencyAlignmentDisposition",
+  "genericQuestionScoring",
+  "notes",
+  "redFlagCoverageExpectation",
+].sort();
+
+const OWNER_FACING_CLAIM_PATTERNS = [
+  /\bdiagnos(?:e|is|ed|ing)\b/i,
+  /\btreat(?:ment|ed|ing|s)?\b/i,
+  /\bcure(?:d|s)?\b/i,
+  /\bprescri(?:be|bed|ption)\b/i,
+  /\bantibiotic\b/i,
+  /\bsteroid\b/i,
+  /\bsurgery\b/i,
+  /\bdos(?:e|age)\b/i,
+];
+
+const scenarioFixture = scenarios as ShadowPlannerScenario[];
+const outcomeFixture = outcomes as ShadowPlannerExpectedOutcome[];
+const normalizationFixture =
+  normalizationRows as ShadowPlannerExpectedOutcomeNormalization[];
+
+function getScenarioByCaseId(caseId: string): ShadowPlannerScenario {
+  const scenario = scenarioFixture.find((row) => row.caseId === caseId);
+  if (!scenario) {
+    throw new Error(`Missing scenario for ${caseId}`);
+  }
+  return scenario;
+}
+
+function getOutcomeByCaseId(caseId: string): ShadowPlannerExpectedOutcome {
+  const outcome = outcomeFixture.find((row) => row.caseId === caseId);
+  if (!outcome) {
+    throw new Error(`Missing expected outcome for ${caseId}`);
+  }
+  return outcome;
+}
+
+function getNormalizationRow(
+  caseId: string
+): ShadowPlannerExpectedOutcomeNormalization {
+  const row = normalizationFixture.find((item) => item.caseId === caseId);
+  if (!row) {
+    throw new Error(`Missing normalization row for ${caseId}`);
+  }
+  return row;
+}
+
+describe("shadow planner expected outcome normalization pack", () => {
+  it("packages one normalization row for every expected outcome row", () => {
+    expect(normalizationFixture).toHaveLength(33);
+    expect(normalizationFixture).toHaveLength(outcomeFixture.length);
+
+    const caseIds = new Set<string>();
+    const registeredModuleIds = new Set(
+      getComplaintModules().map((complaintModule) => complaintModule.id)
+    );
+
+    for (const row of normalizationFixture) {
+      expect(Object.keys(row).sort()).toEqual(REQUIRED_KEYS);
+      expect(row.caseId).toMatch(/^[a-z0-9_]+$/);
+      expect(caseIds.has(row.caseId)).toBe(false);
+      caseIds.add(row.caseId);
+
+      const outcome = getOutcomeByCaseId(row.caseId);
+
+      expect(row.acceptableModuleIds.length).toBeGreaterThan(0);
+      expect(row.acceptableModuleIds).toContain(outcome.expectedComplaintModuleId);
+      expect(row.notes.trim()).toBe(row.notes);
+      expect(row.notes.length).toBeGreaterThan(20);
+
+      for (const moduleId of row.acceptableModuleIds) {
+        expect(registeredModuleIds.has(moduleId)).toBe(true);
+      }
+    }
+  });
+
+  it("normalizes every confusing multi-symptom row and preserves strict primary handling for non-confusers", () => {
+    const confuserRows = normalizationFixture.filter((row) => {
+      const scenario = getScenarioByCaseId(row.caseId);
+      return scenario.isConfusingMultiSymptom;
+    });
+    const strictPrimaryRows = normalizationFixture.filter(
+      (row) => row.ambiguityDisposition === "strict_primary"
+    );
+
+    expect(confuserRows).toHaveLength(15);
+
+    for (const row of confuserRows) {
+      expect(row.ambiguityDisposition).not.toBe("strict_primary");
+    }
+
+    for (const row of strictPrimaryRows) {
+      const scenario = getScenarioByCaseId(row.caseId);
+      expect(scenario.isConfusingMultiSymptom).toBe(false);
+      expect(row.acceptableModuleIds).toEqual([
+        getOutcomeByCaseId(row.caseId).expectedComplaintModuleId,
+      ]);
+    }
+
+    expect(
+      normalizationFixture.filter(
+        (row) => row.ambiguityDisposition === "allow_module_alternatives"
+      )
+    ).toHaveLength(12);
+
+    expect(
+      getNormalizationRow(
+        "heatstroke_heat_exposure_03_heat_plus_vomit_confuser"
+      ).acceptableModuleIds
+    ).toEqual(
+      expect.arrayContaining([
+        "heatstroke_heat_exposure",
+        "gi_vomiting_diarrhea",
+      ])
+    );
+    expect(
+      getNormalizationRow(
+        "trauma_bleeding_wound_03_limping_after_fall_confuser"
+      ).acceptableModuleIds
+    ).toEqual(
+      expect.arrayContaining([
+        "trauma_bleeding_wound",
+        "limping_mobility_pain",
+      ])
+    );
+    expect(
+      getNormalizationRow(
+        "respiratory_distress_03_fast_breathing_after_heat_confuser"
+      ).acceptableModuleIds
+    ).toEqual(
+      expect.arrayContaining([
+        "respiratory_distress",
+        "heatstroke_heat_exposure",
+      ])
+    );
+    expect(
+      getNormalizationRow(
+        "skin_itching_allergy_03_face_swelling_and_vomit_confuser"
+      ).acceptableModuleIds
+    ).toEqual(
+      expect.arrayContaining([
+        "skin_itching_allergy",
+        "respiratory_distress",
+        "gi_vomiting_diarrhea",
+      ])
+    );
+
+    expect(
+      getNormalizationRow(
+        "urinary_obstruction_02_accidents_blood_straining"
+      ).ambiguityDisposition
+    ).toBe("same_module_only");
+    expect(
+      getNormalizationRow("respiratory_distress_02_cough_and_blue_tongue")
+        .ambiguityDisposition
+    ).toBe("same_module_only");
+    expect(
+      getNormalizationRow("gi_vomiting_diarrhea_02_bloody_diarrhea")
+        .ambiguityDisposition
+    ).toBe("same_module_only");
+  });
+
+  it("marks emergency-alignment-only rows directly from the expected outcome emergency signal", () => {
+    const alignmentOnlyRows = normalizationFixture.filter(
+      (row) => row.emergencyAlignmentDisposition === "alignment_only_ok"
+    );
+
+    expect(alignmentOnlyRows).toHaveLength(23);
+
+    for (const row of normalizationFixture) {
+      const outcome = getOutcomeByCaseId(row.caseId);
+      expect(row.emergencyAlignmentDisposition).toBe(
+        outcome.shouldScreenEmergencyEarlier
+          ? "alignment_only_ok"
+          : "question_match_required"
+      );
+    }
+  });
+
+  it("marks partial red-flag coverage and generic scoring exclusions only where the canonical global emergency screen is already acceptable", () => {
+    const partialRows = normalizationFixture.filter(
+      (row) => row.redFlagCoverageExpectation === "partial"
+    );
+    const excludedGenericRows = normalizationFixture.filter(
+      (row) => row.genericQuestionScoring === "exclude_for_now"
+    );
+
+    expect(partialRows).toHaveLength(28);
+    expect(excludedGenericRows).toHaveLength(28);
+
+    for (const row of normalizationFixture) {
+      const outcome = getOutcomeByCaseId(row.caseId);
+      const acceptsGlobalEmergencyScreen =
+        outcome.acceptablePlannedQuestionIds.includes("emergency_global_screen");
+
+      expect(row.redFlagCoverageExpectation).toBe(
+        acceptsGlobalEmergencyScreen ? "partial" : "complete"
+      );
+      expect(row.genericQuestionScoring).toBe(
+        acceptsGlobalEmergencyScreen ? "exclude_for_now" : "include"
+      );
+    }
+  });
+
+  it("keeps normalization notes free of diagnosis or treatment instructions", () => {
+    for (const row of normalizationFixture) {
+      for (const pattern of OWNER_FACING_CLAIM_PATTERNS) {
+        expect(row.notes).not.toMatch(pattern);
+      }
+    }
+  });
+});

--- a/tests/fixtures/clinical-intelligence/shadow-planner-expected-outcome-normalization.json
+++ b/tests/fixtures/clinical-intelligence/shadow-planner-expected-outcome-normalization.json
@@ -374,5 +374,289 @@
     "redFlagCoverageExpectation": "complete",
     "genericQuestionScoring": "include",
     "notes": "Mixed symptom wording can reasonably open trauma_bleeding_wound as alternate complaint-module matches while keeping the primary safety screen in scope. The first planned question should still come from the explicit accepted question set for this case. Red-flag coverage stays complete because the accepted first-question set is already specific enough for direct comparison. Generic-question scoring stays in scope because this row expects a specific targeted first question rather than a catch-all emergency screen."
+  },
+  {
+    "caseId": "edge_heat_mild_after_walk_vs_hard_panting",
+    "acceptableModuleIds": [
+      "heatstroke_heat_exposure",
+      "respiratory_distress"
+    ],
+    "ambiguityDisposition": "allow_module_alternatives",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "complete",
+    "genericQuestionScoring": "include",
+    "notes": "This edge-case row keeps heatstroke_heat_exposure and respiratory_distress as acceptable complaint-module matches because the merged edge-case fixture already regards that overlap as clinically acceptable on the first turn. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage stays complete because the accepted first-question set is already specific enough for direct comparison. Generic-question scoring stays in scope because this row expects a specific targeted first question rather than a catch-all emergency screen."
+  },
+  {
+    "caseId": "edge_heat_not_sure_breathing_or_panting",
+    "acceptableModuleIds": [
+      "heatstroke_heat_exposure",
+      "respiratory_distress"
+    ],
+    "ambiguityDisposition": "allow_module_alternatives",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This edge-case row keeps heatstroke_heat_exposure and respiratory_distress as acceptable complaint-module matches because the merged edge-case fixture already regards that overlap as clinically acceptable on the first turn. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "edge_trauma_small_scrape_vs_steady_bleed",
+    "acceptableModuleIds": [
+      "trauma_bleeding_wound",
+      "limping_mobility_pain"
+    ],
+    "ambiguityDisposition": "allow_module_alternatives",
+    "emergencyAlignmentDisposition": "question_match_required",
+    "redFlagCoverageExpectation": "complete",
+    "genericQuestionScoring": "include",
+    "notes": "This edge-case row keeps trauma_bleeding_wound and limping_mobility_pain as acceptable complaint-module matches because the merged edge-case fixture already regards that overlap as clinically acceptable on the first turn. The first planned question should still come from the explicit accepted question set for this case. Red-flag coverage stays complete because the accepted first-question set is already specific enough for direct comparison. Generic-question scoring stays in scope because this row expects a specific targeted first question rather than a catch-all emergency screen."
+  },
+  {
+    "caseId": "edge_trauma_repeat_bleeding_avoidance",
+    "acceptableModuleIds": [
+      "trauma_bleeding_wound",
+      "limping_mobility_pain"
+    ],
+    "ambiguityDisposition": "allow_module_alternatives",
+    "emergencyAlignmentDisposition": "question_match_required",
+    "redFlagCoverageExpectation": "complete",
+    "genericQuestionScoring": "include",
+    "notes": "This edge-case row keeps trauma_bleeding_wound and limping_mobility_pain as acceptable complaint-module matches because the merged edge-case fixture already regards that overlap as clinically acceptable on the first turn. The merged edge-case fixture already carries repeated-question context for this row, but that setup does not widen the accepted complaint-module set. The first planned question should still come from the explicit accepted question set for this case. Red-flag coverage stays complete because the accepted first-question set is already specific enough for direct comparison. Generic-question scoring stays in scope because this row expects a specific targeted first question rather than a catch-all emergency screen."
+  },
+  {
+    "caseId": "edge_urinary_frequent_trips_vs_no_output",
+    "acceptableModuleIds": [
+      "urinary_obstruction"
+    ],
+    "ambiguityDisposition": "strict_primary",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This edge-case row keeps the primary complaint module as the only accepted module match for the current fixture wording. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "edge_urinary_repeat_straining_avoidance",
+    "acceptableModuleIds": [
+      "urinary_obstruction"
+    ],
+    "ambiguityDisposition": "strict_primary",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This edge-case row keeps the primary complaint module as the only accepted module match for the current fixture wording. The merged edge-case fixture already carries repeated-question context for this row, but that setup does not widen the accepted complaint-module set. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "edge_bloat_ate_fast_vs_unproductive_gagging",
+    "acceptableModuleIds": [
+      "bloat_gdv",
+      "gi_vomiting_diarrhea"
+    ],
+    "ambiguityDisposition": "allow_module_alternatives",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This edge-case row keeps bloat_gdv and gi_vomiting_diarrhea as acceptable complaint-module matches because the merged edge-case fixture already regards that overlap as clinically acceptable on the first turn. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "edge_bloat_not_sure_belly_size",
+    "acceptableModuleIds": [
+      "bloat_gdv"
+    ],
+    "ambiguityDisposition": "strict_primary",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This edge-case row keeps the primary complaint module as the only accepted module match for the current fixture wording. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "edge_respiratory_excited_vs_resting_fast_breath",
+    "acceptableModuleIds": [
+      "respiratory_distress",
+      "heatstroke_heat_exposure"
+    ],
+    "ambiguityDisposition": "allow_module_alternatives",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This edge-case row keeps respiratory_distress and heatstroke_heat_exposure as acceptable complaint-module matches because the merged edge-case fixture already regards that overlap as clinically acceptable on the first turn. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "edge_respiratory_repeat_breathing_avoidance",
+    "acceptableModuleIds": [
+      "respiratory_distress",
+      "collapse_weakness"
+    ],
+    "ambiguityDisposition": "allow_module_alternatives",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This edge-case row keeps respiratory_distress and collapse_weakness as acceptable complaint-module matches because the merged edge-case fixture already regards that overlap as clinically acceptable on the first turn. The merged edge-case fixture already carries repeated-question context for this row, but that setup does not widen the accepted complaint-module set. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "edge_collapse_tired_vs_cannot_stand",
+    "acceptableModuleIds": [
+      "collapse_weakness",
+      "heatstroke_heat_exposure"
+    ],
+    "ambiguityDisposition": "allow_module_alternatives",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This edge-case row keeps collapse_weakness and heatstroke_heat_exposure as acceptable complaint-module matches because the merged edge-case fixture already regards that overlap as clinically acceptable on the first turn. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "edge_collapse_not_sure_faint_or_slip",
+    "acceptableModuleIds": [
+      "collapse_weakness",
+      "seizure_collapse_neuro"
+    ],
+    "ambiguityDisposition": "allow_module_alternatives",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This edge-case row keeps collapse_weakness and seizure_collapse_neuro as acceptable complaint-module matches because the merged edge-case fixture already regards that overlap as clinically acceptable on the first turn. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "edge_seizure_shiver_vs_uncontrolled_shaking",
+    "acceptableModuleIds": [
+      "seizure_collapse_neuro",
+      "collapse_weakness"
+    ],
+    "ambiguityDisposition": "allow_module_alternatives",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This edge-case row keeps seizure_collapse_neuro and collapse_weakness as acceptable complaint-module matches because the merged edge-case fixture already regards that overlap as clinically acceptable on the first turn. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "edge_seizure_repeat_duration_avoidance",
+    "acceptableModuleIds": [
+      "seizure_collapse_neuro"
+    ],
+    "ambiguityDisposition": "strict_primary",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This edge-case row keeps the primary complaint module as the only accepted module match for the current fixture wording. The merged edge-case fixture already carries repeated-question context for this row, but that setup does not widen the accepted complaint-module set. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "edge_toxin_unknown_amount_vs_none_seen",
+    "acceptableModuleIds": [
+      "toxin_poisoning_exposure",
+      "gi_vomiting_diarrhea"
+    ],
+    "ambiguityDisposition": "allow_module_alternatives",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This edge-case row keeps toxin_poisoning_exposure and gi_vomiting_diarrhea as acceptable complaint-module matches because the merged edge-case fixture already regards that overlap as clinically acceptable on the first turn. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "edge_toxin_repeat_exposure_avoidance",
+    "acceptableModuleIds": [
+      "toxin_poisoning_exposure",
+      "collapse_weakness"
+    ],
+    "ambiguityDisposition": "allow_module_alternatives",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This edge-case row keeps toxin_poisoning_exposure and collapse_weakness as acceptable complaint-module matches because the merged edge-case fixture already regards that overlap as clinically acceptable on the first turn. The merged edge-case fixture already carries repeated-question context for this row, but that setup does not widen the accepted complaint-module set. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "edge_gi_one_vomit_vs_cannot_keep_water",
+    "acceptableModuleIds": [
+      "gi_vomiting_diarrhea"
+    ],
+    "ambiguityDisposition": "strict_primary",
+    "emergencyAlignmentDisposition": "question_match_required",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This edge-case row keeps the primary complaint module as the only accepted module match for the current fixture wording. The first planned question should still come from the explicit accepted question set for this case. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "edge_gi_blood_or_food_color_unclear",
+    "acceptableModuleIds": [
+      "gi_vomiting_diarrhea",
+      "toxin_poisoning_exposure"
+    ],
+    "ambiguityDisposition": "allow_module_alternatives",
+    "emergencyAlignmentDisposition": "question_match_required",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This edge-case row keeps gi_vomiting_diarrhea and toxin_poisoning_exposure as acceptable complaint-module matches because the merged edge-case fixture already regards that overlap as clinically acceptable on the first turn. The first planned question should still come from the explicit accepted question set for this case. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "edge_skin_hives_vs_regular_itch",
+    "acceptableModuleIds": [
+      "skin_itching_allergy"
+    ],
+    "ambiguityDisposition": "strict_primary",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This edge-case row keeps the primary complaint module as the only accepted module match for the current fixture wording. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "edge_skin_repeat_location_avoidance",
+    "acceptableModuleIds": [
+      "skin_itching_allergy"
+    ],
+    "ambiguityDisposition": "strict_primary",
+    "emergencyAlignmentDisposition": "question_match_required",
+    "redFlagCoverageExpectation": "complete",
+    "genericQuestionScoring": "include",
+    "notes": "This edge-case row keeps the primary complaint module as the only accepted module match for the current fixture wording. The merged edge-case fixture already carries repeated-question context for this row, but that setup does not widen the accepted complaint-module set. The first planned question should still come from the explicit accepted question set for this case. Red-flag coverage stays complete because the accepted first-question set is already specific enough for direct comparison. Generic-question scoring stays in scope because this row expects a specific targeted first question rather than a catch-all emergency screen."
+  },
+  {
+    "caseId": "edge_limping_sore_vs_no_weight",
+    "acceptableModuleIds": [
+      "limping_mobility_pain",
+      "trauma_bleeding_wound"
+    ],
+    "ambiguityDisposition": "allow_module_alternatives",
+    "emergencyAlignmentDisposition": "question_match_required",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This edge-case row keeps limping_mobility_pain and trauma_bleeding_wound as acceptable complaint-module matches because the merged edge-case fixture already regards that overlap as clinically acceptable on the first turn. The first planned question should still come from the explicit accepted question set for this case. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "edge_limping_not_sure_pain_or_weakness",
+    "acceptableModuleIds": [
+      "limping_mobility_pain",
+      "collapse_weakness"
+    ],
+    "ambiguityDisposition": "allow_module_alternatives",
+    "emergencyAlignmentDisposition": "question_match_required",
+    "redFlagCoverageExpectation": "complete",
+    "genericQuestionScoring": "include",
+    "notes": "This edge-case row keeps limping_mobility_pain and collapse_weakness as acceptable complaint-module matches because the merged edge-case fixture already regards that overlap as clinically acceptable on the first turn. The first planned question should still come from the explicit accepted question set for this case. Red-flag coverage stays complete because the accepted first-question set is already specific enough for direct comparison. Generic-question scoring stays in scope because this row expects a specific targeted first question rather than a catch-all emergency screen."
+  },
+  {
+    "caseId": "edge_multi_vomit_weak_heat_toxin",
+    "acceptableModuleIds": [
+      "toxin_poisoning_exposure",
+      "collapse_weakness",
+      "heatstroke_heat_exposure",
+      "gi_vomiting_diarrhea"
+    ],
+    "ambiguityDisposition": "allow_module_alternatives",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This edge-case row keeps toxin_poisoning_exposure, collapse_weakness, heatstroke_heat_exposure, and gi_vomiting_diarrhea as acceptable complaint-module matches because the merged edge-case fixture already regards that overlap as clinically acceptable on the first turn. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "edge_multi_diarrhea_limping_cut",
+    "acceptableModuleIds": [
+      "limping_mobility_pain",
+      "trauma_bleeding_wound",
+      "gi_vomiting_diarrhea"
+    ],
+    "ambiguityDisposition": "allow_module_alternatives",
+    "emergencyAlignmentDisposition": "question_match_required",
+    "redFlagCoverageExpectation": "complete",
+    "genericQuestionScoring": "include",
+    "notes": "This edge-case row keeps limping_mobility_pain, trauma_bleeding_wound, and gi_vomiting_diarrhea as acceptable complaint-module matches because the merged edge-case fixture already regards that overlap as clinically acceptable on the first turn. The first planned question should still come from the explicit accepted question set for this case. Red-flag coverage stays complete because the accepted first-question set is already specific enough for direct comparison. Generic-question scoring stays in scope because this row expects a specific targeted first question rather than a catch-all emergency screen."
   }
 ]

--- a/tests/fixtures/clinical-intelligence/shadow-planner-expected-outcome-normalization.json
+++ b/tests/fixtures/clinical-intelligence/shadow-planner-expected-outcome-normalization.json
@@ -1,0 +1,378 @@
+[
+  {
+    "caseId": "heatstroke_heat_exposure_01_hot_car_collapse",
+    "acceptableModuleIds": [
+      "heatstroke_heat_exposure"
+    ],
+    "ambiguityDisposition": "strict_primary",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This row keeps the primary complaint module as the only accepted module match for the current fixture wording. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "heatstroke_heat_exposure_02_brachy_panting_after_walk",
+    "acceptableModuleIds": [
+      "heatstroke_heat_exposure"
+    ],
+    "ambiguityDisposition": "strict_primary",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "complete",
+    "genericQuestionScoring": "include",
+    "notes": "This row keeps the primary complaint module as the only accepted module match for the current fixture wording. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage stays complete because the accepted first-question set is already specific enough for direct comparison. Generic-question scoring stays in scope because this row expects a specific targeted first question rather than a catch-all emergency screen."
+  },
+  {
+    "caseId": "heatstroke_heat_exposure_03_heat_plus_vomit_confuser",
+    "acceptableModuleIds": [
+      "heatstroke_heat_exposure",
+      "gi_vomiting_diarrhea"
+    ],
+    "ambiguityDisposition": "allow_module_alternatives",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "Mixed symptom wording can reasonably open gi_vomiting_diarrhea as alternate complaint-module matches while keeping the primary safety screen in scope. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "trauma_bleeding_wound_01_hit_by_car_pale",
+    "acceptableModuleIds": [
+      "trauma_bleeding_wound"
+    ],
+    "ambiguityDisposition": "strict_primary",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This row keeps the primary complaint module as the only accepted module match for the current fixture wording. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "trauma_bleeding_wound_02_bite_puncture_drip",
+    "acceptableModuleIds": [
+      "trauma_bleeding_wound"
+    ],
+    "ambiguityDisposition": "strict_primary",
+    "emergencyAlignmentDisposition": "question_match_required",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This row keeps the primary complaint module as the only accepted module match for the current fixture wording. The first planned question should still come from the explicit accepted question set for this case. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "trauma_bleeding_wound_03_limping_after_fall_confuser",
+    "acceptableModuleIds": [
+      "trauma_bleeding_wound",
+      "limping_mobility_pain"
+    ],
+    "ambiguityDisposition": "allow_module_alternatives",
+    "emergencyAlignmentDisposition": "question_match_required",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "Mixed symptom wording can reasonably open limping_mobility_pain as alternate complaint-module matches while keeping the primary safety screen in scope. The first planned question should still come from the explicit accepted question set for this case. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "urinary_obstruction_01_straining_no_output",
+    "acceptableModuleIds": [
+      "urinary_obstruction"
+    ],
+    "ambiguityDisposition": "strict_primary",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This row keeps the primary complaint module as the only accepted module match for the current fixture wording. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "urinary_obstruction_02_accidents_blood_straining",
+    "acceptableModuleIds": [
+      "urinary_obstruction"
+    ],
+    "ambiguityDisposition": "same_module_only",
+    "emergencyAlignmentDisposition": "question_match_required",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "Mixed symptom wording still stays inside the primary complaint module because the overlap does not justify a different module choice yet. The first planned question should still come from the explicit accepted question set for this case. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "urinary_obstruction_03_vomit_and_no_pee_confuser",
+    "acceptableModuleIds": [
+      "urinary_obstruction",
+      "gi_vomiting_diarrhea"
+    ],
+    "ambiguityDisposition": "allow_module_alternatives",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "Mixed symptom wording can reasonably open gi_vomiting_diarrhea as alternate complaint-module matches while keeping the primary safety screen in scope. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "bloat_gdv_01_retching_swollen_belly",
+    "acceptableModuleIds": [
+      "bloat_gdv"
+    ],
+    "ambiguityDisposition": "strict_primary",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This row keeps the primary complaint module as the only accepted module match for the current fixture wording. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "bloat_gdv_02_pacing_drooling_belly",
+    "acceptableModuleIds": [
+      "bloat_gdv"
+    ],
+    "ambiguityDisposition": "strict_primary",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This row keeps the primary complaint module as the only accepted module match for the current fixture wording. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "bloat_gdv_03_diarrhea_plus_retching_confuser",
+    "acceptableModuleIds": [
+      "bloat_gdv",
+      "gi_vomiting_diarrhea"
+    ],
+    "ambiguityDisposition": "allow_module_alternatives",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "Mixed symptom wording can reasonably open gi_vomiting_diarrhea as alternate complaint-module matches while keeping the primary safety screen in scope. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "respiratory_distress_01_open_mouth_breathing",
+    "acceptableModuleIds": [
+      "respiratory_distress"
+    ],
+    "ambiguityDisposition": "strict_primary",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This row keeps the primary complaint module as the only accepted module match for the current fixture wording. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "respiratory_distress_02_cough_and_blue_tongue",
+    "acceptableModuleIds": [
+      "respiratory_distress"
+    ],
+    "ambiguityDisposition": "same_module_only",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "Mixed symptom wording still stays inside the primary complaint module because the overlap does not justify a different module choice yet. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "respiratory_distress_03_fast_breathing_after_heat_confuser",
+    "acceptableModuleIds": [
+      "respiratory_distress",
+      "heatstroke_heat_exposure"
+    ],
+    "ambiguityDisposition": "allow_module_alternatives",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "Mixed symptom wording can reasonably open heatstroke_heat_exposure as alternate complaint-module matches while keeping the primary safety screen in scope. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "collapse_weakness_01_fainted_and_weak",
+    "acceptableModuleIds": [
+      "collapse_weakness"
+    ],
+    "ambiguityDisposition": "strict_primary",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This row keeps the primary complaint module as the only accepted module match for the current fixture wording. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "collapse_weakness_02_wobbly_pale",
+    "acceptableModuleIds": [
+      "collapse_weakness"
+    ],
+    "ambiguityDisposition": "strict_primary",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This row keeps the primary complaint module as the only accepted module match for the current fixture wording. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "collapse_weakness_03_vomit_then_weak_confuser",
+    "acceptableModuleIds": [
+      "collapse_weakness",
+      "gi_vomiting_diarrhea"
+    ],
+    "ambiguityDisposition": "allow_module_alternatives",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "Mixed symptom wording can reasonably open gi_vomiting_diarrhea as alternate complaint-module matches while keeping the primary safety screen in scope. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "seizure_collapse_neuro_01_long_shaking",
+    "acceptableModuleIds": [
+      "seizure_collapse_neuro"
+    ],
+    "ambiguityDisposition": "strict_primary",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This row keeps the primary complaint module as the only accepted module match for the current fixture wording. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "seizure_collapse_neuro_02_multiple_episodes",
+    "acceptableModuleIds": [
+      "seizure_collapse_neuro",
+      "collapse_weakness"
+    ],
+    "ambiguityDisposition": "allow_module_alternatives",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "Mixed symptom wording can reasonably open collapse_weakness as alternate complaint-module matches while keeping the primary safety screen in scope. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "seizure_collapse_neuro_03_collapse_or_seizure_unclear",
+    "acceptableModuleIds": [
+      "seizure_collapse_neuro",
+      "collapse_weakness"
+    ],
+    "ambiguityDisposition": "allow_module_alternatives",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "Mixed symptom wording can reasonably open collapse_weakness as alternate complaint-module matches while keeping the primary safety screen in scope. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "toxin_poisoning_exposure_01_chocolate_and_vomit",
+    "acceptableModuleIds": [
+      "toxin_poisoning_exposure",
+      "gi_vomiting_diarrhea"
+    ],
+    "ambiguityDisposition": "allow_module_alternatives",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "Mixed symptom wording can reasonably open gi_vomiting_diarrhea as alternate complaint-module matches while keeping the primary safety screen in scope. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "toxin_poisoning_exposure_02_rodent_bait_possible",
+    "acceptableModuleIds": [
+      "toxin_poisoning_exposure"
+    ],
+    "ambiguityDisposition": "strict_primary",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This row keeps the primary complaint module as the only accepted module match for the current fixture wording. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "toxin_poisoning_exposure_03_plant_and_wobbly_confuser",
+    "acceptableModuleIds": [
+      "toxin_poisoning_exposure",
+      "collapse_weakness"
+    ],
+    "ambiguityDisposition": "allow_module_alternatives",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "Mixed symptom wording can reasonably open collapse_weakness as alternate complaint-module matches while keeping the primary safety screen in scope. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "gi_vomiting_diarrhea_01_repeated_vomiting",
+    "acceptableModuleIds": [
+      "gi_vomiting_diarrhea"
+    ],
+    "ambiguityDisposition": "strict_primary",
+    "emergencyAlignmentDisposition": "question_match_required",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This row keeps the primary complaint module as the only accepted module match for the current fixture wording. The first planned question should still come from the explicit accepted question set for this case. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "gi_vomiting_diarrhea_02_bloody_diarrhea",
+    "acceptableModuleIds": [
+      "gi_vomiting_diarrhea"
+    ],
+    "ambiguityDisposition": "same_module_only",
+    "emergencyAlignmentDisposition": "question_match_required",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "Mixed symptom wording still stays inside the primary complaint module because the overlap does not justify a different module choice yet. The first planned question should still come from the explicit accepted question set for this case. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "gi_vomiting_diarrhea_03_water_comes_back_up",
+    "acceptableModuleIds": [
+      "gi_vomiting_diarrhea"
+    ],
+    "ambiguityDisposition": "strict_primary",
+    "emergencyAlignmentDisposition": "question_match_required",
+    "redFlagCoverageExpectation": "complete",
+    "genericQuestionScoring": "include",
+    "notes": "This row keeps the primary complaint module as the only accepted module match for the current fixture wording. The first planned question should still come from the explicit accepted question set for this case. Red-flag coverage stays complete because the accepted first-question set is already specific enough for direct comparison. Generic-question scoring stays in scope because this row expects a specific targeted first question rather than a catch-all emergency screen."
+  },
+  {
+    "caseId": "skin_itching_allergy_01_hives_after_sting",
+    "acceptableModuleIds": [
+      "skin_itching_allergy"
+    ],
+    "ambiguityDisposition": "strict_primary",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This row keeps the primary complaint module as the only accepted module match for the current fixture wording. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "skin_itching_allergy_02_paws_belly_itching",
+    "acceptableModuleIds": [
+      "skin_itching_allergy"
+    ],
+    "ambiguityDisposition": "strict_primary",
+    "emergencyAlignmentDisposition": "question_match_required",
+    "redFlagCoverageExpectation": "complete",
+    "genericQuestionScoring": "include",
+    "notes": "This row keeps the primary complaint module as the only accepted module match for the current fixture wording. The first planned question should still come from the explicit accepted question set for this case. Red-flag coverage stays complete because the accepted first-question set is already specific enough for direct comparison. Generic-question scoring stays in scope because this row expects a specific targeted first question rather than a catch-all emergency screen."
+  },
+  {
+    "caseId": "skin_itching_allergy_03_face_swelling_and_vomit_confuser",
+    "acceptableModuleIds": [
+      "skin_itching_allergy",
+      "respiratory_distress",
+      "gi_vomiting_diarrhea"
+    ],
+    "ambiguityDisposition": "allow_module_alternatives",
+    "emergencyAlignmentDisposition": "alignment_only_ok",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "Mixed symptom wording can reasonably open respiratory_distress, gi_vomiting_diarrhea as alternate complaint-module matches while keeping the primary safety screen in scope. Emergency-screen alignment is sufficient even if the first planned question differs from one specific card. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "limping_mobility_pain_01_non_weight_bearing",
+    "acceptableModuleIds": [
+      "limping_mobility_pain"
+    ],
+    "ambiguityDisposition": "strict_primary",
+    "emergencyAlignmentDisposition": "question_match_required",
+    "redFlagCoverageExpectation": "partial",
+    "genericQuestionScoring": "exclude_for_now",
+    "notes": "This row keeps the primary complaint module as the only accepted module match for the current fixture wording. The first planned question should still come from the explicit accepted question set for this case. Red-flag coverage is partial because the global emergency screen already captures the required urgent branch. Generic-question scoring stays excluded for now because a global emergency screen is already an accepted first move."
+  },
+  {
+    "caseId": "limping_mobility_pain_02_sudden_after_jump",
+    "acceptableModuleIds": [
+      "limping_mobility_pain"
+    ],
+    "ambiguityDisposition": "strict_primary",
+    "emergencyAlignmentDisposition": "question_match_required",
+    "redFlagCoverageExpectation": "complete",
+    "genericQuestionScoring": "include",
+    "notes": "This row keeps the primary complaint module as the only accepted module match for the current fixture wording. The first planned question should still come from the explicit accepted question set for this case. Red-flag coverage stays complete because the accepted first-question set is already specific enough for direct comparison. Generic-question scoring stays in scope because this row expects a specific targeted first question rather than a catch-all emergency screen."
+  },
+  {
+    "caseId": "limping_mobility_pain_03_limping_with_wound_confuser",
+    "acceptableModuleIds": [
+      "limping_mobility_pain",
+      "trauma_bleeding_wound"
+    ],
+    "ambiguityDisposition": "allow_module_alternatives",
+    "emergencyAlignmentDisposition": "question_match_required",
+    "redFlagCoverageExpectation": "complete",
+    "genericQuestionScoring": "include",
+    "notes": "Mixed symptom wording can reasonably open trauma_bleeding_wound as alternate complaint-module matches while keeping the primary safety screen in scope. The first planned question should still come from the explicit accepted question set for this case. Red-flag coverage stays complete because the accepted first-question set is already specific enough for direct comparison. Generic-question scoring stays in scope because this row expects a specific targeted first question rather than a catch-all emergency screen."
+  }
+]


### PR DESCRIPTION
## Summary
- publish the expected outcome normalization pack on top of fresh master after #444, #445, and #447
- extend the normalization fixture and guard to the merged 57-case eval surface by covering the 33 base outcome rows plus 24 edge-case scenario rows
- document the merged-surface normalization rules and updated report-only counts without touching eval or runtime code

## Validation
- npm test -- --runTestsByPath tests/clinical-intelligence/shadow-planner-expected-outcome-normalization-pack.test.ts
- npm test -- --runTestsByPath tests/clinical-intelligence/shadow-planner-scenario-pack.test.ts
- npm test -- --runTestsByPath tests/clinical-intelligence/shadow-planner-outcome-pack.test.ts
- npm test -- --runTestsByPath tests/clinical-intelligence/shadow-planner-edge-case-scenario-pack.test.ts
- npm run build