### PR TITLE
VET-1455K: Shadow Eval Failure Annotation Pack

### DIFF
--- a/docs/clinical-intelligence/shadow-eval-failure-annotation-pack-kimi.md
+++ b/docs/clinical-intelligence/shadow-eval-failure-annotation-pack-kimi.md
@@ -1,0 +1,133 @@
+# Shadow Eval Failure Annotation Pack (VET-1455K)
+
+## Scope
+
+This ticket adds packaging-only artifacts:
+
+- `tests/fixtures/clinical-intelligence/shadow-eval-failure-annotations.json`
+- `tests/clinical-intelligence/shadow-eval-failure-annotation-pack.test.ts`
+- `docs/clinical-intelligence/shadow-eval-failure-annotation-pack-kimi.md`
+
+It does not change eval code, planner behavior, adapter behavior, question cards,
+complaint modules, routing, runtime wiring, UI, env, infra, or workflows.
+
+## Purpose
+
+The normalized shadow eval summary still reports `57` failed cases. That raw list
+is too noisy to review directly because most rows share the same owner-facing
+result:
+
+- adapter complaint-module detection still lands inside the accepted module set
+- emergency alignment still stays intact
+- the planner still picks `emergency_global_screen`
+- the failure often comes from report-only scoring, missing edge normalization
+  application, or a narrow acceptable-question expectation
+
+This pack turns the current failed-case list into a reviewer-friendly annotation
+fixture so the next fix ticket can be targeted instead of inferred from raw
+metrics alone.
+
+## Annotation Shape
+
+Each row maps one failed eval case to:
+
+- `caseId`
+- `primaryFailureClass`
+- `secondaryFailureClasses`
+- `patchTarget`
+- `reviewerAction`
+- `safetyImpact`
+- `notes`
+
+The allowed primary classes stay intentionally narrow:
+
+- `fixture_ambiguity`
+- `report_only_quality_gap`
+- `adapter_selection_gap`
+- `red_flag_coverage_gap`
+- `repeated_metric_setup_gap`
+- `generic_metric_setup_gap`
+- `planner_improvement_candidate`
+
+In the current pack, the primary split is:
+
+- `report_only_quality_gap`: `46`
+- `planner_improvement_candidate`: `9`
+- `red_flag_coverage_gap`: `1`
+- `fixture_ambiguity`: `1`
+- `adapter_selection_gap`: `0`
+- `safetyImpact = blocker`: `0`
+
+## What The Split Means
+
+### Report-only quality gaps
+
+These rows should not drive immediate runtime work.
+
+They are dominated by two secondary tags:
+
+- `repeated_metric_setup_gap`: `39` rows
+- `generic_metric_setup_gap`: `29` rows
+
+That means the annotation pack is explicitly preserving the same conclusion from
+the earlier triage lane: the eval still over-penalizes the global emergency
+screen before repeat-state and edge normalization are fully honored.
+
+### Planner improvement candidates
+
+These are the rows where the planner still needs a real follow-up review because
+the global emergency screen is outside the explicit acceptable question set or
+the `selectedBecause` value is outside the accepted reasoning lane.
+
+Current planner-review rows:
+
+- `gi_vomiting_diarrhea_03_water_comes_back_up`
+- `skin_itching_allergy_02_paws_belly_itching`
+- `limping_mobility_pain_02_sudden_after_jump`
+- `limping_mobility_pain_03_limping_with_wound_confuser`
+- `edge_trauma_small_scrape_vs_steady_bleed`
+- `edge_trauma_repeat_bleeding_avoidance`
+- `edge_skin_repeat_location_avoidance`
+- `edge_limping_not_sure_pain_or_weakness`
+- `edge_multi_diarrhea_limping_cut`
+
+### Red-flag coverage gap
+
+Only one row is packaged as a direct red-flag coverage follow-up:
+
+- `heatstroke_heat_exposure_02_brachy_panting_after_walk`
+
+That row keeps emergency alignment, but the accepted emergency-first path still
+leaves `heatstroke_signs` and `brachycephalic_heat` under-screened.
+
+### Fixture ambiguity
+
+Only one row is packaged as a primary fixture-normalization ambiguity:
+
+- `edge_heat_mild_after_walk_vs_hard_panting`
+
+That row already has acceptable emergency alignment, but the explicit question
+set is still narrower than the live behavior the edge normalization note already
+describes.
+
+## Reviewer Guidance
+
+Use the annotation pack in this order:
+
+1. Start with any `planner_improvement_candidate` or `red_flag_coverage_gap`
+   rows. Those are the only rows that currently justify a concrete future planner
+   review.
+2. Keep `report_only_quality_gap` rows out of runtime queues unless the future
+   normalization or metric lane proves the same case still fails afterward.
+3. Treat `fixture_ambiguity` rows as expectation-shaping work first, not planner
+   regression proof.
+4. Ignore `adapter_selection_gap` for now because the live normalized summary
+   still shows `57/57` complaint-module matches.
+
+## Notes
+
+- The annotation pack is deterministic against the current `node
+  scripts/eval-shadow-planner-scenarios.ts --json` output.
+- The annotation pack is packaging-only and does not alter the eval harness.
+- The annotation pack keeps secondary setup-gap tags visible even when the
+  primary class is `report_only_quality_gap`.

