### PR TITLE
VET-1529C hold shadow readout until comparisons persist

### DIFF
--- a/.github/workflows/shadow-readout-scheduler.yml
+++ b/.github/workflows/shadow-readout-scheduler.yml
@@ -75,7 +75,7 @@ jobs:
               `Report count: \`${reportJson.readout?.reportCount ?? 0}\``,
               `Warning: \`${reportJson.readout?.warning ?? "null"}\``,
               "",
-              "Run the formal VET-1492C rerun if this report shows meaningful production sessions. Keep flags in shadow/off otherwise.",
+              reportJson.nextAction ?? "Keep flags in shadow/off and continue collecting invited tester sessions.",
               "",
               "<details><summary>Scheduler report</summary>",
               "",

--- a/scripts/shadow-readout-scheduler-logic.cjs
+++ b/scripts/shadow-readout-scheduler-logic.cjs
@@ -1,0 +1,114 @@
+function numberFrom(value, fallback = 0) {
+  const parsed = Number(value ?? fallback);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function countFromRate(rate, total) {
+  const parsedRate = Number(rate);
+  if (!Number.isFinite(parsedRate) || parsedRate <= 0 || total <= 0) {
+    return 0;
+  }
+  return Math.round(parsedRate * total);
+}
+
+function summarizeServiceMetrics(service) {
+  const observations = numberFrom(
+    service.observations ??
+      service.totalObservations ??
+      service.observationCount,
+    0
+  );
+  const shadowComparisons = numberFrom(
+    service.shadowComparisons ??
+      service.shadowComparisonCount ??
+      service.comparisonCount,
+    0
+  );
+
+  return {
+    service: service.service,
+    observations,
+    shadowComparisons,
+    errors: numberFrom(
+      service.errors ??
+        service.errorObservations ??
+        service.errorCount ??
+        countFromRate(service.errorRate, observations),
+      0
+    ),
+    timeouts: numberFrom(
+      service.timeouts ??
+        service.timeoutObservations ??
+        service.timeoutCount ??
+        countFromRate(service.timeoutRate, observations),
+      0
+    ),
+  };
+}
+
+function summarizePayload(payload) {
+  const baseline = payload?.baseline ?? {};
+  const summary = payload?.summary ?? {};
+  const serviceMetrics = Array.isArray(baseline.serviceMetrics)
+    ? baseline.serviceMetrics.map(summarizeServiceMetrics)
+    : [];
+
+  return {
+    ok: payload?.ok === true,
+    overallStatus: summary.overallStatus ?? null,
+    reportCount: numberFrom(baseline.reportCount, 0),
+    parsedReportCount: numberFrom(baseline.parsedReportCount, 0),
+    malformedReportCount: numberFrom(baseline.malformedReportCount, 0),
+    observationCount: numberFrom(baseline.observationCount, 0),
+    shadowComparisonCount: numberFrom(baseline.shadowComparisonCount, 0),
+    warning: baseline.warning ?? null,
+    serviceMetrics,
+  };
+}
+
+function decideStatus(readout) {
+  if (readout.warning) {
+    return {
+      status: "readout_warning",
+      decision: "HOLD - telemetry readout returned a warning",
+    };
+  }
+
+  if (readout.shadowComparisonCount > 0) {
+    return {
+      status: "ready_for_formal_readout",
+      decision: "RUN FORMAL VET-1492C RERUN",
+    };
+  }
+
+  if (readout.reportCount > 0 || readout.observationCount > 0) {
+    return {
+      status: "blocked_missing_shadow_comparisons",
+      decision: "HOLD - production sessions found but no shadow comparisons recorded",
+    };
+  }
+
+  return {
+    status: "healthy_empty_readout",
+    decision: "HOLD - no completed production sessions found yet",
+  };
+}
+
+function nextActionForStatus(status) {
+  if (status === "ready_for_formal_readout") {
+    return "Start the formal VET-1492C rerun against this production window before any model promotion.";
+  }
+  if (status === "blocked_missing_shadow_comparisons") {
+    return "Trigger a tester flow that reaches an accepted second-opinion shadow comparison, then rerun the scheduler before starting a formal readout.";
+  }
+  if (status === "readout_warning") {
+    return "Keep flags in shadow/off and repair the telemetry readout warning before collecting formal readout evidence.";
+  }
+  return "Keep flags in shadow/off and continue collecting invited tester sessions.";
+}
+
+module.exports = {
+  decideStatus,
+  nextActionForStatus,
+  summarizePayload,
+};

--- a/scripts/shadow-readout-scheduler.mjs
+++ b/scripts/shadow-readout-scheduler.mjs
@@ -2,6 +2,7 @@
 
 import fs from "node:fs/promises";
 import path from "node:path";
+import schedulerLogic from "./shadow-readout-scheduler-logic.cjs";
 
 const DEFAULT_READOUT_URL =
   "https://pawvital-ai.vercel.app/api/ai/shadow-rollout";
@@ -11,6 +12,7 @@ const DEFAULT_JSON_OUTPUT =
   "data/shadow-readout/vet-1492c-scheduled-readout.json";
 const DEFAULT_MARKDOWN_OUTPUT =
   "data/shadow-readout/vet-1492c-scheduled-readout.md";
+const { decideStatus, nextActionForStatus, summarizePayload } = schedulerLogic;
 
 function parseBoolean(value) {
   return value === "1" || value === "true" || value === "yes";
@@ -29,54 +31,6 @@ function sanitizeForLogs(value) {
   return value
     .replace(/[A-Za-z0-9_-]{32,}/g, "[redacted-token]")
     .replace(/Bearer\s+[^\s]+/gi, "Bearer [redacted]");
-}
-
-function summarizePayload(payload) {
-  const baseline = payload?.baseline ?? {};
-  const summary = payload?.summary ?? {};
-  const serviceMetrics = Array.isArray(baseline.serviceMetrics)
-    ? baseline.serviceMetrics.map((service) => ({
-        service: service.service,
-        observations: service.observations ?? service.totalObservations ?? 0,
-        shadowComparisons:
-          service.shadowComparisons ?? service.shadowComparisonCount ?? 0,
-        errors: service.errors ?? service.errorObservations ?? 0,
-        timeouts: service.timeouts ?? service.timeoutObservations ?? 0,
-      }))
-    : [];
-
-  return {
-    ok: payload?.ok === true,
-    overallStatus: summary.overallStatus ?? null,
-    reportCount: Number(baseline.reportCount ?? 0),
-    parsedReportCount: Number(baseline.parsedReportCount ?? 0),
-    malformedReportCount: Number(baseline.malformedReportCount ?? 0),
-    observationCount: Number(baseline.observationCount ?? 0),
-    shadowComparisonCount: Number(baseline.shadowComparisonCount ?? 0),
-    warning: baseline.warning ?? null,
-    serviceMetrics,
-  };
-}
-
-function decideStatus(readout) {
-  if (readout.warning) {
-    return {
-      status: "readout_warning",
-      decision: "HOLD - telemetry readout returned a warning",
-    };
-  }
-
-  if (readout.reportCount > 0 || readout.observationCount > 0) {
-    return {
-      status: "ready_for_formal_readout",
-      decision: "RUN FORMAL VET-1492C RERUN",
-    };
-  }
-
-  return {
-    status: "healthy_empty_readout",
-    decision: "HOLD - no completed production sessions found yet",
-  };
 }
 
 function toMarkdown(report) {
@@ -240,10 +194,7 @@ async function main() {
         ...report,
         ...decision,
         readout,
-        nextAction:
-          decision.status === "ready_for_formal_readout"
-            ? "Start the formal VET-1492C rerun against this production window before any model promotion."
-            : "Keep flags in shadow/off and continue collecting invited tester sessions.",
+        nextAction: nextActionForStatus(decision.status),
       };
     } catch (error) {
       report = {

--- a/tests/shadow-readout-scheduler.test.ts
+++ b/tests/shadow-readout-scheduler.test.ts
@@ -1,0 +1,70 @@
+import schedulerLogic from "../scripts/shadow-readout-scheduler-logic.cjs";
+
+const { decideStatus, nextActionForStatus, summarizePayload } = schedulerLogic;
+
+describe("shadow readout scheduler decision logic", () => {
+  it("holds when production reports and observations exist but shadow comparisons are still zero", () => {
+    const decision = decideStatus({
+      warning: null,
+      reportCount: 2,
+      observationCount: 2,
+      shadowComparisonCount: 0,
+    });
+
+    expect(decision).toEqual({
+      status: "blocked_missing_shadow_comparisons",
+      decision: "HOLD - production sessions found but no shadow comparisons recorded",
+    });
+    expect(nextActionForStatus(decision.status)).toContain(
+      "Trigger a tester flow that reaches an accepted second-opinion shadow comparison"
+    );
+  });
+
+  it("marks the scheduler ready only when shadow comparisons are present", () => {
+    const decision = decideStatus({
+      warning: null,
+      reportCount: 2,
+      observationCount: 2,
+      shadowComparisonCount: 1,
+    });
+
+    expect(decision).toEqual({
+      status: "ready_for_formal_readout",
+      decision: "RUN FORMAL VET-1492C RERUN",
+    });
+  });
+
+  it("summarizes current baseline service metric fields from the production endpoint", () => {
+    const readout = summarizePayload({
+      ok: true,
+      summary: { overallStatus: "insufficient_data" },
+      baseline: {
+        reportCount: 2,
+        parsedReportCount: 2,
+        malformedReportCount: 0,
+        observationCount: 2,
+        shadowComparisonCount: 1,
+        warning: null,
+        serviceMetrics: [
+          {
+            service: "async-review-service",
+            observationCount: 2,
+            comparisonCount: 1,
+            errorRate: 0.5,
+            timeoutRate: 0,
+          },
+        ],
+      },
+    });
+
+    expect(readout.serviceMetrics).toEqual([
+      {
+        service: "async-review-service",
+        observations: 2,
+        shadowComparisons: 1,
+        errors: 1,
+        timeouts: 0,
+      },
+    ]);
+  });
+});

--- a/tests/shadow-rollout-baseline.test.ts
+++ b/tests/shadow-rollout-baseline.test.ts
@@ -181,6 +181,98 @@ describe("shadow rollout baseline persistence", () => {
     expect(mockListShadowTelemetrySnapshots).toHaveBeenCalledWith(100);
   });
 
+  it("counts stored chat comparisons when fresh reports only persist sanitized aggregate observations", async () => {
+    const limit = jest.fn().mockResolvedValue({
+      data: [
+        {
+          id: "8f9ecd7b-0000-4000-8000-00000000cfd5",
+          ai_response: JSON.stringify({
+            system_observability: {
+              timeoutCount: 0,
+              fallbackCount: 0,
+              shadowReadout: {
+                reportPresent: true,
+                sessionPresent: true,
+                observationCount: 2,
+                shadowComparisonCount: 0,
+                timeoutCount: 0,
+                fallbackCount: 0,
+                providerErrorCount: 2,
+                budgetExceededCount: 0,
+              },
+            },
+          }),
+        },
+        {
+          id: "50a0595f-0000-4000-8000-00000000a5ff",
+          ai_response: JSON.stringify({
+            system_observability: {
+              timeoutCount: 0,
+              fallbackCount: 0,
+              shadowReadout: {
+                reportPresent: true,
+                sessionPresent: true,
+                observationCount: 0,
+                shadowComparisonCount: 0,
+                timeoutCount: 0,
+                fallbackCount: 0,
+                providerErrorCount: 0,
+                budgetExceededCount: 0,
+              },
+            },
+          }),
+        },
+      ],
+      error: null,
+    });
+    const order = jest.fn(() => ({ limit }));
+    const gte = jest.fn(() => ({ order }));
+    const select = jest.fn(() => ({ gte }));
+    const from = jest.fn(() => ({ select }));
+    mockGetServiceSupabase.mockReturnValue({ from });
+    mockIsShadowTelemetryStoreConfigured.mockReturnValue(true);
+    mockListShadowTelemetrySnapshots.mockResolvedValue([
+      {
+        source: "chat",
+        generatedAt: new Date().toISOString(),
+        recentServiceCalls: [],
+        recentShadowComparisons: [
+          {
+            service: "async-review-service",
+            usedStrategy: "deterministic_extraction_failed",
+            shadowStrategy: "second_opinion_extractor",
+            summary: "q=vomit_duration; shadow_answer_recorded=true; conf=0.92",
+            disagreementCount: 1,
+            recordedAt: new Date().toISOString(),
+          },
+        ],
+      },
+    ]);
+
+    const { buildPersistedShadowBaselineSnapshot } = await import(
+      "@/lib/shadow-rollout-baseline"
+    );
+    const snapshot = await buildPersistedShadowBaselineSnapshot({
+      windowHours: 24,
+      limit: 100,
+    });
+
+    expect(snapshot.reportCount).toBe(2);
+    expect(snapshot.parsedReportCount).toBe(2);
+    expect(snapshot.observationCount).toBe(2);
+    expect(snapshot.providerErrorCount).toBe(2);
+    expect(snapshot.shadowComparisonCount).toBe(1);
+    expect(snapshot.warning).toBeNull();
+    expect(snapshot.serviceMetrics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          service: "async-review-service",
+          comparisonCount: 1,
+        }),
+      ])
+    );
+  });
+
   it("ignores non-numeric persisted aggregate counts in symptom checks", async () => {
     const limit = jest.fn().mockResolvedValue({
       data: [


### PR DESCRIPTION
## Summary
- Hold the scheduled shadow readout when production reports/observations exist but `shadowComparisonCount` is still zero.
- Extract scheduler decision/summarization logic into a testable helper and fix service metric summarization for the current production endpoint field names.
- Add regressions for the May 26 sanitized aggregate row shape plus stored chat comparison counts.

## Root cause
The scheduler treated `reportCount > 0 || observationCount > 0` as `ready_for_formal_readout`, so issue #495 could say RUN FORMAL READOUT even when `shadowComparisonCount` was zero. The persisted May 26 rows contain only sanitized aggregate `shadowReadout` counts; chat-turn comparisons must come from supplemental telemetry and the scheduler must not promote readiness when that count remains zero.

## Validation
- `npm test -- --runTestsByPath tests/symptom-chat.second-opinion-extractor.test.ts --runInBand`
- `npm test -- --runTestsByPath tests/symptom-chat.telemetry-gate.test.ts --runInBand`
- `npm test -- --runTestsByPath tests/shadow-rollout-baseline.test.ts --runInBand`
- `npm test -- --runTestsByPath tests/shadow-readout-scheduler.test.ts --runInBand`
- production scheduler dry run against `https://pawvital-ai.vercel.app/api/ai/shadow-rollout` now returns `blocked_missing_shadow_comparisons`
- `npm run build`
- `npm run security:secrets`
- `git diff --check`

## Scope notes
- No clinical logic changes.
- No owner-visible behavior changes.
- No model flag promotion.
- No Vercel env changes.
- No Supabase schema changes.
- No secret values exposed.