### PR TITLE
VET-1459C: planner candidate repeated-question fix slice

### DIFF
--- a/docs/clinical-intelligence/planner-candidate-fix-slice-1-codex.md
+++ b/docs/clinical-intelligence/planner-candidate-fix-slice-1-codex.md
@@ -1,0 +1,55 @@
+# Planner Candidate Fix Slice 1 (VET-1459C)
+
+## Scope
+
+This slice stays inside planner and eval support surfaces only:
+
+- `src/lib/clinical-intelligence/shadow-planner-scenario-eval.ts`
+- `tests/clinical-intelligence/next-question-planner.test.ts`
+- `tests/clinical-intelligence/shadow-planner-scenario-eval.test.ts`
+- `docs/clinical-intelligence/planner-candidate-fix-slice-1-codex.md`
+
+It does not touch symptom-chat routing, triage-engine, clinical-matrix,
+symptom-memory, question cards, complaint modules, red flags, clinical signals,
+RAG, UI, env, infrastructure, or workflows.
+
+## Goal
+
+VET-1455K and VET-1458K isolated repeated-question planner candidates where the
+shadow eval was still marking `actual_repeated_question_failure` even when the
+planner did not reselect the prior asked or answered domain question.
+
+This slice tightens that distinction:
+
+- selecting a question already present in `askedQuestionIds` or
+  `answeredQuestionIds` remains a true repeated-question failure
+- reselecting the fixed comparison baseline `emergency_global_screen` is still
+  reported as a generic-baseline quality miss, but no longer counted as an
+  actual repeated-question setup failure for the locked repeated cases
+
+## What Changed
+
+- The eval harness now uses real `askedQuestionIds` and `answeredQuestionIds`
+  when it decides whether a repeated-setup case should receive
+  `actual_repeated_question_failure`.
+- The broad comparison signal for the generic baseline still exists, so the
+  report continues to surface when the planner stays on
+  `emergency_global_screen`.
+- Planner regression tests now include the locked trauma and skin repeat slices
+  to prove the planner does not reselect `bleeding_volume_check` or
+  `skin_location_distribution` once those IDs are already asked and answered.
+
+## Outcome
+
+- repeated-question setup metrics now measure actual prior-question reuse
+  instead of generic baseline reuse
+- the repeated eligible denominator remains `6`
+- the repeated avoidance rate moves to `6/6`
+- emergency alignment remains unchanged
+- the candidate cases can stay in the report for generic-baseline or
+  acceptable-question misses without being mislabeled as true repeat failures
+
+## Notes
+
+- Targeted planner/eval quality fix only.
+- No runtime files touched.