--- a/tests/clinical-intelligence/shadow-eval-failure-annotation-pack.test.ts
+++ b/tests/clinical-intelligence/shadow-eval-failure-annotation-pack.test.ts
@@ -1,0 +1,257 @@
+import annotations from "../fixtures/clinical-intelligence/shadow-eval-failure-annotations.json";
+import edgeCases from "../fixtures/clinical-intelligence/shadow-planner-edge-case-scenarios.json";
+import normalizationRows from "../fixtures/clinical-intelligence/shadow-planner-expected-outcome-normalization.json";
+import outcomes from "../fixtures/clinical-intelligence/shadow-planner-expected-outcomes.json";
+import scenarios from "../fixtures/clinical-intelligence/shadow-planner-scenarios.json";
+
+import {
+  evaluateShadowPlannerScenarios,
+  type ShadowPlannerEdgeCaseScenarioFixture,
+  type ShadowPlannerExpectedOutcomeFixture,
+  type ShadowPlannerExpectedOutcomeNormalizationFixture,
+  type ShadowPlannerScenarioFixture,
+} from "@/lib/clinical-intelligence/shadow-planner-scenario-eval";
+
+type PrimaryFailureClass =
+  | "fixture_ambiguity"
+  | "report_only_quality_gap"
+  | "adapter_selection_gap"
+  | "red_flag_coverage_gap"
+  | "repeated_metric_setup_gap"
+  | "generic_metric_setup_gap"
+  | "planner_improvement_candidate";
+
+type PatchTarget =
+  | "fixture"
+  | "normalization"
+  | "adapter"
+  | "planner"
+  | "question_card"
+  | "no_patch_report_only";
+
+type SafetyImpact = "none" | "monitor" | "blocker";
+
+type ShadowEvalFailureAnnotation = {
+  caseId: string;
+  primaryFailureClass: PrimaryFailureClass;
+  secondaryFailureClasses: PrimaryFailureClass[];
+  patchTarget: PatchTarget;
+  reviewerAction: string;
+  safetyImpact: SafetyImpact;
+  notes: string;
+};
+
+const REQUIRED_KEYS = [
+  "caseId",
+  "notes",
+  "patchTarget",
+  "primaryFailureClass",
+  "reviewerAction",
+  "safetyImpact",
+  "secondaryFailureClasses",
+].sort();
+
+const PRIMARY_FAILURE_CLASSES: PrimaryFailureClass[] = [
+  "fixture_ambiguity",
+  "report_only_quality_gap",
+  "adapter_selection_gap",
+  "red_flag_coverage_gap",
+  "repeated_metric_setup_gap",
+  "generic_metric_setup_gap",
+  "planner_improvement_candidate",
+];
+
+const PATCH_TARGETS: PatchTarget[] = [
+  "fixture",
+  "normalization",
+  "adapter",
+  "planner",
+  "question_card",
+  "no_patch_report_only",
+];
+
+const SAFETY_IMPACTS: SafetyImpact[] = ["none", "monitor", "blocker"];
+
+const OWNER_FACING_CLAIM_PATTERNS = [
+  /\bdiagnos(?:e|is|ed|ing)\b/i,
+  /\btreat(?:ment|ed|ing|s)?\b/i,
+  /\bcure(?:d|s)?\b/i,
+  /\bprescri(?:be|bed|ption)\b/i,
+  /\bantibiotic\b/i,
+  /\bsteroid\b/i,
+  /\bsurgery\b/i,
+  /\bdos(?:e|age)\b/i,
+];
+
+const annotationFixture = annotations as ShadowEvalFailureAnnotation[];
+const scenarioFixture = scenarios as ShadowPlannerScenarioFixture[];
+const outcomeFixture = outcomes as ShadowPlannerExpectedOutcomeFixture[];
+const edgeScenarioFixture =
+  edgeCases as ShadowPlannerEdgeCaseScenarioFixture[];
+const normalizationFixture =
+  normalizationRows as ShadowPlannerExpectedOutcomeNormalizationFixture[];
+
+const evalReport = evaluateShadowPlannerScenarios({
+  scenarios: scenarioFixture,
+  expectedOutcomes: outcomeFixture,
+  edgeScenarios: edgeScenarioFixture,
+  normalizationRows: normalizationFixture,
+});
+
+function getAnnotation(caseId: string): ShadowEvalFailureAnnotation {
+  const row = annotationFixture.find((annotation) => annotation.caseId === caseId);
+  if (!row) {
+    throw new Error(`Missing annotation row for ${caseId}`);
+  }
+  return row;
+}
+
+function countByPrimaryFailureClass(
+  failureClass: PrimaryFailureClass
+): number {
+  return annotationFixture.filter(
+    (annotation) => annotation.primaryFailureClass === failureClass
+  ).length;
+}
+
+function countBySecondaryFailureClass(
+  failureClass: PrimaryFailureClass
+): number {
+  return annotationFixture.filter((annotation) =>
+    annotation.secondaryFailureClasses.includes(failureClass)
+  ).length;
+}
+
+describe("shadow eval failure annotation pack", () => {
+  it("annotates every live failed eval case exactly once with the required schema", () => {
+    const failedCaseIds = new Set(
+      evalReport.summary.failedCases.map((failedCase) => failedCase.caseId)
+    );
+    const annotationCaseIds = new Set<string>();
+
+    expect(annotationFixture).toHaveLength(57);
+    expect(annotationFixture).toHaveLength(evalReport.summary.failedCases.length);
+
+    for (const annotation of annotationFixture) {
+      expect(Object.keys(annotation).sort()).toEqual(REQUIRED_KEYS);
+      expect(annotation.caseId).toMatch(/^[a-z0-9_]+$/);
+      expect(annotationCaseIds.has(annotation.caseId)).toBe(false);
+      annotationCaseIds.add(annotation.caseId);
+
+      expect(failedCaseIds.has(annotation.caseId)).toBe(true);
+      expect(PRIMARY_FAILURE_CLASSES).toContain(annotation.primaryFailureClass);
+      expect(PATCH_TARGETS).toContain(annotation.patchTarget);
+      expect(SAFETY_IMPACTS).toContain(annotation.safetyImpact);
+      expect(new Set(annotation.secondaryFailureClasses).size).toBe(
+        annotation.secondaryFailureClasses.length
+      );
+      expect(annotation.secondaryFailureClasses).not.toContain(
+        annotation.primaryFailureClass
+      );
+      expect(annotation.reviewerAction.trim()).toBe(annotation.reviewerAction);
+      expect(annotation.reviewerAction.length).toBeGreaterThan(20);
+      expect(annotation.notes.trim()).toBe(annotation.notes);
+      expect(annotation.notes.length).toBeGreaterThan(40);
+
+      for (const failureClass of annotation.secondaryFailureClasses) {
+        expect(PRIMARY_FAILURE_CLASSES).toContain(failureClass);
+      }
+    }
+  });
+
+  it("tracks the live failed-case order from the current 57-case summary", () => {
+    expect(annotationFixture.map((annotation) => annotation.caseId)).toEqual(
+      evalReport.summary.failedCases.map((failedCase) => failedCase.caseId)
+    );
+  });
+
+  it("preserves the deterministic primary split with zero adapter or blocker rows", () => {
+    expect(countByPrimaryFailureClass("report_only_quality_gap")).toBe(46);
+    expect(countByPrimaryFailureClass("planner_improvement_candidate")).toBe(9);
+    expect(countByPrimaryFailureClass("red_flag_coverage_gap")).toBe(1);
+    expect(countByPrimaryFailureClass("fixture_ambiguity")).toBe(1);
+    expect(countByPrimaryFailureClass("adapter_selection_gap")).toBe(0);
+    expect(countByPrimaryFailureClass("repeated_metric_setup_gap")).toBe(0);
+    expect(countByPrimaryFailureClass("generic_metric_setup_gap")).toBe(0);
+
+    expect(
+      annotationFixture.filter(
+        (annotation) => annotation.safetyImpact === "monitor"
+      )
+    ).toHaveLength(9);
+    expect(
+      annotationFixture.filter(
+        (annotation) => annotation.safetyImpact === "blocker"
+      )
+    ).toHaveLength(0);
+  });
+
+  it("keeps repeat and generic setup debt visible as secondary classifications", () => {
+    expect(countBySecondaryFailureClass("repeated_metric_setup_gap")).toBe(39);
+    expect(countBySecondaryFailureClass("generic_metric_setup_gap")).toBe(29);
+    expect(countBySecondaryFailureClass("red_flag_coverage_gap")).toBe(27);
+    expect(countBySecondaryFailureClass("fixture_ambiguity")).toBe(31);
+  });
+
+  it("routes representative cases into the expected reviewer lanes", () => {
+    const heatCollapse = getAnnotation(
+      "heatstroke_heat_exposure_01_hot_car_collapse"
+    );
+    expect(heatCollapse).toMatchObject({
+      primaryFailureClass: "report_only_quality_gap",
+      patchTarget: "no_patch_report_only",
+      safetyImpact: "none",
+    });
+    expect(heatCollapse.secondaryFailureClasses).toEqual(
+      expect.arrayContaining(["repeated_metric_setup_gap"])
+    );
+
+    expect(getAnnotation("heatstroke_heat_exposure_02_brachy_panting_after_walk")).toMatchObject({
+      primaryFailureClass: "red_flag_coverage_gap",
+      patchTarget: "planner",
+      safetyImpact: "monitor",
+    });
+
+    expect(
+      getAnnotation("gi_vomiting_diarrhea_03_water_comes_back_up")
+    ).toMatchObject({
+      primaryFailureClass: "planner_improvement_candidate",
+      patchTarget: "planner",
+      safetyImpact: "monitor",
+    });
+
+    expect(
+      getAnnotation("edge_heat_mild_after_walk_vs_hard_panting")
+    ).toMatchObject({
+      primaryFailureClass: "fixture_ambiguity",
+      patchTarget: "normalization",
+      safetyImpact: "none",
+    });
+
+    const edgeUrinaryRepeat = getAnnotation(
+      "edge_urinary_repeat_straining_avoidance"
+    );
+    expect(edgeUrinaryRepeat).toMatchObject({
+      primaryFailureClass: "report_only_quality_gap",
+      patchTarget: "normalization",
+      safetyImpact: "none",
+    });
+    expect(edgeUrinaryRepeat.secondaryFailureClasses).toEqual(
+      expect.arrayContaining([
+        "repeated_metric_setup_gap",
+        "generic_metric_setup_gap",
+        "red_flag_coverage_gap",
+      ])
+    );
+  });
+
+  it("keeps reviewer-facing annotation text free of diagnosis or treatment language", () => {
+    for (const annotation of annotationFixture) {
+      const reviewerFacingText = `${annotation.reviewerAction} ${annotation.notes}`;
+
+      for (const pattern of OWNER_FACING_CLAIM_PATTERNS) {
+        expect(reviewerFacingText).not.toMatch(pattern);
+      }
+    }
+  });
+});

