### PR TITLE
VET-1423: Pending Question State Machine + Repeat Loop Guardrails

### DIFF
--- a/docs/clinical-intelligence/pending-question-repeat-loop-guardrails-codex.md
+++ b/docs/clinical-intelligence/pending-question-repeat-loop-guardrails-codex.md
@@ -1,0 +1,73 @@
+# VET-1423 Pending Question Repeat Loop Guardrails
+
+## Scope
+
+This change hardens pending follow-up handling so the same question cannot loop indefinitely once the route has already tried to recover it from direct owner text.
+
+In scope:
+
+- pending question identity
+- per-question ask counts
+- per-question clarification attempt counts
+- pending resolution before next-question selection
+- non-critical unknown closure after the second ask
+- critical fail-closed escalation after the second ask
+- compression protection for the new control-state fields
+
+Out of scope:
+
+- model routing
+- Grok
+- planner cutover
+- emergency sentinel behavior
+- diagnosis or treatment wording
+- triage-engine or clinical-matrix refactors
+
+## Control State
+
+The protected control state now includes:
+
+- `case_memory.pending_question_id`
+- `case_memory.question_asked_counts`
+- `case_memory.clarification_attempts`
+- existing `answered_questions`
+- existing `extracted_answers`
+- existing `unresolved_question_ids`
+- existing `clarification_reasons`
+- existing `last_question_asked`
+
+These fields are preserved across compression and are never allowed to come from compression output.
+
+## Runtime Rules
+
+1. A question becomes the active pending question when it is actually asked.
+2. If the owner answers that pending question, it is resolved before the route selects another question.
+3. The same `question_id` can be asked at most 2 times.
+4. If a third recovery attempt would be required:
+   - non-critical question: record `unknown`, clear pending state, and move on
+   - critical question: fail closed through `cannot_assess`
+5. Answered question ids are pruned out of unresolved control state before next-question sync and before compression merge.
+
+## Files
+
+- `src/lib/symptom-chat/pending-question-state.ts`
+  Central helper for pending question id, ask counts, clarification attempts, and answered-state pruning.
+- `src/lib/symptom-chat/repeat-loop-guard.ts`
+  Encodes the max-2-asks policy and the non-critical vs critical terminal behavior.
+- `src/app/api/ai/symptom-chat/route.ts`
+  Uses the new helpers during pending-question recovery so loop exits happen before next-question selection.
+- `src/lib/symptom-chat/question-response-flow.ts`
+  Records ask counts when a question is actually asked, including clarification re-asks.
+- `src/lib/symptom-memory.ts`
+  Preserves the new fields across compression and filters answered ids from unresolved state sync.
+
+## Regression Coverage
+
+`tests/symptom-chat.repeat-loop.test.ts` locks:
+
+- duration reply resolves and advances
+- repeated `not sure` cannot loop forever
+- skipped/non-answer reply cannot re-ask more than twice
+- critical pending unknown fails closed
+- answered pending ids do not come back into unresolved state
+- compression preserves pending-question counters