--- a/src/lib/clinical-intelligence/shadow-planner-scenario-eval.ts
+++ b/src/lib/clinical-intelligence/shadow-planner-scenario-eval.ts
@@ -752,6 +752,20 @@ function buildRepeatedQuestionMetricStatus(input: {
   return null;
 }
 
+function avoidsAskedOrAnsweredRepeat(
+  plannedQuestionId: string | null,
+  caseState: ClinicalCaseState
+): boolean {
+  if (!plannedQuestionId) {
+    return false;
+  }
+
+  return (
+    !caseState.askedQuestionIds.includes(plannedQuestionId) &&
+    !caseState.answeredQuestionIds.includes(plannedQuestionId)
+  );
+}
+
 function buildGenericQuestionMetricStatus(input: {
   eligible: boolean;
   genericQuestionAvoided: boolean;
@@ -776,7 +790,9 @@ function evaluateNormalizedShadowPlannerScenario(
     caseState: input.caseState,
   });
   const actual = buildActualDescriptor(input.caseId, integration);
-  const repeatedQuestionAvoidedSignal = integration.comparison.repeatedQuestionAvoided;
+  const repeatedQuestionAvoidedSignal = input.repeatedQuestionMetricEligible
+    ? avoidsAskedOrAnsweredRepeat(actual.plannedQuestionId, input.caseState)
+    : integration.comparison.repeatedQuestionAvoided;
 
   const rawEvaluation = evaluateExpectationMode({
     expected: input.expected,

--- a/tests/clinical-intelligence/next-question-planner.test.ts
+++ b/tests/clinical-intelligence/next-question-planner.test.ts
@@ -200,6 +200,114 @@ describe("Planner never repeats an asked question", () => {
     }
     expect(result.questionId).not.toBe("emergency_global_screen");
   });
+
+  it("does not reselect bleeding_volume_check in the locked trauma repeat slice", () => {
+    const traumaRepeatCards: ClinicalQuestionCard[] = [
+      {
+        ...MOCK_EMERGENCY_CARD,
+        id: "bleeding_volume_check",
+        complaintFamilies: ["emergency", "trauma", "wound"],
+        skipIfAnswered: [],
+      },
+      MOCK_EMERGENCY_CARD,
+      {
+        ...MOCK_SKIN_CARD,
+        id: "wound_characterization_check",
+        complaintFamilies: ["emergency", "trauma", "wound"],
+        phase: "characterize",
+        urgencyImpact: 2,
+        discriminativeValue: 3,
+        reportValue: 3,
+      },
+      {
+        ...MOCK_SKIN_CARD,
+        id: "laceration_depth_check",
+        complaintFamilies: ["emergency", "trauma", "wound"],
+        phase: "discriminate",
+        ownerAnswerability: 2,
+        urgencyImpact: 2,
+        discriminativeValue: 3,
+        reportValue: 3,
+      },
+      {
+        ...MOCK_SKIN_CARD,
+        id: "limping_weight_bearing",
+        complaintFamilies: ["limping", "lameness", "musculoskeletal"],
+        ownerText:
+          "Is your pet putting any weight on the affected leg, or are they holding it completely off the ground?",
+        shortReason:
+          "Whether a pet bears weight on a limb helps distinguish minor strain from more significant injury.",
+      },
+    ];
+    jest.spyOn(registry, "getAllQuestionCards").mockReturnValueOnce(
+      traumaRepeatCards
+    );
+
+    let state = createInitialClinicalCaseState("trauma");
+    state = recordAskedQuestion(state, "bleeding_volume_check");
+    state = recordAnsweredQuestion(
+      state,
+      "bleeding_volume_check",
+      "blood_amount",
+      "Bleeding has stopped"
+    );
+
+    const result = planNextClinicalQuestion(state, {
+      activeComplaintModule: "trauma",
+    });
+
+    expect("type" in result).toBe(false);
+    if ("type" in result) {
+      return;
+    }
+
+    expect(result.questionId).not.toBe("bleeding_volume_check");
+  });
+
+  it("does not reselect skin_location_distribution in the locked skin repeat slice", () => {
+    const skinRepeatCards: ClinicalQuestionCard[] = [
+      MOCK_EMERGENCY_CARD,
+      {
+        ...MOCK_SKIN_CARD,
+        id: "skin_emergency_allergy_screen",
+        complaintFamilies: ["emergency", "skin", "allergy"],
+        phase: "emergency_screen",
+        urgencyImpact: 3,
+        discriminativeValue: 3,
+        reportValue: 3,
+        screensRedFlags: ["angioedema", "urticaria", "anaphylaxis"],
+      },
+      MOCK_SKIN_CARD,
+      {
+        ...MOCK_SKIN_CARD,
+        id: "skin_changes_check",
+        discriminativeValue: 3,
+      },
+    ];
+    jest.spyOn(registry, "getAllQuestionCards").mockReturnValueOnce(
+      skinRepeatCards
+    );
+
+    let state = createInitialClinicalCaseState("skin");
+    state = recordAskedQuestion(state, "skin_location_distribution");
+    state = recordAnsweredQuestion(
+      state,
+      "skin_location_distribution",
+      "skin_location",
+      "Paws and belly"
+    );
+
+    const result = planNextClinicalQuestion(state, {
+      activeComplaintModule: "skin",
+    });
+
+    expect("type" in result).toBe(false);
+    if ("type" in result) {
+      return;
+    }
+
+    expect(result.questionId).not.toBe("skin_location_distribution");
+  });
 });
 
 describe("Emergency-screen cards outrank routine characterization", () => {

--- a/tests/clinical-intelligence/shadow-planner-scenario-eval.test.ts
+++ b/tests/clinical-intelligence/shadow-planner-scenario-eval.test.ts
@@ -44,8 +44,8 @@ describe("shadow planner scenario eval harness", () => {
     );
     expect(report.summary.repeatedQuestionEligibleCases).toBe(6);
     expect(report.summary.repeatedQuestionAvoidanceRelevantCases).toBe(6);
-    expect(report.summary.repeatedQuestionAvoidanceCount).toBe(0);
-    expect(report.summary.repeatedQuestionAvoidanceRate).toBe(0);
+    expect(report.summary.repeatedQuestionAvoidanceCount).toBe(6);
+    expect(report.summary.repeatedQuestionAvoidanceRate).toBe(1);
     expect(report.summary.genericQuestionEligibleCases).toBe(11);
     expect(report.summary.genericQuestionAvoidanceRelevantCases).toBe(11);
     expect(report.summary.genericQuestionAvoidanceCount).toBe(0);
@@ -131,15 +131,19 @@ describe("shadow planner scenario eval harness", () => {
       "actual_generic_question_failure"
     );
 
-    const repeatedFailureCase = report.summary.failedCases.find(
+    const repeatedSetupCase = report.summary.failedCases.find(
       (result) => result.caseId === "edge_urinary_repeat_straining_avoidance"
     );
 
-    expect(repeatedFailureCase?.repeatedQuestionMetricStatus).toBe(
-      "actual_repeated_question_failure"
-    );
-    expect(repeatedFailureCase?.genericQuestionMetricStatus).toBe(
+    expect(repeatedSetupCase?.repeatedQuestionMetricStatus).toBeNull();
+    expect(repeatedSetupCase?.genericQuestionMetricStatus).toBe(
       "no_metric_setup"
+    );
+    expect(repeatedSetupCase?.rawReason).not.toContain(
+      "Repeated-question avoidance expectation was not met"
+    );
+    expect(repeatedSetupCase?.actual.plannedQuestionId).toBe(
+      "emergency_global_screen"
     );
 
     expect(report.summary.complaintModuleMatchRate).toBeGreaterThanOrEqual(0);


### PR DESCRIPTION
## Summary
- tighten the repeated-question eval signal so locked repeated-setup cases only fail when the planner actually reuses an asked or answered question id
- add planner regression coverage for the trauma and skin repeated-question candidate slices
- document the VET-1459C scope and expected metric shift without touching runtime symptom-chat wiring

## Validation
- npm test -- --runTestsByPath tests/clinical-intelligence/next-question-planner.test.ts
- npm test -- --runTestsByPath tests/clinical-intelligence/shadow-planner-scenario-eval.test.ts
- npm test -- --runTestsByPath tests/clinical-intelligence/shadow-eval-planner-improvement-candidate-guard.test.ts
- node scripts/eval-shadow-planner-scenarios.ts --json
- npm run build