### PR TITLE
VET-1502C: Fix password reset recovery link routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13194,9 +13194,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "brace-expansion": "^1.1.12",
     "handlebars": "^4.7.9",
     "picomatch": "^4.0.4",
-    "postcss": "8.5.12"
+    "postcss": "8.5.12",
+    "ws": "^8.20.1"
   }
 }

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -13,7 +13,7 @@ import {
   getAuthActionErrorMessage,
   resolvePostAuthRedirect,
 } from "@/lib/auth-routing";
-import { createClient, isSupabaseConfigured } from "@/lib/supabase";
+import { createRecoveryClient, isSupabaseConfigured } from "@/lib/supabase";
 
 export default function ForgotPasswordPage() {
   const searchParams = useSearchParams();
@@ -43,7 +43,7 @@ export default function ForgotPasswordPage() {
         setLoading(false);
         return;
       }
-      const supabase = createClient();
+      const supabase = createRecoveryClient();
       const { error: resetError } = await supabase.auth.resetPasswordForEmail(email, {
         redirectTo: buildRecoveryPageUrl(window.location.origin, redirectTarget),
       });

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -47,6 +47,7 @@ export default function ResetPasswordPage() {
 
     const cookieSupabase = createClient();
     const implicitSupabase = createRecoveryClient();
+    const shouldUseRecoveryHash = hasRecoveryHash();
     let mounted = true;
 
     async function loadImplicitSession(shouldRetry: boolean) {
@@ -74,7 +75,6 @@ export default function ResetPasswordPage() {
     }
 
     async function loadSession() {
-      const shouldUseRecoveryHash = hasRecoveryHash();
       let session = null;
 
       if (shouldUseRecoveryHash) {
@@ -118,6 +118,10 @@ export default function ResetPasswordPage() {
       session: unknown
     ) {
       if (!mounted) {
+        return;
+      }
+
+      if (shouldUseRecoveryHash && source === "cookie") {
         return;
       }
 

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -24,11 +24,7 @@ function hasRecoveryHash() {
   }
 
   const hashParams = new URLSearchParams(window.location.hash.slice(1));
-  return Boolean(
-    hashParams.get("access_token") ||
-      hashParams.get("refresh_token") ||
-      hashParams.get("token_type")
-  );
+  return Boolean(hashParams.get("access_token") && hashParams.get("refresh_token"));
 }
 
 export default function ResetPasswordPage() {
@@ -53,22 +49,10 @@ export default function ResetPasswordPage() {
     const implicitSupabase = createRecoveryClient();
     let mounted = true;
 
-    async function loadSession() {
-      const shouldRetry = hasRecoveryHash();
-      let session = null;
-
-      const {
-        data: { session: cookieSession },
-      } = await cookieSupabase.auth.getSession();
-
-      if (cookieSession) {
-        session = cookieSession;
-        recoverySessionSource.current = "cookie";
-      }
-
+    async function loadImplicitSession(shouldRetry: boolean) {
       for (
         let attempt = 0;
-        !session && attempt < (shouldRetry ? RECOVERY_SESSION_RETRY_COUNT : 1);
+        attempt < (shouldRetry ? RECOVERY_SESSION_RETRY_COUNT : 1);
         attempt += 1
       ) {
         const {
@@ -76,15 +60,43 @@ export default function ResetPasswordPage() {
         } = await implicitSupabase.auth.getSession();
 
         if (currentSession) {
-          session = currentSession;
-          recoverySessionSource.current = "implicit";
-          break;
+          return currentSession;
         }
 
         if (attempt < RECOVERY_SESSION_RETRY_COUNT - 1) {
           await new Promise((resolve) => {
             window.setTimeout(resolve, RECOVERY_SESSION_RETRY_MS);
           });
+        }
+      }
+
+      return null;
+    }
+
+    async function loadSession() {
+      const shouldUseRecoveryHash = hasRecoveryHash();
+      let session = null;
+
+      if (shouldUseRecoveryHash) {
+        session = await loadImplicitSession(true);
+        if (session) {
+          recoverySessionSource.current = "implicit";
+        }
+      } else {
+        const {
+          data: { session: cookieSession },
+        } = await cookieSupabase.auth.getSession();
+
+        if (cookieSession) {
+          session = cookieSession;
+          recoverySessionSource.current = "cookie";
+        }
+
+        if (!session) {
+          session = await loadImplicitSession(false);
+          if (session) {
+            recoverySessionSource.current = "implicit";
+          }
         }
       }
 

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -8,6 +8,7 @@ import Button, { buttonClassName } from "@/components/ui/button";
 import Input from "@/components/ui/input";
 import {
   appendRedirectParam,
+  buildLoginPath,
   resolvePostAuthRedirect,
 } from "@/lib/auth-routing";
 import { replaceWithBrowser } from "@/lib/browser-navigation";
@@ -146,7 +147,10 @@ export default function ResetPasswordPage() {
         throw updateError;
       }
 
-      replaceWithBrowser(redirectTarget);
+      await supabase.auth.signOut({ scope: "local" }).catch(() => undefined);
+      replaceWithBrowser(
+        buildLoginPath(redirectTarget, { reason: "password_updated" })
+      );
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : "Failed to update password";
       setError(message);

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { ArrowLeft, Heart, Lock } from "lucide-react";
@@ -12,10 +12,11 @@ import {
   resolvePostAuthRedirect,
 } from "@/lib/auth-routing";
 import { replaceWithBrowser } from "@/lib/browser-navigation";
-import { createRecoveryClient, isSupabaseConfigured } from "@/lib/supabase";
+import { createClient, createRecoveryClient, isSupabaseConfigured } from "@/lib/supabase";
 
 const RECOVERY_SESSION_RETRY_MS = 150;
 const RECOVERY_SESSION_RETRY_COUNT = 10;
+type RecoverySessionSource = "cookie" | "implicit";
 
 function hasRecoveryHash() {
   if (typeof window === "undefined") {
@@ -38,6 +39,7 @@ export default function ResetPasswordPage() {
   const [checkingSession, setCheckingSession] = useState(true);
   const [sessionReady, setSessionReady] = useState(false);
   const [error, setError] = useState("");
+  const recoverySessionSource = useRef<RecoverySessionSource>("cookie");
   const redirectTarget = resolvePostAuthRedirect(searchParams.get("redirect"));
 
   useEffect(() => {
@@ -47,20 +49,35 @@ export default function ResetPasswordPage() {
       return;
     }
 
-    const supabase = createRecoveryClient();
+    const cookieSupabase = createClient();
+    const implicitSupabase = createRecoveryClient();
     let mounted = true;
 
     async function loadSession() {
       const shouldRetry = hasRecoveryHash();
       let session = null;
 
-      for (let attempt = 0; attempt < (shouldRetry ? RECOVERY_SESSION_RETRY_COUNT : 1); attempt += 1) {
+      const {
+        data: { session: cookieSession },
+      } = await cookieSupabase.auth.getSession();
+
+      if (cookieSession) {
+        session = cookieSession;
+        recoverySessionSource.current = "cookie";
+      }
+
+      for (
+        let attempt = 0;
+        !session && attempt < (shouldRetry ? RECOVERY_SESSION_RETRY_COUNT : 1);
+        attempt += 1
+      ) {
         const {
           data: { session: currentSession },
-        } = await supabase.auth.getSession();
+        } = await implicitSupabase.auth.getSession();
 
         if (currentSession) {
           session = currentSession;
+          recoverySessionSource.current = "implicit";
           break;
         }
 
@@ -83,9 +100,11 @@ export default function ResetPasswordPage() {
       }
     }
 
-    const {
-      data: { subscription },
-    } = supabase.auth.onAuthStateChange((event, session) => {
+    function handleAuthStateChange(
+      source: RecoverySessionSource,
+      event: string,
+      session: unknown
+    ) {
       if (!mounted) {
         return;
       }
@@ -98,6 +117,7 @@ export default function ResetPasswordPage() {
       ) {
         setSessionReady(Boolean(session));
         if (session) {
+          recoverySessionSource.current = source;
           setError("");
         }
       }
@@ -105,13 +125,25 @@ export default function ResetPasswordPage() {
       if (event === "SIGNED_OUT" && !session) {
         setSessionReady(false);
       }
+    }
+
+    const {
+      data: { subscription: cookieSubscription },
+    } = cookieSupabase.auth.onAuthStateChange((event, session) => {
+      handleAuthStateChange("cookie", event, session);
+    });
+    const {
+      data: { subscription: implicitSubscription },
+    } = implicitSupabase.auth.onAuthStateChange((event, session) => {
+      handleAuthStateChange("implicit", event, session);
     });
 
     void loadSession();
 
     return () => {
       mounted = false;
-      subscription.unsubscribe();
+      cookieSubscription.unsubscribe();
+      implicitSubscription.unsubscribe();
     };
   }, []);
 
@@ -138,7 +170,10 @@ export default function ResetPasswordPage() {
         return;
       }
 
-      const supabase = createRecoveryClient();
+      const supabase =
+        recoverySessionSource.current === "cookie"
+          ? createClient()
+          : createRecoveryClient();
       const { error: updateError } = await supabase.auth.updateUser({
         password,
       });

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -48,7 +48,13 @@ export default function ResetPasswordPage() {
     const cookieSupabase = createClient();
     const implicitSupabase = createRecoveryClient();
     const shouldUseRecoveryHash = hasRecoveryHash();
+    let selectedRecoverySessionSource: RecoverySessionSource | null = null;
     let mounted = true;
+
+    function selectRecoverySessionSource(source: RecoverySessionSource) {
+      selectedRecoverySessionSource = source;
+      recoverySessionSource.current = source;
+    }
 
     async function loadImplicitSession(shouldRetry: boolean) {
       for (
@@ -80,7 +86,7 @@ export default function ResetPasswordPage() {
       if (shouldUseRecoveryHash) {
         session = await loadImplicitSession(true);
         if (session) {
-          recoverySessionSource.current = "implicit";
+          selectRecoverySessionSource("implicit");
         }
       } else {
         const {
@@ -89,13 +95,13 @@ export default function ResetPasswordPage() {
 
         if (cookieSession) {
           session = cookieSession;
-          recoverySessionSource.current = "cookie";
+          selectRecoverySessionSource("cookie");
         }
 
         if (!session) {
           session = await loadImplicitSession(false);
           if (session) {
-            recoverySessionSource.current = "implicit";
+            selectRecoverySessionSource("implicit");
           }
         }
       }
@@ -126,6 +132,14 @@ export default function ResetPasswordPage() {
       }
 
       if (
+        !shouldUseRecoveryHash &&
+        selectedRecoverySessionSource === "cookie" &&
+        source === "implicit"
+      ) {
+        return;
+      }
+
+      if (
         event === "PASSWORD_RECOVERY" ||
         event === "SIGNED_IN" ||
         event === "TOKEN_REFRESHED" ||
@@ -133,7 +147,7 @@ export default function ResetPasswordPage() {
       ) {
         setSessionReady(Boolean(session));
         if (session) {
-          recoverySessionSource.current = source;
+          selectRecoverySessionSource(source);
           setError("");
         }
       }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import {
   isPrivateTesterModeEnabled,
   PRIVATE_TESTER_MODE_RUNTIME_ATTRIBUTE,
 } from "@/lib/private-tester-access";
+import RecoveryRedirect from "@/components/auth/recovery-redirect";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -73,6 +74,7 @@ export default function RootLayout({
             : "0",
         }}
       >
+        <RecoveryRedirect />
         {children}
         <SpeedInsights />
       </body>

--- a/src/components/auth/recovery-redirect.tsx
+++ b/src/components/auth/recovery-redirect.tsx
@@ -10,6 +10,7 @@ import { replaceWithBrowser } from "@/lib/browser-navigation";
 
 const AUTH_CALLBACK_PATH = "/api/auth/callback";
 const BROWSER_CALLBACK_PATH = "/auth/callback";
+const INTERNAL_BASE_URL = "https://pawvital.local";
 
 function isRecoveryFlow(value: string | null) {
   return value === "recovery";
@@ -72,9 +73,26 @@ function buildQueryRecoveryRedirect(url: URL) {
   }
 
   callbackUrl.searchParams.set("type", "recovery");
-  callbackUrl.searchParams.set("next", buildRecoveryRedirectPath(redirectTarget));
+  callbackUrl.searchParams.set(
+    "next",
+    isResetPasswordRedirectTarget(redirectTarget)
+      ? redirectTarget
+      : buildRecoveryRedirectPath(redirectTarget)
+  );
 
   return `${callbackUrl.pathname}${callbackUrl.search}`;
+}
+
+function isResetPasswordRedirectTarget(target: string | null): target is string {
+  if (!target) {
+    return false;
+  }
+
+  try {
+    return new URL(target, INTERNAL_BASE_URL).pathname === RESET_PASSWORD_PATH;
+  } catch {
+    return false;
+  }
 }
 
 function getRecoveryRedirectFromCurrentUrl() {

--- a/src/components/auth/recovery-redirect.tsx
+++ b/src/components/auth/recovery-redirect.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useEffect } from "react";
+import {
+  buildRecoveryRedirectPath,
+  RESET_PASSWORD_PATH,
+  sanitizeRedirectTarget,
+} from "@/lib/auth-routing";
+import { replaceWithBrowser } from "@/lib/browser-navigation";
+
+const AUTH_CALLBACK_PATH = "/api/auth/callback";
+const BROWSER_CALLBACK_PATH = "/auth/callback";
+
+function isRecoveryFlow(value: string | null) {
+  return value === "recovery";
+}
+
+function shouldIgnoreCurrentPath(pathname: string) {
+  return (
+    pathname.startsWith(RESET_PASSWORD_PATH) ||
+    pathname.startsWith(AUTH_CALLBACK_PATH) ||
+    pathname.startsWith(BROWSER_CALLBACK_PATH)
+  );
+}
+
+function buildHashRecoveryRedirect(url: URL) {
+  const hash = url.hash;
+  if (!hash) {
+    return null;
+  }
+
+  const hashParams = new URLSearchParams(hash.slice(1));
+  const isRecoveryHash =
+    isRecoveryFlow(hashParams.get("type")) &&
+    Boolean(hashParams.get("access_token")) &&
+    Boolean(hashParams.get("refresh_token"));
+
+  if (!isRecoveryHash) {
+    return null;
+  }
+
+  const redirectTarget =
+    sanitizeRedirectTarget(url.searchParams.get("redirect")) ||
+    sanitizeRedirectTarget(url.searchParams.get("next"));
+
+  return `${buildRecoveryRedirectPath(redirectTarget)}${hash}`;
+}
+
+function buildQueryRecoveryRedirect(url: URL) {
+  const flow = url.searchParams.get("flow") || url.searchParams.get("type");
+  if (!isRecoveryFlow(flow)) {
+    return null;
+  }
+
+  const code = url.searchParams.get("code");
+  const tokenHash = url.searchParams.get("token_hash");
+  if (!code && !tokenHash) {
+    return null;
+  }
+
+  const redirectTarget =
+    sanitizeRedirectTarget(url.searchParams.get("redirect")) ||
+    sanitizeRedirectTarget(url.searchParams.get("next"));
+  const callbackUrl = new URL(AUTH_CALLBACK_PATH, url.origin);
+
+  if (code) {
+    callbackUrl.searchParams.set("code", code);
+  }
+
+  if (tokenHash) {
+    callbackUrl.searchParams.set("token_hash", tokenHash);
+  }
+
+  callbackUrl.searchParams.set("type", "recovery");
+  callbackUrl.searchParams.set("next", buildRecoveryRedirectPath(redirectTarget));
+
+  return `${callbackUrl.pathname}${callbackUrl.search}`;
+}
+
+function getRecoveryRedirectFromCurrentUrl() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const url = new URL(window.location.href);
+  if (shouldIgnoreCurrentPath(url.pathname)) {
+    return null;
+  }
+
+  return buildHashRecoveryRedirect(url) || buildQueryRecoveryRedirect(url);
+}
+
+export default function RecoveryRedirect() {
+  useEffect(() => {
+    const redirectUrl = getRecoveryRedirectFromCurrentUrl();
+    if (redirectUrl) {
+      replaceWithBrowser(redirectUrl);
+    }
+  }, []);
+
+  return null;
+}

--- a/src/components/auth/recovery-redirect.tsx
+++ b/src/components/auth/recovery-redirect.tsx
@@ -7,10 +7,16 @@ import {
   sanitizeRedirectTarget,
 } from "@/lib/auth-routing";
 import { replaceWithBrowser } from "@/lib/browser-navigation";
+import { createRecoveryClient, isSupabaseConfigured } from "@/lib/supabase";
 
 const AUTH_CALLBACK_PATH = "/api/auth/callback";
 const BROWSER_CALLBACK_PATH = "/auth/callback";
 const INTERNAL_BASE_URL = "https://pawvital.local";
+
+interface RecoveryRedirectTarget {
+  href: string;
+  hydrateCurrentHash: boolean;
+}
 
 function isRecoveryFlow(value: string | null) {
   return value === "recovery";
@@ -24,7 +30,7 @@ function shouldIgnoreCurrentPath(pathname: string) {
   );
 }
 
-function buildHashRecoveryRedirect(url: URL) {
+function buildHashRecoveryRedirect(url: URL): RecoveryRedirectTarget | null {
   const hash = url.hash;
   if (!hash) {
     return null;
@@ -47,10 +53,13 @@ function buildHashRecoveryRedirect(url: URL) {
     ? redirectTarget
     : buildRecoveryRedirectPath(redirectTarget);
 
-  return `${recoveryPath}${hash}`;
+  return {
+    href: recoveryPath,
+    hydrateCurrentHash: true,
+  };
 }
 
-function buildQueryRecoveryRedirect(url: URL) {
+function buildQueryRecoveryRedirect(url: URL): RecoveryRedirectTarget | null {
   const flow = url.searchParams.get("flow") || url.searchParams.get("type");
   if (!isRecoveryFlow(flow)) {
     return null;
@@ -83,7 +92,10 @@ function buildQueryRecoveryRedirect(url: URL) {
       : buildRecoveryRedirectPath(redirectTarget)
   );
 
-  return `${callbackUrl.pathname}${callbackUrl.search}`;
+  return {
+    href: `${callbackUrl.pathname}${callbackUrl.search}`,
+    hydrateCurrentHash: false,
+  };
 }
 
 function isResetPasswordRedirectTarget(target: string | null): target is string {
@@ -113,10 +125,24 @@ function getRecoveryRedirectFromCurrentUrl() {
 
 export default function RecoveryRedirect() {
   useEffect(() => {
-    const redirectUrl = getRecoveryRedirectFromCurrentUrl();
-    if (redirectUrl) {
-      replaceWithBrowser(redirectUrl);
+    const redirect = getRecoveryRedirectFromCurrentUrl();
+    if (!redirect) {
+      return;
     }
+
+    async function completeRedirect() {
+      if (redirect.hydrateCurrentHash && isSupabaseConfigured) {
+        try {
+          await createRecoveryClient().auth.getSession();
+        } catch {
+          // The reset page will show the invalid-link state if hydration fails.
+        }
+      }
+
+      replaceWithBrowser(redirect.href);
+    }
+
+    void completeRedirect();
   }, []);
 
   return null;

--- a/src/components/auth/recovery-redirect.tsx
+++ b/src/components/auth/recovery-redirect.tsx
@@ -129,9 +129,10 @@ export default function RecoveryRedirect() {
     if (!redirect) {
       return;
     }
+    const redirectTarget = redirect;
 
     async function completeRedirect() {
-      if (redirect.hydrateCurrentHash && isSupabaseConfigured) {
+      if (redirectTarget.hydrateCurrentHash && isSupabaseConfigured) {
         try {
           await createRecoveryClient().auth.getSession();
         } catch {
@@ -139,7 +140,7 @@ export default function RecoveryRedirect() {
         }
       }
 
-      replaceWithBrowser(redirect.href);
+      replaceWithBrowser(redirectTarget.href);
     }
 
     void completeRedirect();

--- a/src/components/auth/recovery-redirect.tsx
+++ b/src/components/auth/recovery-redirect.tsx
@@ -43,8 +43,11 @@ function buildHashRecoveryRedirect(url: URL) {
   const redirectTarget =
     sanitizeRedirectTarget(url.searchParams.get("redirect")) ||
     sanitizeRedirectTarget(url.searchParams.get("next"));
+  const recoveryPath = isResetPasswordRedirectTarget(redirectTarget)
+    ? redirectTarget
+    : buildRecoveryRedirectPath(redirectTarget);
 
-  return `${buildRecoveryRedirectPath(redirectTarget)}${hash}`;
+  return `${recoveryPath}${hash}`;
 }
 
 function buildQueryRecoveryRedirect(url: URL) {

--- a/src/components/auth/recovery-redirect.tsx
+++ b/src/components/auth/recovery-redirect.tsx
@@ -7,7 +7,6 @@ import {
   sanitizeRedirectTarget,
 } from "@/lib/auth-routing";
 import { replaceWithBrowser } from "@/lib/browser-navigation";
-import { createRecoveryClient, isSupabaseConfigured } from "@/lib/supabase";
 
 const AUTH_CALLBACK_PATH = "/api/auth/callback";
 const BROWSER_CALLBACK_PATH = "/auth/callback";
@@ -15,7 +14,6 @@ const INTERNAL_BASE_URL = "https://pawvital.local";
 
 interface RecoveryRedirectTarget {
   href: string;
-  hydrateCurrentHash: boolean;
 }
 
 function isRecoveryFlow(value: string | null) {
@@ -54,8 +52,7 @@ function buildHashRecoveryRedirect(url: URL): RecoveryRedirectTarget | null {
     : buildRecoveryRedirectPath(redirectTarget);
 
   return {
-    href: recoveryPath,
-    hydrateCurrentHash: true,
+    href: `${recoveryPath}${hash}`,
   };
 }
 
@@ -94,7 +91,6 @@ function buildQueryRecoveryRedirect(url: URL): RecoveryRedirectTarget | null {
 
   return {
     href: `${callbackUrl.pathname}${callbackUrl.search}`,
-    hydrateCurrentHash: false,
   };
 }
 
@@ -130,20 +126,7 @@ export default function RecoveryRedirect() {
       return;
     }
     const redirectTarget = redirect;
-
-    async function completeRedirect() {
-      if (redirectTarget.hydrateCurrentHash && isSupabaseConfigured) {
-        try {
-          await createRecoveryClient().auth.getSession();
-        } catch {
-          // The reset page will show the invalid-link state if hydration fails.
-        }
-      }
-
-      replaceWithBrowser(redirectTarget.href);
-    }
-
-    void completeRedirect();
+    replaceWithBrowser(redirectTarget.href);
   }, []);
 
   return null;

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,4 +1,5 @@
 import { createBrowserClient } from "@supabase/ssr";
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || "";
 const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "";
@@ -18,10 +19,12 @@ export function createRecoveryClient() {
     throw new Error("DEMO_MODE");
   }
 
-  return createBrowserClient(supabaseUrl, supabaseKey, {
+  return createSupabaseClient(supabaseUrl, supabaseKey, {
     auth: {
+      autoRefreshToken: true,
       detectSessionInUrl: true,
       flowType: "implicit",
+      persistSession: true,
     },
   });
 }

--- a/tests/auth-pages.network-error.test.tsx
+++ b/tests/auth-pages.network-error.test.tsx
@@ -9,6 +9,7 @@ import SignupPage from "@/app/(auth)/signup/page";
 const mockReplace = jest.fn();
 const mockSearchParams = new URLSearchParams();
 const mockCreateClient = jest.fn();
+const mockCreateRecoveryClient = jest.fn();
 
 jest.mock("next/link", () => {
   const ReactActual = jest.requireActual<typeof import("react")>("react");
@@ -35,14 +36,15 @@ jest.mock("next/navigation", () => ({
 
 jest.mock("@/lib/supabase", () => ({
   createClient: () => mockCreateClient(),
+  createRecoveryClient: () => mockCreateRecoveryClient(),
   isSupabaseConfigured: true,
 }));
 
 function fillRequiredAuthFields() {
-  fireEvent.change(screen.getByLabelText("Email"), {
+  fireEvent.change(screen.getByPlaceholderText("you@example.com"), {
     target: { value: "owner@example.com" },
   });
-  fireEvent.change(screen.getByLabelText("Password"), {
+  fireEvent.change(document.querySelector('input[type="password"]')!, {
     target: { value: "super-secret-password" },
   });
 }
@@ -50,6 +52,7 @@ function fillRequiredAuthFields() {
 describe("auth page network error handling", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockCreateRecoveryClient.mockImplementation(() => mockCreateClient());
   });
 
   it("shows a friendly login message instead of the raw fetch failure", async () => {
@@ -119,7 +122,7 @@ describe("auth page network error handling", () => {
     try {
       render(React.createElement(SignupPage));
 
-      fireEvent.change(screen.getByLabelText("Full Name"), {
+      fireEvent.change(screen.getByPlaceholderText("Your name"), {
         target: { value: "Dog Parent" },
       });
       fillRequiredAuthFields();
@@ -140,7 +143,7 @@ describe("auth page network error handling", () => {
 
   it("shows the friendly network message on password reset failure", async () => {
     const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
-    mockCreateClient.mockReturnValue({
+    mockCreateRecoveryClient.mockReturnValue({
       auth: {
         resetPasswordForEmail: jest
           .fn()
@@ -151,7 +154,7 @@ describe("auth page network error handling", () => {
     try {
       render(React.createElement(ForgotPasswordPage));
 
-      fireEvent.change(screen.getByLabelText("Email"), {
+      fireEvent.change(screen.getByPlaceholderText("you@example.com"), {
         target: { value: "owner@example.com" },
       });
       fireEvent.click(screen.getByRole("button", { name: "Send Reset Link" }));
@@ -168,9 +171,9 @@ describe("auth page network error handling", () => {
     }
   });
 
-  it("sends password reset emails through the browser callback for PKCE recovery", async () => {
+  it("sends password reset emails through the implicit recovery client", async () => {
     const resetPasswordForEmail = jest.fn().mockResolvedValue({ error: null });
-    mockCreateClient.mockReturnValue({
+    mockCreateRecoveryClient.mockReturnValue({
       auth: {
         resetPasswordForEmail,
       },
@@ -178,7 +181,7 @@ describe("auth page network error handling", () => {
 
     render(React.createElement(ForgotPasswordPage));
 
-    fireEvent.change(screen.getByLabelText("Email"), {
+    fireEvent.change(screen.getByPlaceholderText("you@example.com"), {
       target: { value: "owner@example.com" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Send Reset Link" }));

--- a/tests/auth-recovery-redirect.test.ts
+++ b/tests/auth-recovery-redirect.test.ts
@@ -49,6 +49,22 @@ describe("recovery redirect guard", () => {
     );
   });
 
+  it("does not double-wrap recovery hashes that already target reset-password", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/?next=%2Freset-password%3Fredirect%3D%252Fhistory#access_token=test-token&refresh_token=test-refresh&type=recovery"
+    );
+
+    render(React.createElement(RecoveryRedirect));
+
+    await waitFor(() =>
+      expect(mockReplaceWithBrowser).toHaveBeenCalledWith(
+        "/reset-password?redirect=%2Fhistory#access_token=test-token&refresh_token=test-refresh&type=recovery"
+      )
+    );
+  });
+
   it("hands root recovery codes to the existing auth callback route", async () => {
     window.history.replaceState(
       {},

--- a/tests/auth-recovery-redirect.test.ts
+++ b/tests/auth-recovery-redirect.test.ts
@@ -39,13 +39,13 @@ describe("recovery redirect guard", () => {
 
     await waitFor(() =>
       expect(mockReplaceWithBrowser).toHaveBeenCalledWith(
-        "/reset-password"
+        "/reset-password#access_token=test-token&refresh_token=test-refresh&type=recovery&token_type=bearer"
       )
     );
-    expect(mockGetSession).toHaveBeenCalledTimes(1);
+    expect(mockGetSession).not.toHaveBeenCalled();
   });
 
-  it("preserves protected redirect targets when recovery hashes land at root", async () => {
+  it("preserves recovery hashes with protected redirect targets when they land at root", async () => {
     window.history.replaceState(
       {},
       "",
@@ -56,9 +56,10 @@ describe("recovery redirect guard", () => {
 
     await waitFor(() =>
       expect(mockReplaceWithBrowser).toHaveBeenCalledWith(
-        "/reset-password?redirect=%2Fsymptom-checker"
+        "/reset-password?redirect=%2Fsymptom-checker#access_token=test-token&refresh_token=test-refresh&type=recovery"
       )
     );
+    expect(mockGetSession).not.toHaveBeenCalled();
   });
 
   it("does not double-wrap recovery hashes that already target reset-password", async () => {
@@ -72,9 +73,10 @@ describe("recovery redirect guard", () => {
 
     await waitFor(() =>
       expect(mockReplaceWithBrowser).toHaveBeenCalledWith(
-        "/reset-password?redirect=%2Fhistory"
+        "/reset-password?redirect=%2Fhistory#access_token=test-token&refresh_token=test-refresh&type=recovery"
       )
     );
+    expect(mockGetSession).not.toHaveBeenCalled();
   });
 
   it("hands root recovery codes to the existing auth callback route", async () => {

--- a/tests/auth-recovery-redirect.test.ts
+++ b/tests/auth-recovery-redirect.test.ts
@@ -1,0 +1,98 @@
+/** @jest-environment jsdom */
+
+import * as React from "react";
+import { render, waitFor } from "@testing-library/react";
+import RecoveryRedirect from "@/components/auth/recovery-redirect";
+
+const mockReplaceWithBrowser = jest.fn();
+
+jest.mock("@/lib/browser-navigation", () => ({
+  replaceWithBrowser: (...args: unknown[]) => mockReplaceWithBrowser(...args),
+}));
+
+describe("recovery redirect guard", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.history.replaceState({}, "", "/");
+    window.location.hash = "";
+  });
+
+  it("moves recovery hashes from the landing page to reset-password", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/#access_token=test-token&refresh_token=test-refresh&type=recovery&token_type=bearer"
+    );
+
+    render(React.createElement(RecoveryRedirect));
+
+    await waitFor(() =>
+      expect(mockReplaceWithBrowser).toHaveBeenCalledWith(
+        "/reset-password#access_token=test-token&refresh_token=test-refresh&type=recovery&token_type=bearer"
+      )
+    );
+  });
+
+  it("preserves protected redirect targets when recovery hashes land at root", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/?redirect=%2Fsymptom-checker#access_token=test-token&refresh_token=test-refresh&type=recovery"
+    );
+
+    render(React.createElement(RecoveryRedirect));
+
+    await waitFor(() =>
+      expect(mockReplaceWithBrowser).toHaveBeenCalledWith(
+        "/reset-password?redirect=%2Fsymptom-checker#access_token=test-token&refresh_token=test-refresh&type=recovery"
+      )
+    );
+  });
+
+  it("hands root recovery codes to the existing auth callback route", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/?code=recovery-code&type=recovery&redirect=%2Fsymptom-checker"
+    );
+
+    render(React.createElement(RecoveryRedirect));
+
+    await waitFor(() => expect(mockReplaceWithBrowser).toHaveBeenCalledTimes(1));
+
+    const destination = new URL(
+      mockReplaceWithBrowser.mock.calls[0][0],
+      window.location.origin
+    );
+    expect(destination.pathname).toBe("/api/auth/callback");
+    expect(destination.searchParams.get("code")).toBe("recovery-code");
+    expect(destination.searchParams.get("type")).toBe("recovery");
+    expect(destination.searchParams.get("next")).toBe(
+      "/reset-password?redirect=%2Fsymptom-checker"
+    );
+  });
+
+  it("does not reroute non-recovery auth hashes", () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/#access_token=test-token&refresh_token=test-refresh&type=signup"
+    );
+
+    render(React.createElement(RecoveryRedirect));
+
+    expect(mockReplaceWithBrowser).not.toHaveBeenCalled();
+  });
+
+  it("does not reroute when already on reset-password", () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/reset-password#access_token=test-token&refresh_token=test-refresh&type=recovery"
+    );
+
+    render(React.createElement(RecoveryRedirect));
+
+    expect(mockReplaceWithBrowser).not.toHaveBeenCalled();
+  });
+});

--- a/tests/auth-recovery-redirect.test.ts
+++ b/tests/auth-recovery-redirect.test.ts
@@ -5,14 +5,25 @@ import { render, waitFor } from "@testing-library/react";
 import RecoveryRedirect from "@/components/auth/recovery-redirect";
 
 const mockReplaceWithBrowser = jest.fn();
+const mockGetSession = jest.fn();
 
 jest.mock("@/lib/browser-navigation", () => ({
   replaceWithBrowser: (...args: unknown[]) => mockReplaceWithBrowser(...args),
 }));
 
+jest.mock("@/lib/supabase", () => ({
+  createRecoveryClient: () => ({
+    auth: {
+      getSession: (...args: unknown[]) => mockGetSession(...args),
+    },
+  }),
+  isSupabaseConfigured: true,
+}));
+
 describe("recovery redirect guard", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetSession.mockResolvedValue({ data: { session: null }, error: null });
     window.history.replaceState({}, "", "/");
     window.location.hash = "";
   });
@@ -28,9 +39,10 @@ describe("recovery redirect guard", () => {
 
     await waitFor(() =>
       expect(mockReplaceWithBrowser).toHaveBeenCalledWith(
-        "/reset-password#access_token=test-token&refresh_token=test-refresh&type=recovery&token_type=bearer"
+        "/reset-password"
       )
     );
+    expect(mockGetSession).toHaveBeenCalledTimes(1);
   });
 
   it("preserves protected redirect targets when recovery hashes land at root", async () => {
@@ -44,7 +56,7 @@ describe("recovery redirect guard", () => {
 
     await waitFor(() =>
       expect(mockReplaceWithBrowser).toHaveBeenCalledWith(
-        "/reset-password?redirect=%2Fsymptom-checker#access_token=test-token&refresh_token=test-refresh&type=recovery"
+        "/reset-password?redirect=%2Fsymptom-checker"
       )
     );
   });
@@ -60,7 +72,7 @@ describe("recovery redirect guard", () => {
 
     await waitFor(() =>
       expect(mockReplaceWithBrowser).toHaveBeenCalledWith(
-        "/reset-password?redirect=%2Fhistory#access_token=test-token&refresh_token=test-refresh&type=recovery"
+        "/reset-password?redirect=%2Fhistory"
       )
     );
   });

--- a/tests/auth-recovery-redirect.test.ts
+++ b/tests/auth-recovery-redirect.test.ts
@@ -72,6 +72,66 @@ describe("recovery redirect guard", () => {
     );
   });
 
+  it("does not double-wrap recovery codes that already target reset-password", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/?code=recovery-code&type=recovery&next=%2Freset-password%3Fredirect%3D%252Fhistory"
+    );
+
+    render(React.createElement(RecoveryRedirect));
+
+    await waitFor(() => expect(mockReplaceWithBrowser).toHaveBeenCalledTimes(1));
+
+    const destination = new URL(
+      mockReplaceWithBrowser.mock.calls[0][0],
+      window.location.origin
+    );
+    expect(destination.pathname).toBe("/api/auth/callback");
+    expect(destination.searchParams.get("next")).toBe(
+      "/reset-password?redirect=%2Fhistory"
+    );
+  });
+
+  it("drops unsafe external redirect targets from recovery codes", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/?code=recovery-code&type=recovery&redirect=https%3A%2F%2Fevil.example%2Fsteal"
+    );
+
+    render(React.createElement(RecoveryRedirect));
+
+    await waitFor(() => expect(mockReplaceWithBrowser).toHaveBeenCalledTimes(1));
+
+    const destination = new URL(
+      mockReplaceWithBrowser.mock.calls[0][0],
+      window.location.origin
+    );
+    expect(destination.searchParams.get("next")).toBe("/reset-password");
+    expect(destination.href).not.toContain("evil.example");
+  });
+
+  it("does not reroute incomplete recovery hashes", () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/#access_token=test-token&type=recovery"
+    );
+
+    render(React.createElement(RecoveryRedirect));
+
+    expect(mockReplaceWithBrowser).not.toHaveBeenCalled();
+  });
+
+  it("does not reroute recovery query links without a verifier", () => {
+    window.history.replaceState({}, "", "/?type=recovery");
+
+    render(React.createElement(RecoveryRedirect));
+
+    expect(mockReplaceWithBrowser).not.toHaveBeenCalled();
+  });
+
   it("does not reroute non-recovery auth hashes", () => {
     window.history.replaceState(
       {},

--- a/tests/forgot-password.page.test.ts
+++ b/tests/forgot-password.page.test.ts
@@ -30,7 +30,7 @@ jest.mock("next/navigation", () => ({
 }));
 
 jest.mock("@/lib/supabase", () => ({
-  createClient: () => ({
+  createRecoveryClient: () => ({
     auth: {
       resetPasswordForEmail: (...args: unknown[]) =>
         mockResetPasswordForEmail(...args),

--- a/tests/reset-password.page.test.ts
+++ b/tests/reset-password.page.test.ts
@@ -181,14 +181,21 @@ describe("reset password page", () => {
     expect(mockImplicitUpdateUser).not.toHaveBeenCalled();
   });
 
-  it("updates implicit hash recovery sessions with the implicit client", async () => {
+  it("updates implicit hash recovery sessions with the implicit client even when a cookie session exists", async () => {
     window.history.replaceState(
       {},
       "",
       "/reset-password?redirect=%2Fhistory#access_token=test-token&refresh_token=test-refresh&token_type=bearer"
     );
     mockSearchParams.set("redirect", "/history");
-    mockCookieGetSession.mockResolvedValue({ data: { session: null } });
+    mockCookieGetSession.mockResolvedValue({
+      data: {
+        session: {
+          access_token: "cookie-session-token",
+          user: { id: "signed-in-user" },
+        },
+      },
+    });
     mockImplicitGetSession.mockResolvedValue({
       data: {
         session: {
@@ -223,6 +230,7 @@ describe("reset password page", () => {
       password: "new-password-1",
     });
     expect(mockImplicitSignOut).toHaveBeenCalledWith({ scope: "local" });
+    expect(mockCookieGetSession).not.toHaveBeenCalled();
     expect(mockCookieUpdateUser).not.toHaveBeenCalled();
   });
 });

--- a/tests/reset-password.page.test.ts
+++ b/tests/reset-password.page.test.ts
@@ -1,7 +1,7 @@
 /** @jest-environment jsdom */
 
 import * as React from "react";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import ResetPasswordPage from "@/app/(auth)/reset-password/page";
 
 const mockReplaceWithBrowser = jest.fn();
@@ -9,6 +9,7 @@ const mockSearchParams = new URLSearchParams();
 const mockGetSession = jest.fn();
 const mockOnAuthStateChange = jest.fn();
 const mockUpdateUser = jest.fn();
+const mockSignOut = jest.fn();
 
 jest.mock("next/link", () => {
   const ReactActual = jest.requireActual<typeof import("react")>("react");
@@ -41,6 +42,7 @@ jest.mock("@/lib/supabase", () => ({
     auth: {
       getSession: (...args: unknown[]) => mockGetSession(...args),
       onAuthStateChange: (...args: unknown[]) => mockOnAuthStateChange(...args),
+      signOut: (...args: unknown[]) => mockSignOut(...args),
       updateUser: (...args: unknown[]) => mockUpdateUser(...args),
     },
   }),
@@ -51,6 +53,10 @@ describe("reset password page", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
+    Array.from(mockSearchParams.keys()).forEach((key) => {
+      mockSearchParams.delete(key);
+    });
+    mockSearchParams.set("redirect", "/symptom-checker");
     window.history.replaceState({}, "", "/reset-password?redirect=%2Fsymptom-checker");
     window.location.hash = "";
     mockOnAuthStateChange.mockReturnValue({
@@ -110,5 +116,40 @@ describe("reset password page", () => {
         screen.getByText("This password reset link is invalid or has expired.")
       ).toBeTruthy()
     );
+  });
+
+  it("routes successful reset back through login with the original redirect", async () => {
+    mockGetSession.mockResolvedValue({
+      data: {
+        session: {
+          access_token: "session-token",
+          user: { id: "user-1" },
+        },
+      },
+    });
+    mockUpdateUser.mockResolvedValue({ error: null });
+    mockSignOut.mockResolvedValue({ error: null });
+
+    render(React.createElement(ResetPasswordPage));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Update Password" })).toBeTruthy()
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("At least 8 characters"), {
+      target: { value: "new-password-1" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Repeat your new password"), {
+      target: { value: "new-password-1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Update Password" }));
+
+    await waitFor(() =>
+      expect(mockReplaceWithBrowser).toHaveBeenCalledWith(
+        "/login?redirect=%2Fsymptom-checker&reason=password_updated"
+      )
+    );
+    expect(mockUpdateUser).toHaveBeenCalledWith({ password: "new-password-1" });
+    expect(mockSignOut).toHaveBeenCalledWith({ scope: "local" });
   });
 });

--- a/tests/reset-password.page.test.ts
+++ b/tests/reset-password.page.test.ts
@@ -195,6 +195,51 @@ describe("reset password page", () => {
     expect(mockImplicitUpdateUser).not.toHaveBeenCalled();
   });
 
+  it("keeps cookie-backed recovery selected when an unrelated implicit session emits", async () => {
+    mockCookieGetSession.mockResolvedValue({
+      data: {
+        session: {
+          access_token: "cookie-recovery-token",
+          user: { id: "recovery-link-user" },
+        },
+      },
+    });
+    mockCookieUpdateUser.mockResolvedValue({ error: null });
+    mockCookieSignOut.mockResolvedValue({ error: null });
+
+    render(React.createElement(ResetPasswordPage));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Update Password" })).toBeTruthy()
+    );
+
+    act(() => {
+      implicitAuthStateChange?.("SIGNED_IN", {
+        access_token: "implicit-local-storage-token",
+        user: { id: "already-signed-in-user" },
+      });
+    });
+
+    fireEvent.change(screen.getByPlaceholderText("At least 8 characters"), {
+      target: { value: "new-password-1" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Repeat your new password"), {
+      target: { value: "new-password-1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Update Password" }));
+
+    await waitFor(() =>
+      expect(mockReplaceWithBrowser).toHaveBeenCalledWith(
+        "/login?redirect=%2Fsymptom-checker&reason=password_updated"
+      )
+    );
+    expect(mockCookieUpdateUser).toHaveBeenCalledWith({
+      password: "new-password-1",
+    });
+    expect(mockCookieSignOut).toHaveBeenCalledWith({ scope: "local" });
+    expect(mockImplicitUpdateUser).not.toHaveBeenCalled();
+  });
+
   it("updates implicit hash recovery sessions with the implicit client even when a cookie session exists", async () => {
     window.history.replaceState(
       {},

--- a/tests/reset-password.page.test.ts
+++ b/tests/reset-password.page.test.ts
@@ -6,10 +6,14 @@ import ResetPasswordPage from "@/app/(auth)/reset-password/page";
 
 const mockReplaceWithBrowser = jest.fn();
 const mockSearchParams = new URLSearchParams();
-const mockGetSession = jest.fn();
-const mockOnAuthStateChange = jest.fn();
-const mockUpdateUser = jest.fn();
-const mockSignOut = jest.fn();
+const mockCookieGetSession = jest.fn();
+const mockCookieOnAuthStateChange = jest.fn();
+const mockCookieUpdateUser = jest.fn();
+const mockCookieSignOut = jest.fn();
+const mockImplicitGetSession = jest.fn();
+const mockImplicitOnAuthStateChange = jest.fn();
+const mockImplicitUpdateUser = jest.fn();
+const mockImplicitSignOut = jest.fn();
 
 jest.mock("next/link", () => {
   const ReactActual = jest.requireActual<typeof import("react")>("react");
@@ -38,12 +42,22 @@ jest.mock("@/lib/browser-navigation", () => ({
 }));
 
 jest.mock("@/lib/supabase", () => ({
+  createClient: () => ({
+    auth: {
+      getSession: (...args: unknown[]) => mockCookieGetSession(...args),
+      onAuthStateChange: (...args: unknown[]) =>
+        mockCookieOnAuthStateChange(...args),
+      signOut: (...args: unknown[]) => mockCookieSignOut(...args),
+      updateUser: (...args: unknown[]) => mockCookieUpdateUser(...args),
+    },
+  }),
   createRecoveryClient: () => ({
     auth: {
-      getSession: (...args: unknown[]) => mockGetSession(...args),
-      onAuthStateChange: (...args: unknown[]) => mockOnAuthStateChange(...args),
-      signOut: (...args: unknown[]) => mockSignOut(...args),
-      updateUser: (...args: unknown[]) => mockUpdateUser(...args),
+      getSession: (...args: unknown[]) => mockImplicitGetSession(...args),
+      onAuthStateChange: (...args: unknown[]) =>
+        mockImplicitOnAuthStateChange(...args),
+      signOut: (...args: unknown[]) => mockImplicitSignOut(...args),
+      updateUser: (...args: unknown[]) => mockImplicitUpdateUser(...args),
     },
   }),
   isSupabaseConfigured: true,
@@ -59,7 +73,16 @@ describe("reset password page", () => {
     mockSearchParams.set("redirect", "/symptom-checker");
     window.history.replaceState({}, "", "/reset-password?redirect=%2Fsymptom-checker");
     window.location.hash = "";
-    mockOnAuthStateChange.mockReturnValue({
+    mockCookieGetSession.mockResolvedValue({ data: { session: null } });
+    mockImplicitGetSession.mockResolvedValue({ data: { session: null } });
+    mockCookieOnAuthStateChange.mockReturnValue({
+      data: {
+        subscription: {
+          unsubscribe: jest.fn(),
+        },
+      },
+    });
+    mockImplicitOnAuthStateChange.mockReturnValue({
       data: {
         subscription: {
           unsubscribe: jest.fn(),
@@ -80,7 +103,8 @@ describe("reset password page", () => {
       "/reset-password?redirect=%2Fsymptom-checker#access_token=test-token&refresh_token=test-refresh&token_type=bearer"
     );
 
-    mockGetSession
+    mockCookieGetSession.mockResolvedValue({ data: { session: null } });
+    mockImplicitGetSession
       .mockResolvedValueOnce({ data: { session: null } })
       .mockResolvedValueOnce({
         data: {
@@ -107,7 +131,8 @@ describe("reset password page", () => {
   });
 
   it("shows the invalid-link state when no recovery session arrives", async () => {
-    mockGetSession.mockResolvedValue({ data: { session: null } });
+    mockCookieGetSession.mockResolvedValue({ data: { session: null } });
+    mockImplicitGetSession.mockResolvedValue({ data: { session: null } });
 
     render(React.createElement(ResetPasswordPage));
 
@@ -118,8 +143,8 @@ describe("reset password page", () => {
     );
   });
 
-  it("routes successful reset back through login with the original redirect", async () => {
-    mockGetSession.mockResolvedValue({
+  it("updates cookie-backed recovery sessions and returns through login", async () => {
+    mockCookieGetSession.mockResolvedValue({
       data: {
         session: {
           access_token: "session-token",
@@ -127,8 +152,8 @@ describe("reset password page", () => {
         },
       },
     });
-    mockUpdateUser.mockResolvedValue({ error: null });
-    mockSignOut.mockResolvedValue({ error: null });
+    mockCookieUpdateUser.mockResolvedValue({ error: null });
+    mockCookieSignOut.mockResolvedValue({ error: null });
 
     render(React.createElement(ResetPasswordPage));
 
@@ -149,7 +174,55 @@ describe("reset password page", () => {
         "/login?redirect=%2Fsymptom-checker&reason=password_updated"
       )
     );
-    expect(mockUpdateUser).toHaveBeenCalledWith({ password: "new-password-1" });
-    expect(mockSignOut).toHaveBeenCalledWith({ scope: "local" });
+    expect(mockCookieUpdateUser).toHaveBeenCalledWith({
+      password: "new-password-1",
+    });
+    expect(mockCookieSignOut).toHaveBeenCalledWith({ scope: "local" });
+    expect(mockImplicitUpdateUser).not.toHaveBeenCalled();
+  });
+
+  it("updates implicit hash recovery sessions with the implicit client", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/reset-password?redirect=%2Fhistory#access_token=test-token&refresh_token=test-refresh&token_type=bearer"
+    );
+    mockSearchParams.set("redirect", "/history");
+    mockCookieGetSession.mockResolvedValue({ data: { session: null } });
+    mockImplicitGetSession.mockResolvedValue({
+      data: {
+        session: {
+          access_token: "session-token",
+          user: { id: "user-1" },
+        },
+      },
+    });
+    mockImplicitUpdateUser.mockResolvedValue({ error: null });
+    mockImplicitSignOut.mockResolvedValue({ error: null });
+
+    render(React.createElement(ResetPasswordPage));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Update Password" })).toBeTruthy()
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("At least 8 characters"), {
+      target: { value: "new-password-1" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Repeat your new password"), {
+      target: { value: "new-password-1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Update Password" }));
+
+    await waitFor(() =>
+      expect(mockReplaceWithBrowser).toHaveBeenCalledWith(
+        "/login?redirect=%2Fhistory&reason=password_updated"
+      )
+    );
+    expect(mockImplicitUpdateUser).toHaveBeenCalledWith({
+      password: "new-password-1",
+    });
+    expect(mockImplicitSignOut).toHaveBeenCalledWith({ scope: "local" });
+    expect(mockCookieUpdateUser).not.toHaveBeenCalled();
   });
 });

--- a/tests/reset-password.page.test.ts
+++ b/tests/reset-password.page.test.ts
@@ -14,6 +14,12 @@ const mockImplicitGetSession = jest.fn();
 const mockImplicitOnAuthStateChange = jest.fn();
 const mockImplicitUpdateUser = jest.fn();
 const mockImplicitSignOut = jest.fn();
+let cookieAuthStateChange:
+  | ((event: string, session: unknown) => void)
+  | null = null;
+let implicitAuthStateChange:
+  | ((event: string, session: unknown) => void)
+  | null = null;
 
 jest.mock("next/link", () => {
   const ReactActual = jest.requireActual<typeof import("react")>("react");
@@ -67,6 +73,8 @@ describe("reset password page", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
+    cookieAuthStateChange = null;
+    implicitAuthStateChange = null;
     Array.from(mockSearchParams.keys()).forEach((key) => {
       mockSearchParams.delete(key);
     });
@@ -75,19 +83,25 @@ describe("reset password page", () => {
     window.location.hash = "";
     mockCookieGetSession.mockResolvedValue({ data: { session: null } });
     mockImplicitGetSession.mockResolvedValue({ data: { session: null } });
-    mockCookieOnAuthStateChange.mockReturnValue({
-      data: {
-        subscription: {
-          unsubscribe: jest.fn(),
+    mockCookieOnAuthStateChange.mockImplementation((callback) => {
+      cookieAuthStateChange = callback as (event: string, session: unknown) => void;
+      return {
+        data: {
+          subscription: {
+            unsubscribe: jest.fn(),
+          },
         },
-      },
+      };
     });
-    mockImplicitOnAuthStateChange.mockReturnValue({
-      data: {
-        subscription: {
-          unsubscribe: jest.fn(),
+    mockImplicitOnAuthStateChange.mockImplementation((callback) => {
+      implicitAuthStateChange = callback as (event: string, session: unknown) => void;
+      return {
+        data: {
+          subscription: {
+            unsubscribe: jest.fn(),
+          },
         },
-      },
+      };
     });
   });
 
@@ -213,6 +227,13 @@ describe("reset password page", () => {
       expect(screen.getByRole("button", { name: "Update Password" })).toBeTruthy()
     );
 
+    act(() => {
+      cookieAuthStateChange?.("SIGNED_IN", {
+        access_token: "cookie-session-token",
+        user: { id: "signed-in-user" },
+      });
+    });
+
     fireEvent.change(screen.getByPlaceholderText("At least 8 characters"), {
       target: { value: "new-password-1" },
     });
@@ -232,5 +253,6 @@ describe("reset password page", () => {
     expect(mockImplicitSignOut).toHaveBeenCalledWith({ scope: "local" });
     expect(mockCookieGetSession).not.toHaveBeenCalled();
     expect(mockCookieUpdateUser).not.toHaveBeenCalled();
+    expect(implicitAuthStateChange).not.toBeNull();
   });
 });

--- a/tests/supabase-recovery-client.test.ts
+++ b/tests/supabase-recovery-client.test.ts
@@ -1,0 +1,74 @@
+describe("Supabase recovery client", () => {
+  const savedUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const savedKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  function restoreEnv(name: string, value: string | undefined) {
+    if (value === undefined) {
+      delete process.env[name];
+      return;
+    }
+
+    process.env[name] = value;
+  }
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+  });
+
+  afterEach(() => {
+    restoreEnv("NEXT_PUBLIC_SUPABASE_URL", savedUrl);
+    restoreEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", savedKey);
+    jest.dontMock("@supabase/ssr");
+    jest.dontMock("@supabase/supabase-js");
+  });
+
+  it("keeps the normal browser client on the SSR helper", () => {
+    const createBrowserClient = jest.fn().mockReturnValue({ kind: "browser" });
+    const createSupabaseClient = jest.fn().mockReturnValue({ kind: "recovery" });
+
+    jest.doMock("@supabase/ssr", () => ({ createBrowserClient }));
+    jest.doMock("@supabase/supabase-js", () => ({
+      createClient: createSupabaseClient,
+    }));
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { createClient } = require("@/lib/supabase");
+
+    expect(createClient()).toEqual({ kind: "browser" });
+    expect(createBrowserClient).toHaveBeenCalledWith(
+      "https://example.supabase.co",
+      "anon-key"
+    );
+    expect(createSupabaseClient).not.toHaveBeenCalled();
+  });
+
+  it("uses the base Supabase client for implicit recovery links", () => {
+    const createBrowserClient = jest.fn().mockReturnValue({ kind: "browser" });
+    const createSupabaseClient = jest.fn().mockReturnValue({ kind: "recovery" });
+
+    jest.doMock("@supabase/ssr", () => ({ createBrowserClient }));
+    jest.doMock("@supabase/supabase-js", () => ({
+      createClient: createSupabaseClient,
+    }));
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { createRecoveryClient } = require("@/lib/supabase");
+
+    expect(createRecoveryClient()).toEqual({ kind: "recovery" });
+    expect(createBrowserClient).not.toHaveBeenCalled();
+    expect(createSupabaseClient).toHaveBeenCalledWith(
+      "https://example.supabase.co",
+      "anon-key",
+      {
+        auth: {
+          autoRefreshToken: true,
+          detectSessionInUrl: true,
+          flowType: "implicit",
+          persistSession: true,
+        },
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- send forgot-password reset emails through the implicit recovery Supabase client
- add a root-layout recovery redirect guard so reset links that land on `/` are moved to `/reset-password` instead of showing the landing page
- preserve safe post-reset redirect targets and hand recovery code links to the existing auth callback route

## Validation
- git diff --check
- NODE_PATH="G:\MY Website\pawvital-ai\node_modules" jest focused auth/reset suite: 5 suites, 25 tests passed
- NODE_PATH="G:\MY Website\pawvital-ai\node_modules" npm run build
- npm run security:secrets

## Notes
- No clinical runtime files touched.
- No Vercel env changes.
- No secret values exposed.