### PR TITLE
VET-1478C: package VET-1424 deterministic coercion

### DIFF
--- a/src/lib/symptom-chat/answer-coercion.ts
+++ b/src/lib/symptom-chat/answer-coercion.ts
@@ -71,6 +71,7 @@ export function coerceAnswerForQuestion(
 ): string | boolean | number | null {
   const question = FOLLOW_UP_QUESTIONS[questionId];
   const message = rawMessage.trim();
+  const normalized = normalizeIntentText(message);
   const lower = message.toLowerCase();
 
   if (!question || !message) return null;
@@ -91,18 +92,19 @@ export function coerceAnswerForQuestion(
       }
     }
 
-    const words = lower.split(/\s+/).filter(Boolean);
+    const words = normalized.split(/\s+/).filter(Boolean);
     if (
-      /(^|\b)(yes|yeah|yep|true)\b/.test(lower) ||
+      hasLeadingAffirmativeCue(normalized) ||
       (words.length <= 3 &&
-        /^(it is|he is|she is|there is|does|has|is)$/.test(lower))
+        /^(it is|he is|she is|there is|does|has|is)$/.test(normalized))
     ) {
       return true;
     }
     if (
-      /(^|\b)(no|nope|none|not really|false)\b/.test(lower) ||
+      hasLeadingNegativeCue(normalized) ||
+      isShortNegativeResponse(normalized) ||
       (words.length <= 4 &&
-        /^(doesn't|doesnt|isn't|isnt|hasn't|hasnt|not)$/.test(lower))
+        /^(doesn't|doesnt|isn't|isnt|hasn't|hasnt|not)$/.test(normalized))
     ) {
       return false;
     }
@@ -248,6 +250,31 @@ function isShortNegativeResponse(lower: string): boolean {
   );
 }
 
+function hasLeadingAffirmativeCue(normalized: string): boolean {
+  return /^(yes|yeah|yep|yup|sure|correct|right|true|indeed|exactly|absolutely|definitely)\b/.test(
+    normalized
+  );
+}
+
+function hasLeadingNegativeCue(normalized: string): boolean {
+  return /^(no|nope|nah|false)\b/.test(normalized);
+}
+
+export function coerceCanonicalUnknownReply(
+  rawMessage: string
+): "unknown" | null {
+  const normalized = normalizeIntentText(rawMessage);
+  if (!normalized) {
+    return null;
+  }
+
+  if (/^(skip|pass|prefer not to say|rather not say)$/.test(normalized)) {
+    return "unknown";
+  }
+
+  return coerceAmbiguousReplyToUnknown(rawMessage);
+}
+
 function isShortUnknownResponse(lower: string): boolean {
   const normalized = normalizeIntentText(lower);
   return /^(i don't know|i dont know|dont know|do not know|not sure|unsure|unknown|can't tell|cant tell|cannot tell|maybe)$/.test(
@@ -292,7 +319,7 @@ export function shouldClarifyAmbiguousReplyForQuestion(
 function isAmbiguousFollowUpReply(rawMessage: string): boolean {
   const normalized = normalizeIntentText(rawMessage);
   return (
-    coerceAmbiguousReplyToUnknown(rawMessage) !== null ||
+    coerceCanonicalUnknownReply(rawMessage) !== null ||
     /\bi (?:do not|don't|dont) (?:really )?know\b/.test(normalized) ||
     /\bi(?: am|'m)? not sure\b/.test(normalized) ||
     /\b(?:can(?:not|'t)|cant) (?:really )?tell\b/.test(normalized) ||
@@ -337,7 +364,7 @@ export function coerceChoiceAnswerFromIntent(
     questionAllowsCanonicalUnknown(question) &&
     !shouldClarifyAmbiguousReplyForQuestion(questionId)
   ) {
-    const unknownCoercion = coerceAmbiguousReplyToUnknown(rawMessage);
+    const unknownCoercion = coerceCanonicalUnknownReply(rawMessage);
     if (unknownCoercion !== null) {
       return unknownCoercion;
     }
@@ -489,6 +516,28 @@ export function coerceChoiceAnswerFromIntent(
         ["none"],
         ["absent"],
       ]);
+    }
+  }
+
+  if (questionId === "trauma_mobility") {
+    if (
+      /\b(can(?:not|'t)? walk|cannot walk|unable to walk|won't walk|wont walk|can't stand|cannot stand|unable to stand|won't stand|wont stand|dragging)\b/.test(
+        lower
+      )
+    ) {
+      return pickChoiceByPriority(choices, [["inability", "stand"]]);
+    }
+
+    if (
+      /\b(can still walk|can walk|still walking|walking slowly|walking carefully|walks but limps)\b/.test(
+        lower
+      )
+    ) {
+      return pickChoiceByPriority(choices, [["walking"]]);
+    }
+
+    if (/\b(limping|hobbling|favoring it)\b/.test(lower)) {
+      return pickChoiceByPriority(choices, [["limping"]]);
     }
   }
 

--- a/src/lib/symptom-chat/answer-coercion.ts
+++ b/src/lib/symptom-chat/answer-coercion.ts
@@ -521,7 +521,7 @@ export function coerceChoiceAnswerFromIntent(
 
   if (questionId === "trauma_mobility") {
     if (
-      /\b(can(?:not|'t)? walk|cannot walk|unable to walk|won't walk|wont walk|can't stand|cannot stand|unable to stand|won't stand|wont stand|dragging)\b/.test(
+      /\b(can't walk|cant walk|cannot walk|unable to walk|won't walk|wont walk|can't stand|cant stand|cannot stand|unable to stand|won't stand|wont stand|dragging)\b/.test(
         lower
       )
     ) {

--- a/src/lib/symptom-chat/answer-extraction.ts
+++ b/src/lib/symptom-chat/answer-extraction.ts
@@ -128,7 +128,9 @@ export function deriveDeterministicAnswerForQuestion(
 ): string | boolean | number | null {
   switch (questionId) {
     case "which_leg":
-      return extractLegLocation(rawMessage);
+      return extractLegLocation(rawMessage, {
+        allowDistalLimbTerms: true,
+      });
     case "wound_location":
       return extractBodyLocation(rawMessage);
     case "limping_onset":
@@ -418,7 +420,9 @@ export function sanitizeAnswerForQuestion(
 
   switch (questionId) {
     case "which_leg":
-      return extractLegLocation(trimmed);
+      return extractLegLocation(trimmed, {
+        allowDistalLimbTerms: true,
+      });
     case "wound_location":
       return extractBodyLocation(trimmed);
     case "toxin_exposure":
@@ -490,15 +494,22 @@ function sanitizePendingVomitContent(rawMessage: string): string | null {
   return null;
 }
 
-function extractLegLocation(rawMessage: string): string | null {
+function extractLegLocation(
+  rawMessage: string,
+  options?: { allowDistalLimbTerms?: boolean }
+): string | null {
   const lower = rawMessage.toLowerCase();
   const side = /\bleft\b/.test(lower)
     ? "left"
     : /\bright\b/.test(lower)
       ? "right"
       : "";
+  const allowDistalLimbTerms = options?.allowDistalLimbTerms ?? false;
   const mentionsLegContext =
-    /\bleg\b/.test(lower) || /\b(back|hind|rear|front|fore)\b/.test(lower);
+    /\bleg\b/.test(lower) ||
+    /\b(back|hind|rear|front|fore)\b/.test(lower) ||
+    (allowDistalLimbTerms &&
+      /\b(paw|foot|feet|toe|toes|digit|digits)\b/.test(lower));
   const position = /\b(back|hind|rear)\b/.test(lower)
     ? "back"
     : /\b(front|fore)\b/.test(lower)

--- a/src/lib/symptom-chat/answer-extraction.ts
+++ b/src/lib/symptom-chat/answer-extraction.ts
@@ -6,6 +6,7 @@ import { FOLLOW_UP_QUESTIONS, SYMPTOM_MAP } from "@/lib/clinical-matrix";
 import { coerceAmbiguousReplyToUnknown } from "@/lib/ambiguous-reply";
 import {
   coerceAnswerForQuestion,
+  coerceCanonicalUnknownReply,
   coerceChoiceAnswerFromIntent,
   questionAllowsCanonicalUnknown,
   sanitizePendingRawAnswer,
@@ -75,7 +76,7 @@ function coerceFallbackAnswerForPendingQuestion(
     questionAllowsCanonicalUnknown(question) &&
     !shouldClarifyAmbiguousReplyForQuestion(questionId)
   ) {
-    const unknownCoercion = coerceAmbiguousReplyToUnknown(rawMessage);
+    const unknownCoercion = coerceCanonicalUnknownReply(rawMessage);
     if (unknownCoercion !== null) {
       return unknownCoercion;
     }
@@ -121,7 +122,7 @@ export function extractDeterministicAnswersForTurn(
   return answers;
 }
 
-function deriveDeterministicAnswerForQuestion(
+export function deriveDeterministicAnswerForQuestion(
   questionId: string,
   rawMessage: string
 ): string | boolean | number | null {
@@ -420,6 +421,10 @@ export function sanitizeAnswerForQuestion(
       return extractLegLocation(trimmed);
     case "wound_location":
       return extractBodyLocation(trimmed);
+    case "toxin_exposure":
+      return sanitizePendingToxinExposure(trimmed);
+    case "vomit_content":
+      return sanitizePendingVomitContent(trimmed);
     case "limping_onset":
       return extractLimpingOnset(trimmed) ? trimmed : null;
     case "limping_progression":
@@ -439,6 +444,52 @@ export function sanitizeAnswerForQuestion(
   }
 }
 
+function sanitizePendingToxinExposure(rawMessage: string): string | null {
+  const lower = rawMessage.toLowerCase();
+  const canonicalSubstances: Array<[RegExp, string]> = [
+    [/\b(ibuprofen|advil|motrin)\b/, "ibuprofen"],
+    [/\b(naproxen|aleve)\b/, "naproxen"],
+    [/\b(acetaminophen|tylenol)\b/, "acetaminophen"],
+    [/\b(aspirin)\b/, "aspirin"],
+    [/\b(rat poison|rodenticide|mouse bait|bait station)\b/, "rat poison"],
+    [/\b(xylitol)\b/, "xylitol"],
+    [/\b(chocolate|cocoa)\b/, "chocolate"],
+    [/\b(grapes|raisins)\b/, "grapes or raisins"],
+    [/\b(antifreeze|ethylene glycol)\b/, "antifreeze"],
+    [/\b(marijuana|cannabis|thc)\b/, "marijuana"],
+  ];
+
+  for (const [pattern, canonicalValue] of canonicalSubstances) {
+    if (pattern.test(lower)) {
+      return canonicalValue;
+    }
+  }
+
+  return null;
+}
+
+function sanitizePendingVomitContent(rawMessage: string): string | null {
+  const lower = rawMessage.toLowerCase();
+
+  if (
+    /\b(green bile|yellow bile|bile|bright green vomit|green vomit|green fluid|yellow fluid)\b/.test(
+      lower
+    )
+  ) {
+    return "bile";
+  }
+
+  if (/\b(foam|foamy|froth|frothy)\b/.test(lower)) {
+    return "foam";
+  }
+
+  if (/\b(food|undigested food|kibble|grass)\b/.test(lower)) {
+    return "food";
+  }
+
+  return null;
+}
+
 function extractLegLocation(rawMessage: string): string | null {
   const lower = rawMessage.toLowerCase();
   const side = /\bleft\b/.test(lower)
@@ -446,13 +497,15 @@ function extractLegLocation(rawMessage: string): string | null {
     : /\bright\b/.test(lower)
       ? "right"
       : "";
+  const mentionsLegContext =
+    /\bleg\b/.test(lower) || /\b(back|hind|rear|front|fore)\b/.test(lower);
   const position = /\b(back|hind|rear)\b/.test(lower)
     ? "back"
     : /\b(front|fore)\b/.test(lower)
       ? "front"
       : "";
 
-  if (!side) {
+  if (!side || !mentionsLegContext) {
     return null;
   }
 
@@ -679,6 +732,7 @@ function extractRatPoisonAccess(rawMessage: string): boolean | null {
 
 function extractToxinExposure(rawMessage: string): string | null {
   const lower = rawMessage.toLowerCase();
+
   if (
     /\b(rat poison|rodenticide|mouse bait|bait station|xylitol|chocolate|grapes|raisins|antifreeze|ibuprofen|naproxen|acetaminophen|marijuana|cannabis)\b/.test(
       lower
@@ -693,6 +747,14 @@ function extractToxinExposure(rawMessage: string): string | null {
 function extractWeightBearingStatus(rawMessage: string): string | null {
   const lower = rawMessage.toLowerCase();
 
+  if (
+    /\b(partial(?:ly)? weight|partially weight|partial weight|toe touching|touching toes|favoring it|limping but walking)\b/.test(
+      lower
+    )
+  ) {
+    return "partial";
+  }
+
   if (/\bnon[_\s-]?weight[_\s-]?bearing\b/.test(lower)) {
     return "non_weight_bearing";
   }
@@ -706,14 +768,6 @@ function extractWeightBearingStatus(rawMessage: string): string | null {
     )
   ) {
     return "non_weight_bearing";
-  }
-
-  if (
-    /\b(partial weight|barely putting weight|toe touching|touching toes|favoring it|limping but walking)\b/.test(
-      lower
-    )
-  ) {
-    return "partial";
   }
 
   if (/\b(putting weight|bearing weight|walking on it|still using it)\b/.test(lower)) {
@@ -761,7 +815,7 @@ function extractTraumaMobility(rawMessage: string): string | null {
   const lower = rawMessage.toLowerCase();
 
   if (
-    /\b(can'?t use (his|her|their)? ?back legs|cannot use (his|her|their)? ?back legs|dragging (himself|herself|themself)|dragging (his|her|their) back legs|paraly[sz]ed|can'?t stand|unable to stand|barely stand)\b/.test(
+    /\b(can'?t use (his|her|their)? ?back legs|cannot use (his|her|their)? ?back legs|dragging (himself|herself|themself)|dragging (his|her|their) back legs|paraly[sz]ed|can'?t stand|unable to stand|barely stand|can'?t walk|cannot walk|won't walk|wont walk)\b/.test(
       lower
     )
   ) {
@@ -772,7 +826,7 @@ function extractTraumaMobility(rawMessage: string): string | null {
     return "limping";
   }
 
-  if (/\bwalking|still walking|walking okay\b/.test(lower)) {
+  if (/\bwalking|still walking|walking okay|can still walk|can walk\b/.test(lower)) {
     return "walking";
   }
 

--- a/src/lib/symptom-chat/context-helpers.ts
+++ b/src/lib/symptom-chat/context-helpers.ts
@@ -150,6 +150,12 @@ function hasLongUnknownLikeReply(rawMessage: string): boolean {
   );
 }
 
+function isExplicitCanonicalUnknownOptOut(normalizedMessage: string): boolean {
+  return /^(skip|pass|prefer not to say|rather not say)$/.test(
+    normalizedMessage
+  );
+}
+
 function startsWithAnchoredBooleanCue(normalizedMessage: string): boolean {
   return /^(yes|yeah|yep|yup|sure|correct|right|true|indeed|exactly|absolutely|definitely|no|nope|nah|false)\b/.test(
     normalizedMessage
@@ -516,6 +522,13 @@ export function getDeterministicFastPathExtraction(
   if (!question) return null;
 
   const normalizedMessage = normalizeIntentText(trimmed);
+
+  if (
+    shouldEscalateForUnknown(pendingQuestionId) &&
+    isExplicitCanonicalUnknownOptOut(normalizedMessage)
+  ) {
+    return null;
+  }
 
   const words = trimmed.split(/\s+/).filter(Boolean);
   const looksShortAnswer =

--- a/src/lib/symptom-chat/context-helpers.ts
+++ b/src/lib/symptom-chat/context-helpers.ts
@@ -16,9 +16,14 @@ import { isInternalTelemetry } from "@/lib/sidecar-observability";
 import { coerceAmbiguousReplyToUnknown } from "@/lib/ambiguous-reply";
 import {
   coerceAnswerForQuestion,
+  coerceChoiceAnswerFromIntent,
+  normalizeChoiceLabel,
+  normalizeIntentText,
   questionAllowsCanonicalUnknown,
+  shouldEscalateForUnknown,
   shouldClarifyAmbiguousReplyForQuestion,
 } from "@/lib/symptom-chat/answer-coercion";
+import { sanitizeAnswerForQuestion } from "@/lib/symptom-chat/answer-extraction";
 import { extractSymptomsFromKeywords } from "@/lib/symptom-chat/extraction-helpers";
 
 const SAFE_FOLLOW_UP_UNKNOWN_QUESTION_IDS = new Set([
@@ -40,7 +45,7 @@ const SAFE_FOLLOW_UP_UNKNOWN_QUESTION_IDS = new Set([
 
 const EXTENDED_FOLLOW_UP_UNKNOWN_PATTERNS = [
   /\bi (?:do not|don't|dont) (?:really )?know\b/,
-  /\bi(?: am|'m)? not sure\b/,
+  /\bi(?: am|'m)? not (?:really )?sure\b/,
   /\b(?:do not|don't|dont) remember\b/,
   /\b(?:did not|didn't|didnt) (?:really )?(?:look|notice)\b/,
   /\b(?:can(?:not|'t)|cant) (?:really )?(?:tell|pinpoint|judge|describe)\b/,
@@ -80,6 +85,127 @@ function coerceExtendedFollowUpUnknown(
   )
     ? "unknown"
     : null;
+}
+
+const PENDING_FAST_PATH_STRING_ENTITY_QUESTION_IDS = new Set([
+  "which_leg",
+  "wound_location",
+]);
+
+function questionLooksDurationLike(question: {
+  question_text?: string;
+  extraction_hint?: string;
+}): boolean {
+  const combinedText =
+    `${question.question_text || ""} ${question.extraction_hint || ""}`.toLowerCase();
+  return /\b(duration|how long|when did|when does|onset|started|going on|timing|frequency)\b/.test(
+    combinedText
+  );
+}
+
+function hasDurationLikeSignal(normalizedMessage: string): boolean {
+  return /\b((?:about|around|roughly|approximately|maybe|almost)\s+)?(\d+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|few|several)\s*(hour|day|week|month|year)s?\b|\b(couple of\s*(hour|day|week|month|year)s?|today|yesterday|tonight|this morning|last night|since|for\s+\w+|sudden|suddenly|gradual|gradually)\b/.test(
+    normalizedMessage
+  );
+}
+
+function coercePendingFastPathAnswer(
+  questionId: string,
+  rawMessage: string
+): string | boolean | number | null {
+  if (PENDING_FAST_PATH_STRING_ENTITY_QUESTION_IDS.has(questionId)) {
+    return sanitizeAnswerForQuestion(questionId, rawMessage);
+  }
+
+  return coerceAnswerForQuestion(questionId, rawMessage);
+}
+
+function hasLongUnknownLikeReply(rawMessage: string): boolean {
+  const normalized = normalizeExtendedUnknownReply(rawMessage);
+  return (
+    normalized.length > 0 &&
+    EXTENDED_FOLLOW_UP_UNKNOWN_PATTERNS.some((pattern) =>
+      pattern.test(normalized)
+    )
+  );
+}
+
+function startsWithAnchoredBooleanCue(normalizedMessage: string): boolean {
+  return /^(yes|yeah|yep|yup|sure|correct|right|true|indeed|exactly|absolutely|definitely|no|nope|nah|not really|not at all|no way|it's not|its not|not)\b/.test(
+    normalizedMessage
+  );
+}
+
+function messageMatchesChoiceLabel(
+  question: {
+    choices?: readonly string[];
+  },
+  normalizedMessage: string
+): boolean {
+  return Array.isArray(question.choices)
+    ? question.choices.some((choice) =>
+        normalizedMessage.includes(normalizeChoiceLabel(String(choice)))
+      )
+    : false;
+}
+
+function shouldAllowPendingUnknownFastPath(
+  questionId: string,
+  question: {
+    data_type: "boolean" | "string" | "number" | "choice";
+    choices?: readonly string[];
+  },
+  rawMessage: string
+): boolean {
+  return (
+    questionAllowsCanonicalUnknown(question) &&
+    !shouldClarifyAmbiguousReplyForQuestion(questionId) &&
+    !shouldEscalateForUnknown(questionId) &&
+    hasLongUnknownLikeReply(rawMessage)
+  );
+}
+
+function shouldAllowLongPendingAnswerFastPath(
+  questionId: string,
+  question: {
+    data_type: "boolean" | "string" | "number" | "choice";
+    question_text?: string;
+    extraction_hint?: string;
+    choices?: readonly string[];
+  },
+  rawMessage: string,
+  normalizedMessage: string,
+  coercedAnswer: string | boolean | number
+): boolean {
+  if (question.data_type === "boolean") {
+    return (
+      typeof coercedAnswer === "boolean" &&
+      startsWithAnchoredBooleanCue(normalizedMessage)
+    );
+  }
+
+  if (question.data_type === "choice") {
+    return (
+      typeof coercedAnswer === "string" &&
+      (coerceChoiceAnswerFromIntent(questionId, rawMessage) !== null ||
+        messageMatchesChoiceLabel(question, normalizedMessage) ||
+        startsWithAnchoredBooleanCue(normalizedMessage))
+    );
+  }
+
+  if (question.data_type !== "string" || typeof coercedAnswer !== "string") {
+    return false;
+  }
+
+  if (
+    questionLooksDurationLike(question) &&
+    (hasDurationLikeSignal(normalizedMessage) ||
+      shouldAllowPendingUnknownFastPath(questionId, question, rawMessage))
+  ) {
+    return true;
+  }
+
+  return PENDING_FAST_PATH_STRING_ENTITY_QUESTION_IDS.has(questionId);
 }
 
 export function buildCompactImageSignalContext(
@@ -360,14 +486,14 @@ export function getDeterministicFastPathExtraction(
   const question = FOLLOW_UP_QUESTIONS[pendingQuestionId];
   if (!question) return null;
 
+  const normalizedMessage = normalizeIntentText(trimmed);
+
   const words = trimmed.split(/\s+/).filter(Boolean);
   const looksShortAnswer =
     trimmed.length <= 80 &&
     words.length <= 12 &&
     !/[\n\r]/.test(trimmed) &&
     (question.data_type !== "string" || !/[.!?].+[.!?]/.test(trimmed));
-
-  if (!looksShortAnswer) return null;
 
   if (
     questionAllowsCanonicalUnknown(question) &&
@@ -384,6 +510,15 @@ export function getDeterministicFastPathExtraction(
     }
   }
 
+  if (shouldAllowPendingUnknownFastPath(pendingQuestionId, question, trimmed)) {
+    return {
+      symptoms: [],
+      answers: {
+        [pendingQuestionId]: "unknown",
+      },
+    };
+  }
+
   const newKeywordSymptoms = extractSymptomsFromKeywords(trimmed).filter(
     (symptom) => !session.known_symptoms.includes(symptom)
   );
@@ -391,8 +526,26 @@ export function getDeterministicFastPathExtraction(
     return null;
   }
 
-  const coercedAnswer = coerceAnswerForQuestion(pendingQuestionId, trimmed);
-  if (coercedAnswer === null) return null;
+  const coercedAnswer = coercePendingFastPathAnswer(
+    pendingQuestionId,
+    trimmed
+  );
+  if (coercedAnswer === null) {
+    return null;
+  }
+
+  if (
+    !looksShortAnswer &&
+    !shouldAllowLongPendingAnswerFastPath(
+      pendingQuestionId,
+      question,
+      trimmed,
+      normalizedMessage,
+      coercedAnswer
+    )
+  ) {
+    return null;
+  }
 
   return {
     symptoms: [],

--- a/src/lib/symptom-chat/context-helpers.ts
+++ b/src/lib/symptom-chat/context-helpers.ts
@@ -13,9 +13,9 @@ import {
 } from "@/lib/image-gate";
 import type { SidecarObservation } from "@/lib/clinical-evidence";
 import { isInternalTelemetry } from "@/lib/sidecar-observability";
-import { coerceAmbiguousReplyToUnknown } from "@/lib/ambiguous-reply";
 import {
   coerceAnswerForQuestion,
+  coerceCanonicalUnknownReply,
   coerceChoiceAnswerFromIntent,
   normalizeChoiceLabel,
   normalizeIntentText,
@@ -23,7 +23,10 @@ import {
   shouldEscalateForUnknown,
   shouldClarifyAmbiguousReplyForQuestion,
 } from "@/lib/symptom-chat/answer-coercion";
-import { sanitizeAnswerForQuestion } from "@/lib/symptom-chat/answer-extraction";
+import {
+  deriveDeterministicAnswerForQuestion,
+  sanitizeAnswerForQuestion,
+} from "@/lib/symptom-chat/answer-extraction";
 import { extractSymptomsFromKeywords } from "@/lib/symptom-chat/extraction-helpers";
 
 const SAFE_FOLLOW_UP_UNKNOWN_QUESTION_IDS = new Set([
@@ -90,6 +93,13 @@ function coerceExtendedFollowUpUnknown(
 const PENDING_FAST_PATH_STRING_ENTITY_QUESTION_IDS = new Set([
   "which_leg",
   "wound_location",
+  "toxin_exposure",
+  "vomit_content",
+]);
+
+const PENDING_FAST_PATH_DERIVED_QUESTION_IDS = new Set([
+  "weight_bearing",
+  "trauma_mobility",
 ]);
 
 function questionLooksDurationLike(question: {
@@ -113,6 +123,16 @@ function coercePendingFastPathAnswer(
   questionId: string,
   rawMessage: string
 ): string | boolean | number | null {
+  if (PENDING_FAST_PATH_DERIVED_QUESTION_IDS.has(questionId)) {
+    const deterministicAnswer = deriveDeterministicAnswerForQuestion(
+      questionId,
+      rawMessage
+    );
+    if (deterministicAnswer !== null) {
+      return deterministicAnswer;
+    }
+  }
+
   if (PENDING_FAST_PATH_STRING_ENTITY_QUESTION_IDS.has(questionId)) {
     return sanitizeAnswerForQuestion(questionId, rawMessage);
   }
@@ -131,7 +151,7 @@ function hasLongUnknownLikeReply(rawMessage: string): boolean {
 }
 
 function startsWithAnchoredBooleanCue(normalizedMessage: string): boolean {
-  return /^(yes|yeah|yep|yup|sure|correct|right|true|indeed|exactly|absolutely|definitely|no|nope|nah|not really|not at all|no way|it's not|its not|not)\b/.test(
+  return /^(yes|yeah|yep|yup|sure|correct|right|true|indeed|exactly|absolutely|definitely|no|nope|nah|false)\b/.test(
     normalizedMessage
   );
 }
@@ -177,17 +197,25 @@ function shouldAllowLongPendingAnswerFastPath(
   normalizedMessage: string,
   coercedAnswer: string | boolean | number
 ): boolean {
+  const deterministicAnswer = PENDING_FAST_PATH_DERIVED_QUESTION_IDS.has(
+    questionId
+  )
+    ? deriveDeterministicAnswerForQuestion(questionId, rawMessage)
+    : null;
+
   if (question.data_type === "boolean") {
     return (
       typeof coercedAnswer === "boolean" &&
-      startsWithAnchoredBooleanCue(normalizedMessage)
+      (startsWithAnchoredBooleanCue(normalizedMessage) ||
+        deterministicAnswer !== null)
     );
   }
 
   if (question.data_type === "choice") {
     return (
       typeof coercedAnswer === "string" &&
-      (coerceChoiceAnswerFromIntent(questionId, rawMessage) !== null ||
+      (deterministicAnswer !== null ||
+        coerceChoiceAnswerFromIntent(questionId, rawMessage) !== null ||
         messageMatchesChoiceLabel(question, normalizedMessage) ||
         startsWithAnchoredBooleanCue(normalizedMessage))
     );
@@ -199,6 +227,7 @@ function shouldAllowLongPendingAnswerFastPath(
 
   if (
     questionLooksDurationLike(question) &&
+    !/[.!?].+[.!?]/.test(rawMessage) &&
     (hasDurationLikeSignal(normalizedMessage) ||
       shouldAllowPendingUnknownFastPath(questionId, question, rawMessage))
   ) {
@@ -499,7 +528,7 @@ export function getDeterministicFastPathExtraction(
     questionAllowsCanonicalUnknown(question) &&
     !shouldClarifyAmbiguousReplyForQuestion(pendingQuestionId)
   ) {
-    const unknownCoercion = coerceAmbiguousReplyToUnknown(trimmed);
+    const unknownCoercion = coerceCanonicalUnknownReply(trimmed);
     if (unknownCoercion !== null) {
       return {
         symptoms: [],

--- a/tests/symptom-chat.answer-coercion.test.ts
+++ b/tests/symptom-chat.answer-coercion.test.ts
@@ -75,6 +75,16 @@ describe("VET-1424 deterministic answer coercion", () => {
     expect(extraction).toBeNull();
   });
 
+  it("keeps unsafe pending string questions unresolved for canonical unknown skip replies", () => {
+    const session = buildPendingSession(
+      "breathing_onset",
+      ["difficulty_breathing"]
+    );
+    const extraction = getDeterministicFastPathExtraction(session, "skip");
+
+    expect(extraction).toBeNull();
+  });
+
   it("does not coerce a vague negative into a false emergency-red-flag answer", () => {
     const session = buildPendingSession("vomit_blood", ["vomiting"]);
     const extraction = getDeterministicFastPathExtraction(
@@ -165,6 +175,21 @@ describe("VET-1424 deterministic answer coercion", () => {
     const extraction = getDeterministicFastPathExtraction(
       session,
       "He can still walk on it, just slowly and carefully."
+    );
+
+    expect(extraction).toEqual({
+      symptoms: [],
+      answers: {
+        trauma_mobility: "walking",
+      },
+    });
+  });
+
+  it("treats plain can-walk replies as ambulatory mobility", () => {
+    const session = buildPendingSession("trauma_mobility", ["limping"]);
+    const extraction = getDeterministicFastPathExtraction(
+      session,
+      "He can walk, just not very fast."
     );
 
     expect(extraction).toEqual({

--- a/tests/symptom-chat.answer-coercion.test.ts
+++ b/tests/symptom-chat.answer-coercion.test.ts
@@ -245,6 +245,21 @@ describe("VET-1424 deterministic answer coercion", () => {
     });
   });
 
+  it("coerces sided paw replies for pending which-leg questions", () => {
+    const session = buildPendingSession("which_leg", ["limping"]);
+    const extraction = getDeterministicFastPathExtraction(
+      session,
+      "It looks like the left paw is the one bothering him."
+    );
+
+    expect(extraction).toEqual({
+      symptoms: [],
+      answers: {
+        which_leg: "left leg",
+      },
+    });
+  });
+
   it("coerces body-part location replies for wound questions", () => {
     const session = buildPendingSession("wound_location", ["wound_skin_issue"]);
     const extraction = getDeterministicFastPathExtraction(

--- a/tests/symptom-chat.answer-coercion.test.ts
+++ b/tests/symptom-chat.answer-coercion.test.ts
@@ -1,0 +1,285 @@
+jest.mock("@/lib/nvidia-models", () => ({
+  extractWithQwen: jest.fn(),
+}));
+
+import { createSession, type TriageSession } from "@/lib/triage-engine";
+import { getDeterministicFastPathExtraction } from "@/lib/symptom-chat/context-helpers";
+
+function buildPendingSession(
+  questionId: string,
+  knownSymptoms: string[]
+): TriageSession {
+  const session = createSession();
+
+  return {
+    ...session,
+    known_symptoms: knownSymptoms,
+    candidate_diseases: ["placeholder_condition"],
+    body_systems_involved: ["systemic"],
+    last_question_asked: questionId,
+    case_memory: {
+      ...session.case_memory,
+      unresolved_question_ids: [questionId],
+    },
+  };
+}
+
+describe("VET-1424 deterministic answer coercion", () => {
+  it.each([
+    "for about two days",
+    "since Tuesday",
+    "started yesterday",
+    "a few hours",
+    "about a week",
+    "two weeks ago",
+  ])(
+    "coerces anchored duration reply '%s' for pending duration questions",
+    (message) => {
+      const session = buildPendingSession("vomit_duration", ["vomiting"]);
+      const extraction = getDeterministicFastPathExtraction(session, message);
+
+      expect(extraction).toEqual({
+        symptoms: [],
+        answers: {
+          vomit_duration: message,
+        },
+      });
+    }
+  );
+
+  it.each([
+    "not sure",
+    "I can't tell",
+    "I don't know",
+    "maybe",
+    "skip",
+  ])("coerces '%s' to unknown for safe anchored follow-up questions", (message) => {
+    const session = buildPendingSession("vomit_duration", ["vomiting"]);
+    const extraction = getDeterministicFastPathExtraction(session, message);
+
+    expect(extraction).toEqual({
+      symptoms: [],
+      answers: {
+        vomit_duration: "unknown",
+      },
+    });
+  });
+
+  it("keeps emergency unknown replies unresolved when the question does not allow canonical unknown", () => {
+    const session = buildPendingSession("gum_color", ["difficulty_breathing"]);
+    const extraction = getDeterministicFastPathExtraction(
+      session,
+      "I can't tell what color they are."
+    );
+
+    expect(extraction).toBeNull();
+  });
+
+  it("does not coerce a vague negative into a false emergency-red-flag answer", () => {
+    const session = buildPendingSession("vomit_blood", ["vomiting"]);
+    const extraction = getDeterministicFastPathExtraction(
+      session,
+      "Not really sure, I did not get a good look."
+    );
+
+    expect(extraction).toBeNull();
+  });
+
+  it("still accepts an explicit denial for emergency-red-flag follow-ups", () => {
+    const session = buildPendingSession("vomit_blood", ["vomiting"]);
+    const extraction = getDeterministicFastPathExtraction(
+      session,
+      "No, there is no blood in what he threw up."
+    );
+
+    expect(extraction).toEqual({
+      symptoms: [],
+      answers: {
+        vomit_blood: false,
+      },
+    });
+  });
+
+  it("coerces long yes replies for pending boolean questions", () => {
+    const session = buildPendingSession("pain_on_touch", ["limping"]);
+    const extraction = getDeterministicFastPathExtraction(
+      session,
+      "Yes, he yelps every time I touch that front leg near the paw."
+    );
+
+    expect(extraction).toEqual({
+      symptoms: [],
+      answers: {
+        pain_on_touch: true,
+      },
+    });
+  });
+
+  it("coerces long choice replies for pending normality questions", () => {
+    const session = buildPendingSession("water_intake", ["drinking_more"]);
+    const extraction = getDeterministicFastPathExtraction(
+      session,
+      "She is drinking less than usual lately, and I only see a few sips now."
+    );
+
+    expect(extraction).toEqual({
+      symptoms: [],
+      answers: {
+        water_intake: "less_than_usual",
+      },
+    });
+  });
+
+  it("coerces appetite status replies deterministically", () => {
+    const session = buildPendingSession("appetite_status", ["vomiting"]);
+    const extraction = getDeterministicFastPathExtraction(
+      session,
+      "He is eating less than usual today."
+    );
+
+    expect(extraction).toEqual({
+      symptoms: [],
+      answers: {
+        appetite_status: "decreased",
+      },
+    });
+  });
+
+  it("coerces partial weight-bearing replies deterministically", () => {
+    const session = buildPendingSession("weight_bearing", ["limping"]);
+    const extraction = getDeterministicFastPathExtraction(
+      session,
+      "He is only partially weight bearing and just toe touching on that leg."
+    );
+
+    expect(extraction).toEqual({
+      symptoms: [],
+      answers: {
+        weight_bearing: "partial",
+      },
+    });
+  });
+
+  it("coerces mobility walk phrasing for trauma mobility questions", () => {
+    const session = buildPendingSession("trauma_mobility", ["limping"]);
+    const extraction = getDeterministicFastPathExtraction(
+      session,
+      "He can still walk on it, just slowly and carefully."
+    );
+
+    expect(extraction).toEqual({
+      symptoms: [],
+      answers: {
+        trauma_mobility: "walking",
+      },
+    });
+  });
+
+  it("coerces cannot-walk phrasing for trauma mobility questions", () => {
+    const session = buildPendingSession("trauma_mobility", ["limping"]);
+    const extraction = getDeterministicFastPathExtraction(
+      session,
+      "He cannot walk and keeps dragging the leg."
+    );
+
+    expect(extraction).toEqual({
+      symptoms: [],
+      answers: {
+        trauma_mobility: "inability_to_stand",
+      },
+    });
+  });
+
+  it("coerces mild/moderate/severe choice labels directly", () => {
+    const session = buildPendingSession("lethargy_severity", ["lethargy"]);
+    const extraction = getDeterministicFastPathExtraction(
+      session,
+      "I would call it moderate overall."
+    );
+
+    expect(extraction).toEqual({
+      symptoms: [],
+      answers: {
+        lethargy_severity: "moderate",
+      },
+    });
+  });
+
+  it("coerces long simple location replies for pending entity questions", () => {
+    const session = buildPendingSession("which_leg", ["limping"]);
+    const extraction = getDeterministicFastPathExtraction(
+      session,
+      "It seems to be the left back leg, mostly around the knee when he walks."
+    );
+
+    expect(extraction).toEqual({
+      symptoms: [],
+      answers: {
+        which_leg: "left back leg",
+      },
+    });
+  });
+
+  it("coerces body-part location replies for wound questions", () => {
+    const session = buildPendingSession("wound_location", ["wound_skin_issue"]);
+    const extraction = getDeterministicFastPathExtraction(
+      session,
+      "The sore is on her right paw near the toes."
+    );
+
+    expect(extraction).toEqual({
+      symptoms: [],
+      answers: {
+        wound_location: "right paw",
+      },
+    });
+  });
+
+  it("coerces medication/substance mentions for anchored exposure questions", () => {
+    const session = buildPendingSession("toxin_exposure", ["vomiting"]);
+    const message = "He got into ibuprofen tablets from my bag last night.";
+    const extraction = getDeterministicFastPathExtraction(session, message);
+
+    expect(extraction).toEqual({
+      symptoms: [],
+      answers: {
+        toxin_exposure: "ibuprofen",
+      },
+    });
+  });
+
+  it("coerces appearance replies for anchored vomit-content questions", () => {
+    const session = buildPendingSession("vomit_content", ["vomiting"]);
+    const extraction = getDeterministicFastPathExtraction(
+      session,
+      "It looks like yellow bile with some foam."
+    );
+
+    expect(extraction).toEqual({
+      symptoms: [],
+      answers: {
+        vomit_content: "bile",
+      },
+    });
+  });
+
+  it("stays unresolved when the reply introduces a new symptom outside the pending question", () => {
+    const session = buildPendingSession("vomit_duration", ["vomiting"]);
+    const extraction = getDeterministicFastPathExtraction(
+      session,
+      "He has been vomiting for two days and is limping now."
+    );
+
+    expect(extraction).toBeNull();
+  });
+
+  it("stays unresolved when a long pending string reply does not contain a deterministic entity", () => {
+    const session = buildPendingSession("which_leg", ["limping"]);
+    const extraction = getDeterministicFastPathExtraction(
+      session,
+      "He started limping after fetch yesterday and it seems worse after exercise."
+    );
+
+    expect(extraction).toBeNull();
+  });
+});

--- a/tests/symptom-chat.pending-answer-coercion.test.ts
+++ b/tests/symptom-chat.pending-answer-coercion.test.ts
@@ -1,0 +1,112 @@
+import {
+  createSession,
+  type TriageSession,
+} from "@/lib/triage-engine";
+import { getDeterministicFastPathExtraction } from "@/lib/symptom-chat/context-helpers";
+
+function buildPendingSession(
+  questionId: string,
+  knownSymptoms: string[]
+): TriageSession {
+  const session = createSession();
+
+  return {
+    ...session,
+    known_symptoms: knownSymptoms,
+    candidate_diseases: ["placeholder_condition"],
+    body_systems_involved: ["systemic"],
+    last_question_asked: questionId,
+    case_memory: {
+      ...session.case_memory,
+      unresolved_question_ids: [questionId],
+    },
+  };
+}
+
+describe("VET-1424 pending answer coercion fast path", () => {
+  it("resolves long duration replies for pending duration questions", () => {
+    const session = buildPendingSession("vomit_duration", ["vomiting"]);
+    const extraction = getDeterministicFastPathExtraction(
+      session,
+      "He has been vomiting since Monday night, so it has been about two days now overall."
+    );
+
+    expect(extraction).toEqual({
+      symptoms: [],
+      answers: {
+        vomit_duration:
+          "He has been vomiting since Monday night, so it has been about two days now overall.",
+      },
+    });
+  });
+
+  it("resolves long yes replies for pending boolean questions", () => {
+    const session = buildPendingSession("pain_on_touch", ["limping"]);
+    const extraction = getDeterministicFastPathExtraction(
+      session,
+      "Yes, he yelps every time I touch that front leg near the paw."
+    );
+
+    expect(extraction).toEqual({
+      symptoms: [],
+      answers: {
+        pain_on_touch: true,
+      },
+    });
+  });
+
+  it("resolves long unknown replies for pending safe follow-up questions", () => {
+    const session = buildPendingSession("vomit_duration", ["vomiting"]);
+    const extraction = getDeterministicFastPathExtraction(
+      session,
+      "I am not really sure because I was asleep when it started and my partner noticed first."
+    );
+
+    expect(extraction).toEqual({
+      symptoms: [],
+      answers: {
+        vomit_duration: "unknown",
+      },
+    });
+  });
+
+  it("resolves long choice replies for pending choice questions", () => {
+    const session = buildPendingSession("water_intake", ["drinking_more"]);
+    const extraction = getDeterministicFastPathExtraction(
+      session,
+      "She is drinking less than usual lately, and I only see a few sips now."
+    );
+
+    expect(extraction).toEqual({
+      symptoms: [],
+      answers: {
+        water_intake: "less_than_usual",
+      },
+    });
+  });
+
+  it("resolves long simple location replies for pending entity questions", () => {
+    const session = buildPendingSession("which_leg", ["limping"]);
+    const extraction = getDeterministicFastPathExtraction(
+      session,
+      "It seems to be the left back leg, mostly around the knee when he walks."
+    );
+
+    expect(extraction).toEqual({
+      symptoms: [],
+      answers: {
+        which_leg: "left back leg",
+      },
+    });
+  });
+
+  it("stays unresolved when a long pending string reply does not contain a deterministic entity", () => {
+    const session = buildPendingSession("which_leg", ["limping"]);
+    const extraction = getDeterministicFastPathExtraction(
+      session,
+      "He started limping after fetch yesterday and it seems worse after exercise."
+    );
+
+    expect(extraction).toBeNull();
+  });
+});

--- a/tests/symptom-chat.pending-answer-coercion.test.ts
+++ b/tests/symptom-chat.pending-answer-coercion.test.ts
@@ -1,7 +1,8 @@
-import {
-  createSession,
-  type TriageSession,
-} from "@/lib/triage-engine";
+jest.mock("@/lib/nvidia-models", () => ({
+  extractWithQwen: jest.fn(),
+}));
+
+import { createSession, type TriageSession } from "@/lib/triage-engine";
 import { getDeterministicFastPathExtraction } from "@/lib/symptom-chat/context-helpers";
 
 function buildPendingSession(

--- a/tests/symptom-chat.route.test.ts
+++ b/tests/symptom-chat.route.test.ts
@@ -5272,19 +5272,16 @@ describe("VET-725: asked-state regression pack", () => {
     expect(payload1.session.last_question_asked).toBe("vomit_duration");
 
     const askedOnTurn1 = payload1.session.last_question_asked;
+    mockExtractWithQwen.mockClear();
 
-    // The second-turn message must NOT be caught by the deterministic fast path
-    // (getDeterministicFastPathExtraction). The fast path only fires when
-    // looksShortAnswer is true — which requires no multi-sentence pattern
-    // (/[.!?].+[.!?]/ must not match). Using two complete sentences here forces
-    // looksShortAnswer=false so the fast path returns null and extractWithQwen
-    // runs. The mock returning "not-json" is therefore live, causing extraction
-    // to fail and triggering the pending-recovery raw-text fallback path to
-    // close vomit_duration via shouldPersistRawPendingAnswer/sanitizePendingRawAnswer.
+    // After VET-1424, long anchored duration replies should resolve before
+    // extraction fallback/recovery logic. Keep the invalid extractor mock here
+    // to prove the route no longer depends on broken structured extraction for
+    // this common owner answer shape.
     mockExtractWithQwen.mockResolvedValueOnce("not-json");
 
     const secondTurnMessage =
-      "He has been vomiting for about two days. It started on Monday night.";
+      "He has been vomiting since Monday night, so it has been about two days now overall.";
     const response2 = await POST(
       makeTextOnlyRequest(payload1.session, secondTurnMessage)
     );
@@ -5293,7 +5290,7 @@ describe("VET-725: asked-state regression pack", () => {
     expect(response2.status).toBe(200);
     assertVet725AskedStatePayloadSafe(payload2);
     expect(payload2.type).toBe("question");
-    // The raw-text fallback records the sanitized full message as the answer
+    expect(mockExtractWithQwen).not.toHaveBeenCalled();
     expect(payload2.session.extracted_answers.vomit_duration).toBe(secondTurnMessage);
     expect(payload2.session.answered_questions).toContain(askedOnTurn1);
     expect(payload2.session.last_question_asked).not.toBe(askedOnTurn1);

--- a/tests/symptom-chat.route.test.ts
+++ b/tests/symptom-chat.route.test.ts
@@ -6827,6 +6827,29 @@ describe("VET-900: world-class symptom checker regression pack", () => {
       expect(response.status).toBe(200);
     });
 
+    it("VET-1424: long duration replies resolve on the fast path before extraction", async () => {
+      const session = createSession();
+      const sessionWithSymptom = addSymptoms(session, ["vomiting"]);
+      sessionWithSymptom.last_question_asked = "vomit_duration";
+      sessionWithSymptom.case_memory = {
+        ...sessionWithSymptom.case_memory!,
+        turn_count: 1,
+        unresolved_question_ids: ["vomit_duration"],
+      };
+
+      const longReply =
+        "He has been vomiting since Monday night, so it has been about two days now overall.";
+
+      const { POST } = await import("@/app/api/ai/symptom-chat/route");
+      const response = await POST(makeTextOnlyRequest(sessionWithSymptom, longReply));
+      const payload = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(mockExtractWithQwen).not.toHaveBeenCalled();
+      expect(payload.session.answered_questions).toContain("vomit_duration");
+      expect(payload.session.extracted_answers.vomit_duration).toBe(longReply);
+    });
+
     it("VET-900: 'started last Monday' records as duration text", async () => {
       const session = createSession();
       const sessionWithSymptom = addSymptoms(session, ["vomiting"]);


### PR DESCRIPTION
## Summary
- recover the VET-1424 deterministic coercion package onto current master after VET-1423
- keep the port anchored to pending-question deterministic coercion only, with no model-routing or second-opinion changes
- preserve repeat-loop state behavior while adding focused coercion coverage for owner-style replies

## Validation
- npm test -- --runTestsByPath tests/symptom-chat.answer-coercion.test.ts
- npm test -- --runTestsByPath tests/symptom-chat.repeat-loop.test.ts
- npm test -- --testPathPatterns=symptom-chat --runInBand
- npm run build
- APP_BASE_URL=http://127.0.0.1:3010 npm run eval:benchmark:dangerous -- --skip-preflight
- npm run eval:benchmark:release-gate

## Notes
- Qwen VET-1478Q was treated as readiness/reference coverage only, not as a runtime dependency.
- The default dangerous benchmark localhost:3000 target was occupied by an unrelated app on this machine, so the successful run used the PawVital dev server on 127.0.0.1:3010.