--- a/src/app/api/ai/symptom-chat/route.ts
+++ b/src/app/api/ai/symptom-chat/route.ts
@@ -90,6 +90,12 @@ import {
   mergeTurnAnswers,
 } from "@/lib/symptom-chat/answer-extraction";
 import {
+  clearPendingQuestion,
+  getPendingQuestionId,
+  markPendingQuestionClarificationAttempt,
+  pruneAnsweredQuestionState,
+} from "@/lib/symptom-chat/pending-question-state";
+import {
   buildCompactImageSignalContext,
   buildTurnFocusSymptoms,
   propagateSharedLocationAnswers,
@@ -112,6 +118,7 @@ import {
   buildEvidenceChainNotes,
   deriveSymptomsFromImageEvidence,
 } from "@/lib/symptom-chat/report-helpers";
+import { decideRepeatLoopGuard } from "@/lib/symptom-chat/repeat-loop-guard";
 import {
   buildAlternateObservableRecoveryResponse,
   buildImageGateMessage,
@@ -1272,7 +1279,7 @@ export async function POST(request: Request) {
     // If the session had a pending question and extraction didn't capture
     // the answer (e.g. user said "no", "nothing", "I don't know"), force-
     // record the user's raw text so the question is marked answered.
-    const pendingQ = session.last_question_asked;
+    const pendingQ = getPendingQuestionId(session);
     const pendingQWasAnsweredBeforeTurn =
       pendingQ !== undefined && answerKeysBeforeTurn.has(pendingQ);
     let pendingQResolvedThisTurn = Boolean(
@@ -1318,6 +1325,7 @@ export async function POST(request: Request) {
       });
 
       if (criticalInfoDecision) {
+        session = markPendingQuestionClarificationAttempt(session, pendingQ);
         if (criticalInfoDecision.kind === "alternate_observable") {
           const caseMemory = ensureStructuredCaseMemory(session);
           const unresolvedQuestionIds = caseMemory.unresolved_question_ids.includes(
@@ -1384,6 +1392,7 @@ export async function POST(request: Request) {
           value: pendingAnswer.value,
           reason: "pending_question_recovered",
         });
+        session = pruneAnsweredQuestionState(session);
         console.log(
           `[Engine] Resolved pending question "${pendingQ}" via ${pendingAnswer.source} (signal: "${lastUserMessage.content.substring(0, 80)}")`
         );
@@ -1398,26 +1407,78 @@ export async function POST(request: Request) {
           pending_after: false,
         });
       } else {
-        session = transitionToNeedsClarification({
+        const repeatLoopDecision = decideRepeatLoopGuard(
           session,
-          questionId: pendingQ,
-          reason: "pending_recovery_failed",
-        });
-        console.log(
-          `[Engine] Pending question "${pendingQ}" still unresolved after extraction and deterministic fallback`
+          pendingQ,
+          pet.name || "your dog",
+          getQuestionText(pendingQ)
         );
-        session = recordConversationTelemetry(session, {
-          event: "pending_recovery",
-          turn_count: session.case_memory?.turn_count ?? 0,
-          question_id: pendingQ,
-          outcome: isAmbiguousReply ? "needs_clarification" : "failure",
-          source: "unresolved",
-          reason: isAmbiguousReply
-            ? "needs_clarification_re_ask"
-            : "pending_recovery_failed",
-          pending_before: hadUnresolved,
-          pending_after: true,
-        });
+
+        session = markPendingQuestionClarificationAttempt(session, pendingQ);
+
+        if (repeatLoopDecision.kind === "cannot_assess") {
+          session = transitionToEscalation({
+            session,
+            redFlags: [repeatLoopDecision.redFlag],
+            reason: "owner_cannot_assess_critical_indicator",
+          });
+          session = clearPendingQuestion(session, pendingQ);
+          console.log(
+            `[Engine] Repeat-loop guard escalated critical pending question "${pendingQ}" after ${repeatLoopDecision.askedCount} asks`
+          );
+          session = recordConversationTelemetry(session, {
+            event: "pending_recovery",
+            turn_count: session.case_memory?.turn_count ?? 0,
+            question_id: pendingQ,
+            outcome: "escalation",
+            source: "unresolved",
+            reason: repeatLoopDecision.reason,
+            pending_before: hadUnresolved,
+            pending_after: false,
+          });
+          terminalOutcome = repeatLoopDecision.outcome;
+        } else if (repeatLoopDecision.kind === "record_unknown") {
+          session = transitionToAnswered({
+            session,
+            questionId: pendingQ,
+            value: repeatLoopDecision.value,
+            reason: "pending_question_recovered",
+          });
+          session = pruneAnsweredQuestionState(session);
+          pendingQResolvedThisTurn = true;
+          console.log(
+            `[Engine] Repeat-loop guard recorded unknown for non-critical pending question "${pendingQ}" after ${repeatLoopDecision.askedCount} asks`
+          );
+          session = recordConversationTelemetry(session, {
+            event: "pending_recovery",
+            turn_count: session.case_memory?.turn_count ?? 0,
+            question_id: pendingQ,
+            outcome: "success",
+            source: "unresolved",
+            reason: repeatLoopDecision.reason,
+            pending_before: hadUnresolved,
+            pending_after: false,
+          });
+        } else {
+          session = transitionToNeedsClarification({
+            session,
+            questionId: pendingQ,
+            reason: "pending_recovery_failed",
+          });
+          console.log(
+            `[Engine] Pending question "${pendingQ}" still unresolved after extraction and deterministic fallback`
+          );
+          session = recordConversationTelemetry(session, {
+            event: "pending_recovery",
+            turn_count: session.case_memory?.turn_count ?? 0,
+            question_id: pendingQ,
+            outcome: isAmbiguousReply ? "needs_clarification" : "failure",
+            source: "unresolved",
+            reason: repeatLoopDecision.reason,
+            pending_before: hadUnresolved,
+            pending_after: true,
+          });
+        }
       }
     }
 

--- a/src/lib/conversation-state/answer-recording.ts
+++ b/src/lib/conversation-state/answer-recording.ts
@@ -1,6 +1,7 @@
 import { recordAnswer } from "@/lib/triage-engine";
 import type { TriageSession } from "@/lib/triage-engine";
 import { getStateSnapshot, observeTransition } from "./observer";
+import { clearPendingQuestion } from "@/lib/symptom-chat/pending-question-state";
 
 export interface TransitionToAnsweredInput {
   session: TriageSession;
@@ -38,6 +39,8 @@ export function transitionToAnswered(
       },
     };
   }
+
+  updated = clearPendingQuestion(updated, questionId);
 
   updated = observeTransition(updated, {
     before: beforeState,

--- a/src/lib/symptom-chat/next-question-orchestration.ts
+++ b/src/lib/symptom-chat/next-question-orchestration.ts
@@ -10,6 +10,11 @@ import {
 } from "@/lib/symptom-memory";
 import { getNextQuestionAvoidingRepeat } from "@/lib/symptom-chat/answer-coercion";
 import { didVisualEvidenceInfluenceQuestion } from "@/lib/symptom-chat/report-helpers";
+import {
+  getPendingQuestionId,
+  getQuestionAskedCount,
+} from "@/lib/symptom-chat/pending-question-state";
+import { MAX_PENDING_QUESTION_ASKS } from "@/lib/symptom-chat/repeat-loop-guard";
 
 interface OrchestrateNextQuestionInput {
   session: TriageSession;
@@ -70,18 +75,25 @@ export function orchestrateNextQuestion(
 function resolveNeedsClarificationQuestionId(
   input: OrchestrateNextQuestionInput
 ): string | null {
-  const lastQuestionAsked = input.session.last_question_asked;
-  if (!lastQuestionAsked || input.pendingQResolvedThisTurn) {
+  const pendingQuestionId = getPendingQuestionId(input.session);
+  if (!pendingQuestionId || input.pendingQResolvedThisTurn) {
+    return null;
+  }
+
+  if (
+    getQuestionAskedCount(input.session, pendingQuestionId) >=
+    MAX_PENDING_QUESTION_ASKS
+  ) {
     return null;
   }
 
   const clarificationReasons =
     input.session.case_memory?.clarification_reasons ?? {};
   const wasPreviouslyUnresolved =
-    clarificationReasons[lastQuestionAsked] ||
-    input.incomingUnresolvedIds.includes(lastQuestionAsked);
+    clarificationReasons[pendingQuestionId] ||
+    input.incomingUnresolvedIds.includes(pendingQuestionId);
 
-  return wasPreviouslyUnresolved ? lastQuestionAsked : null;
+  return wasPreviouslyUnresolved ? pendingQuestionId : null;
 }
 
 function recordRepeatSuppressionTelemetry(

--- a/src/lib/symptom-chat/pending-question-state.ts
+++ b/src/lib/symptom-chat/pending-question-state.ts
@@ -1,0 +1,135 @@
+import { createSession, type TriageSession } from "@/lib/triage-engine";
+
+export interface PendingQuestionStateSnapshot {
+  pendingQuestionId?: string;
+  questionAskedCounts: Record<string, number>;
+  clarificationAttempts: Record<string, number>;
+}
+
+function getCaseMemory(session: TriageSession) {
+  return session.case_memory ?? createSession().case_memory!;
+}
+
+export function getPendingQuestionState(
+  session: TriageSession
+): PendingQuestionStateSnapshot {
+  const caseMemory = getCaseMemory(session);
+  return {
+    pendingQuestionId: caseMemory.pending_question_id ?? session.last_question_asked,
+    questionAskedCounts: { ...(caseMemory.question_asked_counts ?? {}) },
+    clarificationAttempts: { ...(caseMemory.clarification_attempts ?? {}) },
+  };
+}
+
+export function getPendingQuestionId(
+  session: TriageSession
+): string | undefined {
+  return getPendingQuestionState(session).pendingQuestionId;
+}
+
+export function getQuestionAskedCount(
+  session: TriageSession,
+  questionId: string
+): number {
+  const state = getPendingQuestionState(session);
+  if (state.questionAskedCounts[questionId] !== undefined) {
+    return state.questionAskedCounts[questionId];
+  }
+
+  return state.pendingQuestionId === questionId ? 1 : 0;
+}
+
+export function getClarificationAttemptCount(
+  session: TriageSession,
+  questionId: string
+): number {
+  return getPendingQuestionState(session).clarificationAttempts[questionId] ?? 0;
+}
+
+export function markPendingQuestionAsked(
+  session: TriageSession,
+  questionId: string
+): TriageSession {
+  const caseMemory = getCaseMemory(session);
+  const nextCount = getQuestionAskedCount(session, questionId) + 1;
+
+  return {
+    ...session,
+    case_memory: {
+      ...caseMemory,
+      pending_question_id: questionId,
+      question_asked_counts: {
+        ...(caseMemory.question_asked_counts ?? {}),
+        [questionId]: nextCount,
+      },
+    },
+  };
+}
+
+export function markPendingQuestionClarificationAttempt(
+  session: TriageSession,
+  questionId: string
+): TriageSession {
+  const caseMemory = getCaseMemory(session);
+  const nextAttempts = getClarificationAttemptCount(session, questionId) + 1;
+
+  return {
+    ...session,
+    case_memory: {
+      ...caseMemory,
+      pending_question_id: questionId,
+      clarification_attempts: {
+        ...(caseMemory.clarification_attempts ?? {}),
+        [questionId]: nextAttempts,
+      },
+    },
+  };
+}
+
+export function clearPendingQuestion(
+  session: TriageSession,
+  questionId: string
+): TriageSession {
+  const caseMemory = getCaseMemory(session);
+  if (caseMemory.pending_question_id !== questionId) {
+    return session;
+  }
+
+  return {
+    ...session,
+    case_memory: {
+      ...caseMemory,
+      pending_question_id: undefined,
+    },
+  };
+}
+
+export function pruneAnsweredQuestionState(
+  session: TriageSession
+): TriageSession {
+  const caseMemory = getCaseMemory(session);
+  const answeredIds = new Set(session.answered_questions ?? []);
+  const clarificationReasons = {
+    ...(caseMemory.clarification_reasons ?? {}),
+  };
+
+  for (const answeredId of answeredIds) {
+    delete clarificationReasons[answeredId];
+  }
+
+  return {
+    ...session,
+    case_memory: {
+      ...caseMemory,
+      pending_question_id:
+        caseMemory.pending_question_id &&
+        answeredIds.has(caseMemory.pending_question_id)
+          ? undefined
+          : caseMemory.pending_question_id,
+      unresolved_question_ids: (caseMemory.unresolved_question_ids ?? []).filter(
+        (questionId) => !answeredIds.has(questionId)
+      ),
+      clarification_reasons: clarificationReasons,
+    },
+  };
+}

--- a/src/lib/symptom-chat/question-response-flow.ts
+++ b/src/lib/symptom-chat/question-response-flow.ts
@@ -11,6 +11,7 @@ import {
   transitionToAsked,
   transitionToConfirmed,
 } from "@/lib/conversation-state";
+import { markPendingQuestionAsked } from "@/lib/symptom-chat/pending-question-state";
 import { sanitizeSessionForClient } from "@/lib/symptom-chat/context-helpers";
 import {
   buildQuestionPhrasingContext,
@@ -95,7 +96,7 @@ function prepareSessionForQuestionResponse(
   needsClarificationQuestionId: string | null
 ): TriageSession {
   if (needsClarificationQuestionId) {
-    return session;
+    return markPendingQuestionAsked(session, nextQuestionId);
   }
 
   const withConfirmedTransition = shouldConfirmSufficientData(session)
@@ -105,8 +106,13 @@ function prepareSessionForQuestionResponse(
       })
     : session;
 
+  const withPendingState = markPendingQuestionAsked(
+    withConfirmedTransition,
+    nextQuestionId
+  );
+
   return transitionToAsked({
-    session: withConfirmedTransition,
+    session: withPendingState,
     questionId: nextQuestionId,
     reason: "next_question_selected",
   });

--- a/src/lib/symptom-chat/repeat-loop-guard.ts
+++ b/src/lib/symptom-chat/repeat-loop-guard.ts
@@ -1,0 +1,77 @@
+import { FOLLOW_UP_QUESTIONS } from "@/lib/clinical-matrix";
+import { buildCannotAssessOutcome } from "@/lib/clinical/uncertainty-routing";
+import type { UncertaintyTerminalOutcome } from "@/lib/clinical/uncertainty-routing";
+import type { TriageSession } from "@/lib/triage-engine";
+import {
+  getClarificationAttemptCount,
+  getQuestionAskedCount,
+} from "@/lib/symptom-chat/pending-question-state";
+
+export const MAX_PENDING_QUESTION_ASKS = 2;
+export const NON_CRITICAL_UNKNOWN_VALUE = "unknown";
+
+type RepeatLoopGuardDecision =
+  | {
+      kind: "allow_reask";
+      askedCount: number;
+      clarificationAttemptCount: number;
+      reason: "needs_clarification_re_ask";
+    }
+  | {
+      kind: "record_unknown";
+      askedCount: number;
+      clarificationAttemptCount: number;
+      value: typeof NON_CRITICAL_UNKNOWN_VALUE;
+      reason: "max_pending_ask_count_reached_noncritical_unknown";
+    }
+  | {
+      kind: "cannot_assess";
+      askedCount: number;
+      clarificationAttemptCount: number;
+      outcome: UncertaintyTerminalOutcome;
+      redFlag: string;
+      reason: "max_pending_ask_count_reached_critical_cannot_assess";
+    };
+
+export function decideRepeatLoopGuard(
+  session: TriageSession,
+  questionId: string,
+  petName: string,
+  questionText?: string | null
+): RepeatLoopGuardDecision {
+  const askedCount = getQuestionAskedCount(session, questionId);
+  const clarificationAttemptCount =
+    getClarificationAttemptCount(session, questionId) + 1;
+
+  if (askedCount < MAX_PENDING_QUESTION_ASKS) {
+    return {
+      kind: "allow_reask",
+      askedCount,
+      clarificationAttemptCount,
+      reason: "needs_clarification_re_ask",
+    };
+  }
+
+  if (!FOLLOW_UP_QUESTIONS[questionId]?.critical) {
+    return {
+      kind: "record_unknown",
+      askedCount,
+      clarificationAttemptCount,
+      value: NON_CRITICAL_UNKNOWN_VALUE,
+      reason: "max_pending_ask_count_reached_noncritical_unknown",
+    };
+  }
+
+  return {
+    kind: "cannot_assess",
+    askedCount,
+    clarificationAttemptCount,
+    outcome: buildCannotAssessOutcome({
+      petName,
+      questionId,
+      questionText,
+    }),
+    redFlag: `cannot_assess_${questionId}`,
+    reason: "max_pending_ask_count_reached_critical_cannot_assess",
+  };
+}

--- a/src/lib/symptom-memory.ts
+++ b/src/lib/symptom-memory.ts
@@ -39,6 +39,9 @@ export const PROTECTED_CONTROL_STATE_KEYS = [
   "extracted_answers",
   "unresolved_question_ids",
   "clarification_reasons",
+  "pending_question_id",
+  "question_asked_counts",
+  "clarification_attempts",
   "last_question_asked",
 ] as const;
 
@@ -54,6 +57,9 @@ export interface ProtectedConversationState {
   extracted_answers: Record<string, string | boolean | number>;
   unresolved_question_ids: string[];
   clarification_reasons: Record<string, string>;
+  pending_question_id?: string;
+  question_asked_counts: Record<string, number>;
+  clarification_attempts: Record<string, number>;
   last_question_asked?: string;
 }
 
@@ -71,6 +77,11 @@ export function getProtectedConversationState(
       session.case_memory?.unresolved_question_ids ?? [],
     clarification_reasons:
       session.case_memory?.clarification_reasons ?? {},
+    pending_question_id: session.case_memory?.pending_question_id,
+    question_asked_counts:
+      session.case_memory?.question_asked_counts ?? {},
+    clarification_attempts:
+      session.case_memory?.clarification_attempts ?? {},
     last_question_asked: session.last_question_asked,
   };
 }
@@ -148,6 +159,23 @@ function sameReasonMap(
   return beforeKeys.every((key) => before[key] === after[key]);
 }
 
+function sameNumberMap(
+  before: Record<string, number>,
+  after: Record<string, number>
+): boolean {
+  const beforeKeys = Object.keys(before).sort();
+  const afterKeys = Object.keys(after).sort();
+
+  if (
+    beforeKeys.length !== afterKeys.length ||
+    beforeKeys.some((key, index) => key !== afterKeys[index])
+  ) {
+    return false;
+  }
+
+  return beforeKeys.every((key) => before[key] === after[key]);
+}
+
 /**
  * VET-900: Detect whether protected control state has been mutated.
  * Compares a pre-operation snapshot against the current session state.
@@ -189,6 +217,22 @@ export function hasControlStateChanged(
       before.clarification_reasons,
       after.clarification_reasons
     )
+  ) {
+    return true;
+  }
+
+  if (before.pending_question_id !== after.pending_question_id) {
+    return true;
+  }
+
+  if (
+    !sameNumberMap(before.question_asked_counts, after.question_asked_counts)
+  ) {
+    return true;
+  }
+
+  if (
+    !sameNumberMap(before.clarification_attempts, after.clarification_attempts)
   ) {
     return true;
   }
@@ -258,6 +302,9 @@ export function mergeCompressionResult(
       // Protected: never comes from compression output
       unresolved_question_ids: protectedState.unresolved_question_ids,
       clarification_reasons: protectedState.clarification_reasons,
+      pending_question_id: protectedState.pending_question_id,
+      question_asked_counts: protectedState.question_asked_counts,
+      clarification_attempts: protectedState.clarification_attempts,
       // Only these fields come from compression
       compressed_summary: compressed.summary.replace(/\s+/g, " ").trim(),
       compression_model: compressed.model,
@@ -497,6 +544,9 @@ export function ensureStructuredCaseMemory(
     red_flag_notes: existing?.red_flag_notes || [],
     unresolved_question_ids: existing?.unresolved_question_ids || [],
     clarification_reasons: existing?.clarification_reasons || {},
+    pending_question_id: existing?.pending_question_id,
+    question_asked_counts: existing?.question_asked_counts || {},
+    clarification_attempts: existing?.clarification_attempts || {},
     timeline_notes: existing?.timeline_notes || [],
     visual_evidence: existing?.visual_evidence || [],
     retrieval_evidence: existing?.retrieval_evidence || [],
@@ -708,6 +758,7 @@ export function syncStructuredCaseMemoryQuestions(
   missingQuestionIds: string[]
 ): TriageSession {
   const memory = ensureStructuredCaseMemory(session);
+  const answeredQuestionIds = new Set(session.answered_questions ?? []);
 
   // VET-900: Merge — not overwrite — unresolved_question_ids.
   // Previous implementation discarded existing unresolved IDs, destroying
@@ -719,7 +770,7 @@ export function syncStructuredCaseMemoryQuestions(
       ...missingQuestionIds,
     ],
     12
-  );
+  ).filter((questionId) => !answeredQuestionIds.has(questionId));
 
   // VET-900: Protect ALL control state fields from clobber.
   // answered_questions, extracted_answers, last_question_asked live on session;
@@ -732,6 +783,11 @@ export function syncStructuredCaseMemoryQuestions(
     last_question_asked: session.last_question_asked,
     case_memory: {
       ...memory,
+      pending_question_id:
+        memory.pending_question_id &&
+        answeredQuestionIds.has(memory.pending_question_id)
+          ? undefined
+          : memory.pending_question_id,
       unresolved_question_ids: mergedUnresolved,
     },
   };

--- a/src/lib/triage-engine.ts
+++ b/src/lib/triage-engine.ts
@@ -76,6 +76,9 @@ export interface StructuredCaseMemory {
   red_flag_notes: string[];
   unresolved_question_ids: string[];
   clarification_reasons?: Record<string, string>;
+  pending_question_id?: string;
+  question_asked_counts?: Record<string, number>;
+  clarification_attempts?: Record<string, number>;
   timeline_notes: string[];
   visual_evidence: VisionClinicalEvidence[];
   retrieval_evidence: Array<RetrievalTextEvidence | RetrievalImageEvidence>;
@@ -134,6 +137,9 @@ export function createSession(): TriageSession {
       red_flag_notes: [],
       unresolved_question_ids: [],
       clarification_reasons: {},
+      pending_question_id: undefined,
+      question_asked_counts: {},
+      clarification_attempts: {},
       timeline_notes: [],
       visual_evidence: [],
       retrieval_evidence: [],

--- a/tests/symptom-chat.repeat-loop.test.ts
+++ b/tests/symptom-chat.repeat-loop.test.ts
@@ -1,0 +1,466 @@
+import {
+  addSymptoms,
+  createSession,
+  type TriageSession,
+} from "@/lib/triage-engine";
+import {
+  getProtectedConversationState,
+  mergeCompressionResult,
+} from "@/lib/symptom-memory";
+
+const mockCheckRateLimit = jest.fn();
+const mockGetRateLimitId = jest.fn();
+const mockCreateServerSupabaseClient = jest.fn();
+const mockIsNvidiaConfigured = jest.fn(() => true);
+const mockExtractWithQwen = jest.fn();
+const mockPhraseWithLlama = jest.fn();
+const mockVerifyQuestionWithNemotron = jest.fn();
+const mockRunRoboflowSkinWorkflow = jest.fn();
+const mockShouldAnalyzeWoundImage = jest.fn();
+const mockCompressCaseMemoryWithMiniMax = jest.fn();
+const mockIsVisionPreprocessConfigured = jest.fn(() => false);
+const mockIsMultimodalConsultConfigured = jest.fn(() => false);
+const mockIsTextRetrievalConfigured = jest.fn(() => false);
+const mockIsImageRetrievalConfigured = jest.fn(() => false);
+
+jest.mock("@/lib/rate-limit", () => ({
+  symptomChatLimiter: {},
+  checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
+  getRateLimitId: (...args: unknown[]) => mockGetRateLimitId(...args),
+}));
+
+jest.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: (...args: unknown[]) =>
+    mockCreateServerSupabaseClient(...args),
+}));
+
+jest.mock("@/lib/nvidia-models", () => ({
+  isNvidiaConfigured: (...args: unknown[]) => mockIsNvidiaConfigured(...args),
+  extractWithQwen: (...args: unknown[]) => mockExtractWithQwen(...args),
+  phraseWithLlama: (...args: unknown[]) => mockPhraseWithLlama(...args),
+  verifyQuestionWithNemotron: (...args: unknown[]) =>
+    mockVerifyQuestionWithNemotron(...args),
+  reviewQuestionPlanWithNemotron: jest.fn(),
+  runVisionPipeline: jest.fn(),
+  parseVisionForMatrix: jest.fn(),
+  imageGuardrail: jest.fn(),
+  diagnoseWithDeepSeek: jest.fn(),
+  verifyWithGLM: jest.fn(),
+}));
+
+jest.mock("@/lib/pet-enrichment", () => ({
+  detectBreedWithNyckel: jest.fn(),
+  fetchBreedProfile: jest.fn(),
+  getEffectivePetProfile: (pet: unknown) => pet,
+  isLikelyDogContext: () => true,
+  runRoboflowSkinWorkflow: (...args: unknown[]) =>
+    mockRunRoboflowSkinWorkflow(...args),
+  shouldUseImageInferredBreed: () => false,
+}));
+
+jest.mock("@/lib/image-gate", () => ({
+  evaluateImageGate: jest.fn(),
+  shouldAnalyzeWoundImage: (...args: unknown[]) =>
+    mockShouldAnalyzeWoundImage(...args),
+}));
+
+jest.mock("@/lib/minimax", () => ({
+  isMiniMaxConfigured: () => true,
+  compressCaseMemoryWithMiniMax: (...args: unknown[]) =>
+    mockCompressCaseMemoryWithMiniMax(...args),
+}));
+
+jest.mock("@/lib/hf-sidecars", () => {
+  const actual = jest.requireActual("@/lib/hf-sidecars");
+  return {
+    ...actual,
+    isVisionPreprocessConfigured: (...args: unknown[]) =>
+      mockIsVisionPreprocessConfigured(...args),
+    isTextRetrievalConfigured: (...args: unknown[]) =>
+      mockIsTextRetrievalConfigured(...args),
+    isImageRetrievalConfigured: (...args: unknown[]) =>
+      mockIsImageRetrievalConfigured(...args),
+    isMultimodalConsultConfigured: (...args: unknown[]) =>
+      mockIsMultimodalConsultConfigured(...args),
+    preprocessVeterinaryImage: jest.fn(),
+    consultWithMultimodalSidecar: jest.fn(),
+    retrieveVeterinaryEvidenceFromSidecar: jest.fn(),
+  };
+});
+
+jest.mock("@/lib/text-retrieval-service", () => ({
+  isTextRetrievalConfigured: (...args: unknown[]) =>
+    mockIsTextRetrievalConfigured(...args),
+  retrieveVeterinaryTextEvidence: jest.fn(),
+}));
+
+jest.mock("@/lib/image-retrieval-service", () => ({
+  isImageRetrievalConfigured: (...args: unknown[]) =>
+    mockIsImageRetrievalConfigured(...args),
+  retrieveVeterinaryImageEvidence: jest.fn(),
+}));
+
+jest.mock("@/lib/async-review-client", () => ({
+  enqueueAsyncReview: jest.fn(),
+}));
+
+jest.mock("@/lib/confidence-calibrator", () => ({
+  calibrateDiagnosticConfidence: jest.fn(),
+}));
+
+jest.mock("@/lib/icd-10-mapper", () => ({
+  getICD10CodesForDisease: () => null,
+  generateICD10Summary: () => [],
+}));
+
+jest.mock("@/lib/report-storage", () => ({
+  saveSymptomReportToDB: jest.fn(),
+}));
+
+jest.mock("@/lib/events/event-bus", () => ({
+  EventType: {
+    REPORT_READY: "REPORT_READY",
+    URGENCY_HIGH: "URGENCY_HIGH",
+    OUTCOME_REQUESTED: "OUTCOME_REQUESTED",
+    SUBSCRIPTION_CHANGED: "SUBSCRIPTION_CHANGED",
+    PET_ADDED: "PET_ADDED",
+  },
+  emit: jest.fn(),
+}));
+
+jest.mock("@/lib/events/notification-handler", () => ({}));
+
+const PET = {
+  name: "Bruno",
+  breed: "Golden Retriever",
+  age_years: 5,
+  weight: 72,
+  species: "dog",
+};
+
+function makeTextOnlyRequest(session: TriageSession, message: string) {
+  return new Request("http://localhost/api/ai/symptom-chat", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      action: "chat",
+      pet: PET,
+      session,
+      messages: [{ role: "user", content: message }],
+    }),
+  });
+}
+
+function buildAuthSupabase(userId: string | null) {
+  return {
+    auth: {
+      getUser: jest.fn().mockResolvedValue({
+        data: {
+          user: userId ? { id: userId } : null,
+        },
+      }),
+    },
+  };
+}
+
+function seedPendingQuestion(
+  session: TriageSession,
+  questionId: string,
+  options?: {
+    askedCount?: number;
+    clarificationAttempts?: number;
+    unresolved?: boolean;
+  }
+): TriageSession {
+  const askedCount = options?.askedCount ?? 1;
+  const clarificationAttempts = options?.clarificationAttempts ?? 0;
+  const unresolved = options?.unresolved ?? true;
+  const caseMemory = session.case_memory!;
+
+  return {
+    ...session,
+    last_question_asked: questionId,
+    case_memory: {
+      ...caseMemory,
+      pending_question_id: questionId,
+      question_asked_counts: {
+        ...(caseMemory.question_asked_counts ?? {}),
+        [questionId]: askedCount,
+      },
+      clarification_attempts: {
+        ...(caseMemory.clarification_attempts ?? {}),
+        [questionId]: clarificationAttempts,
+      },
+      unresolved_question_ids: unresolved
+        ? Array.from(
+            new Set([...(caseMemory.unresolved_question_ids ?? []), questionId])
+          )
+        : caseMemory.unresolved_question_ids ?? [],
+      clarification_reasons: unresolved
+        ? {
+            ...(caseMemory.clarification_reasons ?? {}),
+            [questionId]: "pending_recovery_failed",
+          }
+        : caseMemory.clarification_reasons ?? {},
+    },
+  };
+}
+
+async function postTurn(session: TriageSession, message: string) {
+  const { POST } = await import("@/app/api/ai/symptom-chat/route");
+  const response = await POST(makeTextOnlyRequest(session, message));
+  const payload = await response.json();
+  return { response, payload };
+}
+
+describe("VET-1423 pending question repeat-loop guardrails", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    mockCheckRateLimit.mockResolvedValue({
+      success: true,
+      reset: Date.now() + 60_000,
+    });
+    mockGetRateLimitId.mockReturnValue("test-user");
+    mockCreateServerSupabaseClient.mockResolvedValue(buildAuthSupabase(null));
+    mockCompressCaseMemoryWithMiniMax.mockResolvedValue({
+      summary: "Case summary.",
+      model: "MiniMax-M2.7",
+    });
+    mockRunRoboflowSkinWorkflow.mockResolvedValue({
+      positive: false,
+      summary: "",
+      labels: [],
+    });
+    mockShouldAnalyzeWoundImage.mockReturnValue(false);
+    mockExtractWithQwen.mockResolvedValue(
+      JSON.stringify({ symptoms: [], answers: {} })
+    );
+    mockPhraseWithLlama.mockImplementation(async (prompt: string) => {
+      const questionId =
+        prompt.match(/\(Internal ID: ([^,)\n]+)/)?.[1] || "unknown";
+      return `QUESTION_ID:${questionId}`;
+    });
+    mockVerifyQuestionWithNemotron.mockImplementation(async (prompt: string) => {
+      const questionId =
+        prompt.match(/Internal ID: ([^\n]+)/)?.[1]?.trim() || "unknown";
+      return JSON.stringify({ message: `Next: ${questionId}?` });
+    });
+  });
+
+  it("resolves duration-style pending answers and does not repeat the answered question", async () => {
+    mockExtractWithQwen.mockResolvedValueOnce(
+      JSON.stringify({ symptoms: ["coughing"], answers: {} })
+    );
+
+    let session = createSession();
+    session = addSymptoms(session, ["coughing"]);
+    session = seedPendingQuestion(session, "cough_duration", {
+      askedCount: 1,
+      clarificationAttempts: 0,
+      unresolved: true,
+    });
+
+    const { response, payload } = await postTurn(session, "For about two days.");
+
+    expect(response.status).toBe(200);
+    expect(payload.type).toBe("question");
+    expect(payload.session.extracted_answers.cough_duration).toBe(
+      "For about two days."
+    );
+    expect(payload.session.answered_questions).toContain("cough_duration");
+    expect(payload.session.last_question_asked).not.toBe("cough_duration");
+    expect(payload.session.case_memory?.unresolved_question_ids ?? []).not.toContain(
+      "cough_duration"
+    );
+    expect(payload.session.case_memory?.pending_question_id).not.toBe(
+      "cough_duration"
+    );
+  });
+
+  it("does not loop forever on repeated 'not sure' replies", async () => {
+    mockExtractWithQwen.mockResolvedValue(
+      JSON.stringify({
+        symptoms: ["drinking_more", "weight_loss"],
+        answers: {},
+      })
+    );
+
+    let session = createSession();
+    session = addSymptoms(session, ["drinking_more", "weight_loss"]);
+    session = seedPendingQuestion(session, "appetite_change", {
+      askedCount: 1,
+      clarificationAttempts: 0,
+      unresolved: true,
+    });
+
+    const firstTurn = await postTurn(session, "not sure");
+
+    expect(firstTurn.response.status).toBe(200);
+    expect(firstTurn.payload.type).toBe("question");
+    expect(firstTurn.payload.session.last_question_asked).toBe(
+      "appetite_change"
+    );
+    expect(
+      firstTurn.payload.session.case_memory?.question_asked_counts
+        ?.appetite_change
+    ).toBe(2);
+    expect(
+      firstTurn.payload.session.case_memory?.clarification_attempts
+        ?.appetite_change
+    ).toBe(1);
+
+    const secondTurn = await postTurn(firstTurn.payload.session, "not sure");
+
+    expect(secondTurn.response.status).toBe(200);
+    expect(secondTurn.payload.type).toBe("cannot_assess");
+    expect(secondTurn.payload.reason_code).toBe(
+      "owner_cannot_assess_appetite_change"
+    );
+  });
+
+  it("does not re-ask the same non-critical question more than twice after skipped replies", async () => {
+    mockExtractWithQwen.mockResolvedValue(
+      JSON.stringify({ symptoms: ["limping"], answers: {} })
+    );
+
+    let session = createSession();
+    session = addSymptoms(session, ["limping"]);
+    session = seedPendingQuestion(session, "swelling_present", {
+      askedCount: 1,
+      clarificationAttempts: 0,
+      unresolved: true,
+    });
+
+    const firstTurn = await postTurn(session, "skip");
+
+    expect(firstTurn.response.status).toBe(200);
+    expect(firstTurn.payload.type).toBe("question");
+    expect(firstTurn.payload.session.last_question_asked).toBe(
+      "swelling_present"
+    );
+    expect(
+      firstTurn.payload.session.case_memory?.question_asked_counts
+        ?.swelling_present
+    ).toBe(2);
+    expect(
+      firstTurn.payload.session.case_memory?.clarification_attempts
+        ?.swelling_present
+    ).toBe(1);
+
+    const secondTurn = await postTurn(firstTurn.payload.session, "skip");
+
+    expect(secondTurn.response.status).toBe(200);
+    expect(secondTurn.payload.type).toBe("question");
+    expect(secondTurn.payload.session.extracted_answers.swelling_present).toBe(
+      "unknown"
+    );
+    expect(secondTurn.payload.session.answered_questions).toContain(
+      "swelling_present"
+    );
+    expect(secondTurn.payload.session.last_question_asked).not.toBe(
+      "swelling_present"
+    );
+    expect(
+      secondTurn.payload.session.case_memory?.unresolved_question_ids ?? []
+    ).not.toContain("swelling_present");
+    expect(
+      secondTurn.payload.session.case_memory?.question_asked_counts
+        ?.swelling_present
+    ).toBe(2);
+    expect(
+      secondTurn.payload.session.case_memory?.clarification_attempts
+        ?.swelling_present
+    ).toBe(2);
+  });
+
+  it("escalates safely when a critical pending question reaches the third attempt", async () => {
+    mockExtractWithQwen.mockResolvedValue(
+      JSON.stringify({ symptoms: ["coughing"], answers: {} })
+    );
+
+    let session = createSession();
+    session = addSymptoms(session, ["coughing"]);
+    session = seedPendingQuestion(session, "cough_type", {
+      askedCount: 1,
+      clarificationAttempts: 0,
+      unresolved: true,
+    });
+
+    const firstTurn = await postTurn(
+      session,
+      "I'm not sure what kind of cough it is."
+    );
+
+    expect(firstTurn.response.status).toBe(200);
+    expect(firstTurn.payload.type).toBe("question");
+    expect(firstTurn.payload.session.last_question_asked).toBe("cough_type");
+    expect(
+      firstTurn.payload.session.case_memory?.question_asked_counts?.cough_type
+    ).toBe(2);
+
+    const secondTurn = await postTurn(
+      firstTurn.payload.session,
+      "I'm still not sure what kind of cough it is."
+    );
+
+    expect(secondTurn.response.status).toBe(200);
+    expect(secondTurn.payload.type).toBe("cannot_assess");
+    expect(secondTurn.payload.terminal_state).toBe("cannot_assess");
+    expect(secondTurn.payload.reason_code).toBe(
+      "owner_cannot_assess_cough_type"
+    );
+  });
+
+  it("does not re-add an answered pending question back into unresolved ids", async () => {
+    mockExtractWithQwen.mockResolvedValueOnce(
+      JSON.stringify({ symptoms: ["coughing"], answers: {} })
+    );
+
+    let session = createSession();
+    session = addSymptoms(session, ["coughing"]);
+    session = seedPendingQuestion(session, "cough_duration", {
+      askedCount: 1,
+      clarificationAttempts: 0,
+      unresolved: true,
+    });
+
+    const { payload } = await postTurn(session, "For about two days");
+
+    expect(payload.session.answered_questions).toContain("cough_duration");
+    expect(payload.session.case_memory?.unresolved_question_ids ?? []).not.toContain(
+      "cough_duration"
+    );
+  });
+
+  it("preserves pending question state and ask counts across compression", () => {
+    let session = createSession();
+    session = addSymptoms(session, ["limping"]);
+    session = seedPendingQuestion(session, "swelling_present", {
+      askedCount: 2,
+      clarificationAttempts: 1,
+      unresolved: true,
+    });
+    session.answered_questions = ["which_leg"];
+    session.extracted_answers = { which_leg: "left back leg" };
+
+    const protectedState = getProtectedConversationState(session);
+    const compressed = mergeCompressionResult(
+      session,
+      { summary: "Compressed summary.", model: "MiniMax-M2.7" },
+      protectedState
+    );
+
+    expect(compressed.case_memory?.pending_question_id).toBe(
+      "swelling_present"
+    );
+    expect(
+      compressed.case_memory?.question_asked_counts?.swelling_present
+    ).toBe(2);
+    expect(
+      compressed.case_memory?.clarification_attempts?.swelling_present
+    ).toBe(1);
+    expect(compressed.answered_questions).toEqual(["which_leg"]);
+  });
+});


### PR DESCRIPTION
## Summary
- add protected pending-question control state for active pending id, ask counts, and clarification attempts
- cap pending question asks at two and fail closed on the third unresolved turn
- add a focused repeat-loop regression suite plus implementation notes

## Validation
- npm test -- --runTestsByPath tests/symptom-chat.repeat-loop.test.ts
- npm test -- --testPathPatterns=symptom-chat --runInBand
- npm run build
- npm run eval:benchmark:dangerous -- --skip-preflight
- npm run eval:benchmark:release-gate

## Notes
- no Grok or model routing changes
- no emergency sentinel behavior changes
- benchmark report artifacts were left unstaged and are not part of this PR