--- a/tests/fixtures/clinical-intelligence/shadow-eval-failure-annotations.json
+++ b/tests/fixtures/clinical-intelligence/shadow-eval-failure-annotations.json
@@ -1,0 +1,700 @@
+[
+  {
+    "caseId": "heatstroke_heat_exposure_01_hot_car_collapse",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap"
+    ],
+    "patchTarget": "no_patch_report_only",
+    "reviewerAction": "Count this as repeat-metric noise until the harness carries prior asked and answered state.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; normalization=strict_primary/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true"
+  },
+  {
+    "caseId": "heatstroke_heat_exposure_02_brachy_panting_after_walk",
+    "primaryFailureClass": "red_flag_coverage_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap",
+      "generic_metric_setup_gap"
+    ],
+    "patchTarget": "planner",
+    "reviewerAction": "Review whether the planner should escalate to a more specific registered question that screens the missing red flags.",
+    "safetyImpact": "monitor",
+    "notes": "normalizedReason=Missing required screened red flags: heatstroke_signs, brachycephalic_heat; Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; Generic-question avoidance expectation was not met; normalization=strict_primary/alignment_only_ok/complete/include; actual=emergency_global_screen"
+  },
+  {
+    "caseId": "heatstroke_heat_exposure_03_heat_plus_vomit_confuser",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "no_patch_report_only",
+    "reviewerAction": "Count this as repeat-metric noise until the harness carries prior asked and answered state.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; normalization=allow_module_alternatives/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true"
+  },
+  {
+    "caseId": "trauma_bleeding_wound_01_hit_by_car_pale",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap"
+    ],
+    "patchTarget": "no_patch_report_only",
+    "reviewerAction": "Count this as repeat-metric noise until the harness carries prior asked and answered state.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; normalization=strict_primary/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true"
+  },
+  {
+    "caseId": "trauma_bleeding_wound_02_bite_puncture_drip",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap"
+    ],
+    "patchTarget": "no_patch_report_only",
+    "reviewerAction": "Count this as repeat-metric noise until the harness carries prior asked and answered state.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; normalization=strict_primary/question_match_required/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true"
+  },
+  {
+    "caseId": "trauma_bleeding_wound_03_limping_after_fall_confuser",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "no_patch_report_only",
+    "reviewerAction": "Count this as repeat-metric noise until the harness carries prior asked and answered state.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; normalization=allow_module_alternatives/question_match_required/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true"
+  },
+  {
+    "caseId": "urinary_obstruction_01_straining_no_output",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap"
+    ],
+    "patchTarget": "no_patch_report_only",
+    "reviewerAction": "Count this as repeat-metric noise until the harness carries prior asked and answered state.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; normalization=strict_primary/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true"
+  },
+  {
+    "caseId": "urinary_obstruction_02_accidents_blood_straining",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "no_patch_report_only",
+    "reviewerAction": "Count this as repeat-metric noise until the harness carries prior asked and answered state.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; normalization=same_module_only/question_match_required/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true"
+  },
+  {
+    "caseId": "urinary_obstruction_03_vomit_and_no_pee_confuser",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "no_patch_report_only",
+    "reviewerAction": "Count this as repeat-metric noise until the harness carries prior asked and answered state.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; normalization=allow_module_alternatives/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true"
+  },
+  {
+    "caseId": "bloat_gdv_01_retching_swollen_belly",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap"
+    ],
+    "patchTarget": "no_patch_report_only",
+    "reviewerAction": "Count this as repeat-metric noise until the harness carries prior asked and answered state.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; normalization=strict_primary/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true"
+  },
+  {
+    "caseId": "bloat_gdv_02_pacing_drooling_belly",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap"
+    ],
+    "patchTarget": "no_patch_report_only",
+    "reviewerAction": "Count this as repeat-metric noise until the harness carries prior asked and answered state.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; normalization=strict_primary/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true"
+  },
+  {
+    "caseId": "bloat_gdv_03_diarrhea_plus_retching_confuser",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "no_patch_report_only",
+    "reviewerAction": "Count this as repeat-metric noise until the harness carries prior asked and answered state.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; normalization=allow_module_alternatives/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true"
+  },
+  {
+    "caseId": "respiratory_distress_01_open_mouth_breathing",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap"
+    ],
+    "patchTarget": "no_patch_report_only",
+    "reviewerAction": "Count this as repeat-metric noise until the harness carries prior asked and answered state.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; normalization=strict_primary/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true"
+  },
+  {
+    "caseId": "respiratory_distress_02_cough_and_blue_tongue",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "no_patch_report_only",
+    "reviewerAction": "Count this as repeat-metric noise until the harness carries prior asked and answered state.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; normalization=same_module_only/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true"
+  },
+  {
+    "caseId": "respiratory_distress_03_fast_breathing_after_heat_confuser",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "no_patch_report_only",
+    "reviewerAction": "Count this as repeat-metric noise until the harness carries prior asked and answered state.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; normalization=allow_module_alternatives/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true"
+  },
+  {
+    "caseId": "collapse_weakness_01_fainted_and_weak",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap"
+    ],
+    "patchTarget": "no_patch_report_only",
+    "reviewerAction": "Count this as repeat-metric noise until the harness carries prior asked and answered state.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; normalization=strict_primary/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true"
+  },
+  {
+    "caseId": "collapse_weakness_02_wobbly_pale",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap"
+    ],
+    "patchTarget": "no_patch_report_only",
+    "reviewerAction": "Count this as repeat-metric noise until the harness carries prior asked and answered state.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; normalization=strict_primary/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true"
+  },
+  {
+    "caseId": "collapse_weakness_03_vomit_then_weak_confuser",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "no_patch_report_only",
+    "reviewerAction": "Count this as repeat-metric noise until the harness carries prior asked and answered state.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; normalization=allow_module_alternatives/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true"
+  },
+  {
+    "caseId": "seizure_collapse_neuro_01_long_shaking",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap"
+    ],
+    "patchTarget": "no_patch_report_only",
+    "reviewerAction": "Count this as repeat-metric noise until the harness carries prior asked and answered state.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; normalization=strict_primary/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true"
+  },
+  {
+    "caseId": "seizure_collapse_neuro_02_multiple_episodes",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "no_patch_report_only",
+    "reviewerAction": "Count this as repeat-metric noise until the harness carries prior asked and answered state.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; normalization=allow_module_alternatives/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true"
+  },
+  {
+    "caseId": "seizure_collapse_neuro_03_collapse_or_seizure_unclear",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "no_patch_report_only",
+    "reviewerAction": "Count this as repeat-metric noise until the harness carries prior asked and answered state.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; normalization=allow_module_alternatives/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true"
+  },
+  {
+    "caseId": "toxin_poisoning_exposure_01_chocolate_and_vomit",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "no_patch_report_only",
+    "reviewerAction": "Count this as repeat-metric noise until the harness carries prior asked and answered state.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; normalization=allow_module_alternatives/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true"
+  },
+  {
+    "caseId": "toxin_poisoning_exposure_02_rodent_bait_possible",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap"
+    ],
+    "patchTarget": "no_patch_report_only",
+    "reviewerAction": "Count this as repeat-metric noise until the harness carries prior asked and answered state.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; normalization=strict_primary/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true"
+  },
+  {
+    "caseId": "toxin_poisoning_exposure_03_plant_and_wobbly_confuser",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "no_patch_report_only",
+    "reviewerAction": "Count this as repeat-metric noise until the harness carries prior asked and answered state.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; normalization=allow_module_alternatives/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true"
+  },
+  {
+    "caseId": "gi_vomiting_diarrhea_01_repeated_vomiting",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap"
+    ],
+    "patchTarget": "no_patch_report_only",
+    "reviewerAction": "Count this as repeat-metric noise until the harness carries prior asked and answered state.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; normalization=strict_primary/question_match_required/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true"
+  },
+  {
+    "caseId": "gi_vomiting_diarrhea_02_bloody_diarrhea",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "no_patch_report_only",
+    "reviewerAction": "Count this as repeat-metric noise until the harness carries prior asked and answered state.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; normalization=same_module_only/question_match_required/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true"
+  },
+  {
+    "caseId": "gi_vomiting_diarrhea_03_water_comes_back_up",
+    "primaryFailureClass": "planner_improvement_candidate",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap",
+      "generic_metric_setup_gap",
+      "red_flag_coverage_gap"
+    ],
+    "patchTarget": "planner",
+    "reviewerAction": "Review why the planner still prefers the global emergency screen over the explicit acceptable question set.",
+    "safetyImpact": "monitor",
+    "notes": "normalizedReason=Missing required screened red flags: unable_to_retain_water, persistent_vomiting; Planned question repeated the generic baseline \"emergency_global_screen\"; Planned question \"emergency_global_screen\" is outside the acceptable set; selectedBecause \"emergency_screen\" is outside the acceptable set; Repeated-question avoidance expectation was not met; Generic-question avoidance expectation was not met; normalization=strict_primary/question_match_required/complete/include; actual=emergency_global_screen"
+  },
+  {
+    "caseId": "skin_itching_allergy_01_hives_after_sting",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap"
+    ],
+    "patchTarget": "no_patch_report_only",
+    "reviewerAction": "Count this as repeat-metric noise until the harness carries prior asked and answered state.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; normalization=strict_primary/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true"
+  },
+  {
+    "caseId": "skin_itching_allergy_02_paws_belly_itching",
+    "primaryFailureClass": "planner_improvement_candidate",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap",
+      "generic_metric_setup_gap"
+    ],
+    "patchTarget": "planner",
+    "reviewerAction": "Review why the planner still prefers the global emergency screen over the explicit acceptable question set.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Planned question repeated the generic baseline \"emergency_global_screen\"; Planned question \"emergency_global_screen\" is outside the acceptable set; selectedBecause \"emergency_screen\" is outside the acceptable set; Repeated-question avoidance expectation was not met; Generic-question avoidance expectation was not met; normalization=strict_primary/question_match_required/complete/include; actual=emergency_global_screen"
+  },
+  {
+    "caseId": "skin_itching_allergy_03_face_swelling_and_vomit_confuser",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "no_patch_report_only",
+    "reviewerAction": "Count this as repeat-metric noise until the harness carries prior asked and answered state.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; normalization=allow_module_alternatives/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true"
+  },
+  {
+    "caseId": "limping_mobility_pain_01_non_weight_bearing",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap"
+    ],
+    "patchTarget": "no_patch_report_only",
+    "reviewerAction": "Count this as repeat-metric noise until the harness carries prior asked and answered state.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; normalization=strict_primary/question_match_required/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true"
+  },
+  {
+    "caseId": "limping_mobility_pain_02_sudden_after_jump",
+    "primaryFailureClass": "planner_improvement_candidate",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap",
+      "generic_metric_setup_gap",
+      "red_flag_coverage_gap"
+    ],
+    "patchTarget": "planner",
+    "reviewerAction": "Review why the planner still prefers the global emergency screen over the explicit acceptable question set.",
+    "safetyImpact": "monitor",
+    "notes": "normalizedReason=Missing required screened red flags: post_trauma_lameness, non_weight_bearing; Planned question repeated the generic baseline \"emergency_global_screen\"; Planned question \"emergency_global_screen\" is outside the acceptable set; selectedBecause \"emergency_screen\" is outside the acceptable set; Repeated-question avoidance expectation was not met; Generic-question avoidance expectation was not met; normalization=strict_primary/question_match_required/complete/include; actual=emergency_global_screen"
+  },
+  {
+    "caseId": "limping_mobility_pain_03_limping_with_wound_confuser",
+    "primaryFailureClass": "planner_improvement_candidate",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap",
+      "generic_metric_setup_gap",
+      "red_flag_coverage_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "planner",
+    "reviewerAction": "Review why the planner still prefers the global emergency screen over the explicit acceptable question set.",
+    "safetyImpact": "monitor",
+    "notes": "normalizedReason=Missing required screened red flags: post_trauma_lameness, non_weight_bearing, wound_deep_bleeding; Planned question repeated the generic baseline \"emergency_global_screen\"; Planned question \"emergency_global_screen\" is outside the acceptable set; Repeated-question avoidance expectation was not met; Generic-question avoidance expectation was not met; normalization=allow_module_alternatives/question_match_required/complete/include; actual=emergency_global_screen"
+  },
+  {
+    "caseId": "edge_heat_mild_after_walk_vs_hard_panting",
+    "primaryFailureClass": "fixture_ambiguity",
+    "secondaryFailureClasses": [
+      "generic_metric_setup_gap",
+      "red_flag_coverage_gap",
+      "planner_improvement_candidate"
+    ],
+    "patchTarget": "normalization",
+    "reviewerAction": "Review the edge normalization row first; emergency alignment is already acceptable, so this case should not drive a planner fix yet.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Missing required screened red flags: heatstroke_signs, brachycephalic_heat; Planned question repeated the generic baseline \"emergency_global_screen\"; Planned question \"emergency_global_screen\" is outside the acceptable set; Generic-question avoidance expectation was not met; normalization=allow_module_alternatives/alignment_only_ok/complete/include; actual=emergency_global_screen; fixtureKind=edge"
+  },
+  {
+    "caseId": "edge_heat_not_sure_breathing_or_panting",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "generic_metric_setup_gap",
+      "red_flag_coverage_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "normalization",
+    "reviewerAction": "Apply the existing edge normalization row before counting this as planner debt.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Missing required screened red flags: tachypnea, open_mouth_breathing, heatstroke_signs, brachycephalic_heat; Planned question repeated the generic baseline \"emergency_global_screen\"; Generic-question avoidance expectation was not met; normalization=allow_module_alternatives/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true; fixtureKind=edge"
+  },
+  {
+    "caseId": "edge_trauma_small_scrape_vs_steady_bleed",
+    "primaryFailureClass": "planner_improvement_candidate",
+    "secondaryFailureClasses": [
+      "generic_metric_setup_gap",
+      "red_flag_coverage_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "planner",
+    "reviewerAction": "Review why the planner still prefers the global emergency screen over the explicit acceptable question set.",
+    "safetyImpact": "monitor",
+    "notes": "normalizedReason=Missing required screened red flags: large_blood_volume, wound_deep_bleeding; Planned question repeated the generic baseline \"emergency_global_screen\"; Planned question \"emergency_global_screen\" is outside the acceptable set; Generic-question avoidance expectation was not met; normalization=allow_module_alternatives/question_match_required/complete/include; actual=emergency_global_screen; fixtureKind=edge"
+  },
+  {
+    "caseId": "edge_trauma_repeat_bleeding_avoidance",
+    "primaryFailureClass": "planner_improvement_candidate",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap",
+      "generic_metric_setup_gap",
+      "red_flag_coverage_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "planner",
+    "reviewerAction": "Review why the planner still prefers the global emergency screen over the explicit acceptable question set.",
+    "safetyImpact": "monitor",
+    "notes": "normalizedReason=Missing required screened red flags: wound_deep_bleeding, non_weight_bearing, post_trauma_lameness; Planned question repeated the generic baseline \"emergency_global_screen\"; Planned question \"emergency_global_screen\" is outside the acceptable set; selectedBecause \"emergency_screen\" is outside the acceptable set; Repeated-question avoidance expectation was not met; Generic-question avoidance expectation was not met; normalization=allow_module_alternatives/question_match_required/complete/include; actual=emergency_global_screen; fixtureKind=edge"
+  },
+  {
+    "caseId": "edge_urinary_frequent_trips_vs_no_output",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "generic_metric_setup_gap",
+      "red_flag_coverage_gap"
+    ],
+    "patchTarget": "normalization",
+    "reviewerAction": "Apply the existing edge normalization row before counting this as planner debt.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Missing required screened red flags: urinary_obstruction, anuria, stranguria, pollakiuria; Planned question repeated the generic baseline \"emergency_global_screen\"; Generic-question avoidance expectation was not met; normalization=strict_primary/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true; fixtureKind=edge"
+  },
+  {
+    "caseId": "edge_urinary_repeat_straining_avoidance",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap",
+      "generic_metric_setup_gap",
+      "red_flag_coverage_gap"
+    ],
+    "patchTarget": "normalization",
+    "reviewerAction": "Apply the existing edge normalization row before counting this as planner debt.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Missing required screened red flags: urinary_obstruction, anuria, stranguria, acute_weakness; Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; Generic-question avoidance expectation was not met; normalization=strict_primary/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true; fixtureKind=edge"
+  },
+  {
+    "caseId": "edge_bloat_ate_fast_vs_unproductive_gagging",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "generic_metric_setup_gap",
+      "red_flag_coverage_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "normalization",
+    "reviewerAction": "Apply the existing edge normalization row before counting this as planner debt.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Missing required screened red flags: gastric_dilatation_volvulus, unproductive_retching, persistent_vomiting; Planned question repeated the generic baseline \"emergency_global_screen\"; Generic-question avoidance expectation was not met; normalization=allow_module_alternatives/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true; fixtureKind=edge"
+  },
+  {
+    "caseId": "edge_bloat_not_sure_belly_size",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "generic_metric_setup_gap",
+      "red_flag_coverage_gap"
+    ],
+    "patchTarget": "normalization",
+    "reviewerAction": "Apply the existing edge normalization row before counting this as planner debt.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Missing required screened red flags: gastric_dilatation_volvulus, unproductive_retching; Planned question repeated the generic baseline \"emergency_global_screen\"; Generic-question avoidance expectation was not met; normalization=strict_primary/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true; fixtureKind=edge"
+  },
+  {
+    "caseId": "edge_respiratory_excited_vs_resting_fast_breath",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "generic_metric_setup_gap",
+      "red_flag_coverage_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "normalization",
+    "reviewerAction": "Apply the existing edge normalization row before counting this as planner debt.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Missing required screened red flags: tachypnea, open_mouth_breathing, heatstroke_signs; Planned question repeated the generic baseline \"emergency_global_screen\"; Generic-question avoidance expectation was not met; normalization=allow_module_alternatives/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true; fixtureKind=edge"
+  },
+  {
+    "caseId": "edge_respiratory_repeat_breathing_avoidance",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap",
+      "generic_metric_setup_gap",
+      "red_flag_coverage_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "normalization",
+    "reviewerAction": "Apply the existing edge normalization row before counting this as planner debt.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Missing required screened red flags: pale_gums, gray_gums, acute_weakness; Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; Generic-question avoidance expectation was not met; normalization=allow_module_alternatives/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true; fixtureKind=edge"
+  },
+  {
+    "caseId": "edge_collapse_tired_vs_cannot_stand",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "generic_metric_setup_gap",
+      "red_flag_coverage_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "normalization",
+    "reviewerAction": "Apply the existing edge normalization row before counting this as planner debt.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Missing required screened red flags: acute_weakness, pale_gums, heatstroke_signs; Planned question repeated the generic baseline \"emergency_global_screen\"; Generic-question avoidance expectation was not met; normalization=allow_module_alternatives/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true; fixtureKind=edge"
+  },
+  {
+    "caseId": "edge_collapse_not_sure_faint_or_slip",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "generic_metric_setup_gap",
+      "red_flag_coverage_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "normalization",
+    "reviewerAction": "Apply the existing edge normalization row before counting this as planner debt.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Missing required screened red flags: syncope, pale_gums; Planned question repeated the generic baseline \"emergency_global_screen\"; Generic-question avoidance expectation was not met; normalization=allow_module_alternatives/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true; fixtureKind=edge"
+  },
+  {
+    "caseId": "edge_seizure_shiver_vs_uncontrolled_shaking",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "generic_metric_setup_gap",
+      "red_flag_coverage_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "normalization",
+    "reviewerAction": "Apply the existing edge normalization row before counting this as planner debt.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Missing required screened red flags: status_epilepticus, cluster_seizures; Planned question repeated the generic baseline \"emergency_global_screen\"; Generic-question avoidance expectation was not met; normalization=allow_module_alternatives/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true; fixtureKind=edge"
+  },
+  {
+    "caseId": "edge_seizure_repeat_duration_avoidance",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap",
+      "generic_metric_setup_gap",
+      "red_flag_coverage_gap"
+    ],
+    "patchTarget": "normalization",
+    "reviewerAction": "Apply the existing edge normalization row before counting this as planner debt.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Missing required screened red flags: cluster_seizures, status_epilepticus; Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; Generic-question avoidance expectation was not met; normalization=strict_primary/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true; fixtureKind=edge"
+  },
+  {
+    "caseId": "edge_toxin_unknown_amount_vs_none_seen",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "generic_metric_setup_gap",
+      "red_flag_coverage_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "normalization",
+    "reviewerAction": "Apply the existing edge normalization row before counting this as planner debt.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Missing required screened red flags: suspected_toxin, known_toxin_ingestion, persistent_vomiting; Planned question repeated the generic baseline \"emergency_global_screen\"; Generic-question avoidance expectation was not met; normalization=allow_module_alternatives/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true; fixtureKind=edge"
+  },
+  {
+    "caseId": "edge_toxin_repeat_exposure_avoidance",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap",
+      "generic_metric_setup_gap",
+      "red_flag_coverage_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "normalization",
+    "reviewerAction": "Apply the existing edge normalization row before counting this as planner debt.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Missing required screened red flags: acute_weakness, pale_gums; Planned question repeated the generic baseline \"emergency_global_screen\"; Repeated-question avoidance expectation was not met; Generic-question avoidance expectation was not met; normalization=allow_module_alternatives/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true; fixtureKind=edge"
+  },
+  {
+    "caseId": "edge_gi_one_vomit_vs_cannot_keep_water",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "generic_metric_setup_gap",
+      "red_flag_coverage_gap"
+    ],
+    "patchTarget": "normalization",
+    "reviewerAction": "Apply the existing edge normalization row before counting this as planner debt.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Missing required screened red flags: unable_to_retain_water, persistent_vomiting; Planned question repeated the generic baseline \"emergency_global_screen\"; Generic-question avoidance expectation was not met; normalization=strict_primary/question_match_required/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true; fixtureKind=edge"
+  },
+  {
+    "caseId": "edge_gi_blood_or_food_color_unclear",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "generic_metric_setup_gap",
+      "red_flag_coverage_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "normalization",
+    "reviewerAction": "Apply the existing edge normalization row before counting this as planner debt.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Missing required screened red flags: hematochezia, persistent_vomiting, suspected_toxin; Planned question repeated the generic baseline \"emergency_global_screen\"; Generic-question avoidance expectation was not met; normalization=allow_module_alternatives/question_match_required/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true; fixtureKind=edge"
+  },
+  {
+    "caseId": "edge_skin_hives_vs_regular_itch",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "generic_metric_setup_gap",
+      "red_flag_coverage_gap"
+    ],
+    "patchTarget": "normalization",
+    "reviewerAction": "Apply the existing edge normalization row before counting this as planner debt.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Missing required screened red flags: urticaria, angioedema, anaphylaxis; Planned question repeated the generic baseline \"emergency_global_screen\"; Generic-question avoidance expectation was not met; normalization=strict_primary/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true; fixtureKind=edge"
+  },
+  {
+    "caseId": "edge_skin_repeat_location_avoidance",
+    "primaryFailureClass": "planner_improvement_candidate",
+    "secondaryFailureClasses": [
+      "repeated_metric_setup_gap",
+      "generic_metric_setup_gap",
+      "red_flag_coverage_gap"
+    ],
+    "patchTarget": "planner",
+    "reviewerAction": "Review why the planner still prefers the global emergency screen over the explicit acceptable question set.",
+    "safetyImpact": "monitor",
+    "notes": "normalizedReason=Missing required screened red flags: urticaria, angioedema, anaphylaxis; Planned question repeated the generic baseline \"emergency_global_screen\"; Planned question \"emergency_global_screen\" is outside the acceptable set; Repeated-question avoidance expectation was not met; Generic-question avoidance expectation was not met; normalization=strict_primary/question_match_required/complete/include; actual=emergency_global_screen; fixtureKind=edge"
+  },
+  {
+    "caseId": "edge_limping_sore_vs_no_weight",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "generic_metric_setup_gap",
+      "red_flag_coverage_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "normalization",
+    "reviewerAction": "Apply the existing edge normalization row before counting this as planner debt.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Missing required screened red flags: non_weight_bearing, post_trauma_lameness; Planned question repeated the generic baseline \"emergency_global_screen\"; Generic-question avoidance expectation was not met; normalization=allow_module_alternatives/question_match_required/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true; fixtureKind=edge"
+  },
+  {
+    "caseId": "edge_limping_not_sure_pain_or_weakness",
+    "primaryFailureClass": "planner_improvement_candidate",
+    "secondaryFailureClasses": [
+      "generic_metric_setup_gap",
+      "red_flag_coverage_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "planner",
+    "reviewerAction": "Review why the planner still prefers the global emergency screen over the explicit acceptable question set.",
+    "safetyImpact": "monitor",
+    "notes": "normalizedReason=Missing required screened red flags: non_weight_bearing, acute_weakness, pale_gums, post_trauma_lameness; Planned question repeated the generic baseline \"emergency_global_screen\"; Planned question \"emergency_global_screen\" is outside the acceptable set; Generic-question avoidance expectation was not met; normalization=allow_module_alternatives/question_match_required/complete/include; actual=emergency_global_screen; fixtureKind=edge"
+  },
+  {
+    "caseId": "edge_multi_vomit_weak_heat_toxin",
+    "primaryFailureClass": "report_only_quality_gap",
+    "secondaryFailureClasses": [
+      "generic_metric_setup_gap",
+      "red_flag_coverage_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "normalization",
+    "reviewerAction": "Apply the existing edge normalization row before counting this as planner debt.",
+    "safetyImpact": "none",
+    "notes": "normalizedReason=Missing required screened red flags: suspected_toxin, acute_weakness, heatstroke_signs, persistent_vomiting; Planned question repeated the generic baseline \"emergency_global_screen\"; Generic-question avoidance expectation was not met; normalization=allow_module_alternatives/alignment_only_ok/partial/exclude_for_now; actual=emergency_global_screen; accepts_global_emergency_screen=true; fixtureKind=edge"
+  },
+  {
+    "caseId": "edge_multi_diarrhea_limping_cut",
+    "primaryFailureClass": "planner_improvement_candidate",
+    "secondaryFailureClasses": [
+      "generic_metric_setup_gap",
+      "red_flag_coverage_gap",
+      "fixture_ambiguity"
+    ],
+    "patchTarget": "planner",
+    "reviewerAction": "Review why the planner still prefers the global emergency screen over the explicit acceptable question set.",
+    "safetyImpact": "monitor",
+    "notes": "normalizedReason=Missing required screened red flags: non_weight_bearing, post_trauma_lameness, wound_deep_bleeding, hematochezia; Planned question repeated the generic baseline \"emergency_global_screen\"; Planned question \"emergency_global_screen\" is outside the acceptable set; Generic-question avoidance expectation was not met; normalization=allow_module_alternatives/question_match_required/complete/include; actual=emergency_global_screen; fixtureKind=edge"
+  }
+]
+


### PR DESCRIPTION
## Summary
- add a 57-row shadow eval failure annotation fixture aligned to the current normalized eval summary
- add a deterministic guard test for row coverage, allowed enums, primary split, and representative reviewer lanes
- document how reviewers should separate report-only gaps from planner follow-up candidates

## Validation
- npm test -- --runTestsByPath tests/clinical-intelligence/shadow-eval-failure-annotation-pack.test.ts
- npm test -- --runTestsByPath tests/clinical-intelligence/shadow-planner-scenario-eval.test.ts
- node scripts/eval-shadow-planner-scenarios.ts --json
- npm run build