### PR TITLE
AZ-003: privacy-safe App Insights telemetry

### DIFF
--- a/src/app/api/admin/telemetry/route.ts
+++ b/src/app/api/admin/telemetry/route.ts
@@ -1,23 +1,45 @@
 import { NextResponse } from "next/server";
 import { getAdminRequestContext } from "@/lib/admin-auth";
 import { loadAdminTelemetryDashboardData } from "@/lib/admin-telemetry";
+import {
+  trackException,
+  trackRouteTelemetry,
+} from "@/lib/azure/telemetry";
 
 export const dynamic = "force-dynamic";
+const ROUTE_NAME = "api.admin.telemetry";
 
 export async function GET() {
+  const startedAtMs = Date.now();
+  let statusCode = 200;
+  let errorCode: string | undefined;
+
   try {
     const adminContext = await getAdminRequestContext();
     if (!adminContext) {
+      statusCode = 401;
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
     const telemetry = await loadAdminTelemetryDashboardData(adminContext);
     return NextResponse.json(telemetry);
   } catch (error) {
+    statusCode = 500;
+    errorCode = "admin_telemetry_unhandled";
     console.error("Admin telemetry GET route error:", error);
     return NextResponse.json(
       { error: "Internal Server Error" },
       { status: 500 }
     );
+  } finally {
+    void trackRouteTelemetry({
+      routeName: ROUTE_NAME,
+      statusCode,
+      startedAtMs,
+      errorCode,
+    });
+    if (errorCode) {
+      void trackException(errorCode, { routeName: ROUTE_NAME });
+    }
   }
 }

--- a/src/app/api/ai/symptom-chat/route.ts
+++ b/src/app/api/ai/symptom-chat/route.ts
@@ -161,6 +161,10 @@ import {
   generateReport,
   generateTerminalOutcomeReport,
 } from "@/lib/symptom-chat/report-pipeline";
+import {
+  trackException,
+  trackRouteTelemetry,
+} from "@/lib/azure/telemetry";
 
 // =============================================================================
 // HYBRID STATE MACHINE API — 4-Model NVIDIA NIM Pipeline
@@ -180,6 +184,7 @@ import {
 
 // Detect which engine to use
 const useNvidia = isNvidiaConfigured();
+const ROUTE_NAME = "api.ai.symptom-chat";
 
 interface RequestBody {
   messages: { role: "user" | "assistant"; content: string }[];
@@ -1036,6 +1041,10 @@ function buildDeterministicEmergencyMessage(
 }
 
 export async function POST(request: Request) {
+  const startedAtMs = Date.now();
+  let statusCode = 200;
+  let errorCode: string | undefined;
+
   try {
     // ── Rate limiting ─────────────────────────────────────────────────────
     const rlResult = await checkRateLimit(
@@ -1043,6 +1052,7 @@ export async function POST(request: Request) {
       getRateLimitId(request)
     );
     if (!rlResult.success) {
+      statusCode = 429;
       return NextResponse.json(
         { error: "Too many requests. Please slow down." },
         {
@@ -1074,6 +1084,7 @@ export async function POST(request: Request) {
       session,
     });
     if (usageLimitResponse) {
+      statusCode = usageLimitResponse.status;
       return usageLimitResponse;
     }
 
@@ -2511,6 +2522,7 @@ export async function POST(request: Request) {
       image,
     });
   } catch (error) {
+    errorCode = "symptom_chat_unhandled";
     console.error("Symptom chat error:", error);
     return NextResponse.json(
       {
@@ -2520,5 +2532,15 @@ export async function POST(request: Request) {
       },
       { status: 200 }
     );
+  } finally {
+    void trackRouteTelemetry({
+      routeName: ROUTE_NAME,
+      statusCode,
+      startedAtMs,
+      errorCode,
+    });
+    if (errorCode) {
+      void trackException(errorCode, { routeName: ROUTE_NAME });
+    }
   }
 }

--- a/src/lib/azure/telemetry.ts
+++ b/src/lib/azure/telemetry.ts
@@ -1,0 +1,312 @@
+/**
+ * AZ-003 — App Insights telemetry wrapper
+ *
+ * Privacy rules (enforced at the type level):
+ *   - Only allow-listed SafePropertyKey values can be tracked.
+ *   - Raw symptom text, owner names, pet names, and full chat transcripts
+ *     are structurally excluded — they cannot appear in SafeProperties.
+ *   - Tracking is a silent no-op when the connection string is absent
+ *     (demo mode, CI, any environment without Azure credentials).
+ *   - Telemetry must never throw or disrupt clinical behavior.
+ *
+ * Usage:
+ *   import { trackEvent, trackException } from '@/lib/azure/telemetry';
+ *   await trackEvent({ name: 'triage.urgency.determined', properties: { urgencyTier: 'emergency' } });
+ */
+
+import type { AzureClientOptions } from "@/lib/azure";
+import { getAppInsightsConnectionString } from "@/lib/azure";
+
+// ---------------------------------------------------------------------------
+// Safe event names — operational events only, never raw clinical content
+// ---------------------------------------------------------------------------
+export type SafeEventName =
+  | "route.request"
+  | "route.error"
+  | "triage.session.started"
+  | "triage.urgency.determined"
+  | "ai.model.called"
+  | "sidecar.health.checked"
+  | "azure.service.called"
+  | "feature.flag.checked";
+
+// ---------------------------------------------------------------------------
+// Allow-listed property keys — PII boundary enforced at the type level.
+// Adding a new key here is a deliberate, reviewable act.
+// Raw user input keys (symptomText, ownerName, petName, chatHistory, etc.)
+// are intentionally absent and must never be added.
+// ---------------------------------------------------------------------------
+export type SafePropertyKey =
+  | "routeName"
+  | "statusCode"
+  | "durationMs"
+  | "urgencyTier"
+  | "complaintFamily"
+  | "modelUsed"
+  | "sidecarsHealthy"
+  | "featureFlag"
+  | "flagValue"
+  | "azureService"
+  | "sessionId" // opaque ID only — never an owner or user identifier
+  | "errorCode"
+  | "demoMode";
+
+export type SafeProperties = Partial<
+  Record<SafePropertyKey, string | number | boolean>
+>;
+
+// ---------------------------------------------------------------------------
+// Public event shape
+// ---------------------------------------------------------------------------
+export interface TriageTelemetryEvent {
+  name: SafeEventName;
+  properties?: SafeProperties;
+  measurements?: Record<string, number>;
+}
+
+export interface RouteTelemetryInput {
+  routeName: string;
+  statusCode: number;
+  startedAtMs: number;
+  errorCode?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Injectable transport interface — used for testing without network calls
+// ---------------------------------------------------------------------------
+type EventEnvelope = {
+  name: string;
+  time: string;
+  iKey: string;
+  data: {
+    baseType: "EventData";
+    baseData: {
+      ver: 2;
+      name: string;
+      properties?: Record<string, string>;
+      measurements?: Record<string, number>;
+    };
+  };
+};
+
+type ExceptionEnvelope = {
+  name: string;
+  time: string;
+  iKey: string;
+  data: {
+    baseType: "ExceptionData";
+    baseData: {
+      ver: 2;
+      exceptions: Array<{
+        typeName: "PawVitalTelemetryError";
+        message: string;
+        hasFullStack: false;
+      }>;
+      properties?: Record<string, string>;
+    };
+  };
+};
+
+export type TelemetryEnvelope = EventEnvelope | ExceptionEnvelope;
+
+export interface TelemetryTransportRequest {
+  endpoint: string;
+  envelope: TelemetryEnvelope;
+}
+
+export type TelemetryTransport = (
+  request: TelemetryTransportRequest
+) => Promise<void> | void;
+
+export interface TrackOptions extends AzureClientOptions {
+  /** Inject a mock transport in tests instead of sending to Azure Monitor. */
+  transport?: TelemetryTransport;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function serializeProperties(
+  properties?: SafeProperties
+): Record<string, string> | undefined {
+  if (!properties) return undefined;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(properties)) {
+    if (v !== undefined && v !== null) out[k] = String(v);
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function parseConnectionString(
+  connectionString: string
+): { instrumentationKey: string; ingestionEndpoint: string } | null {
+  const parts = new Map<string, string>();
+  for (const part of connectionString.split(";")) {
+    const [rawKey, ...rawValue] = part.split("=");
+    const key = rawKey?.trim();
+    const value = rawValue.join("=").trim();
+    if (key && value) parts.set(key.toLowerCase(), value);
+  }
+
+  const instrumentationKey = parts.get("instrumentationkey");
+  if (!instrumentationKey) return null;
+
+  return {
+    instrumentationKey,
+    ingestionEndpoint:
+      parts.get("ingestionendpoint") ?? "https://dc.services.visualstudio.com/",
+  };
+}
+
+function buildIngestionEndpoint(connectionString: string): {
+  endpoint: string;
+  instrumentationKey: string;
+} | null {
+  const parsed = parseConnectionString(connectionString);
+  if (!parsed) return null;
+
+  return {
+    instrumentationKey: parsed.instrumentationKey,
+    endpoint: `${parsed.ingestionEndpoint.replace(/\/+$/, "")}/v2.1/track`,
+  };
+}
+
+async function defaultTransport(
+  request: TelemetryTransportRequest
+): Promise<void> {
+  await fetch(request.endpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(request.envelope),
+  });
+}
+
+async function sendEnvelope(
+  connectionString: string,
+  envelope: (instrumentationKey: string) => TelemetryEnvelope,
+  transport: TelemetryTransport = defaultTransport
+): Promise<void> {
+  const target = buildIngestionEndpoint(connectionString);
+  if (!target) return;
+
+  await transport({
+    endpoint: target.endpoint,
+    envelope: envelope(target.instrumentationKey),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Track an operational event.
+ * Silent no-op when the App Insights connection string is unavailable.
+ * Never throws — telemetry must not affect clinical behavior.
+ */
+export async function trackEvent(
+  event: TriageTelemetryEvent,
+  options: TrackOptions = {}
+): Promise<void> {
+  try {
+    const connectionString = await getAppInsightsConnectionString(options);
+    if (!connectionString) return;
+
+    await sendEnvelope(
+      connectionString,
+      (instrumentationKey) => ({
+        name: `Microsoft.ApplicationInsights.${instrumentationKey}.Event`,
+        time: new Date().toISOString(),
+        iKey: instrumentationKey,
+        data: {
+          baseType: "EventData",
+          baseData: {
+            ver: 2,
+            name: `pawvital.${event.name}`,
+            properties: serializeProperties(event.properties),
+            measurements: event.measurements,
+          },
+        },
+      }),
+      options.transport
+    );
+  } catch {
+    // Intentionally swallowed — telemetry must never throw
+  }
+}
+
+/**
+ * Track sanitized route latency/status. The caller must pass a stable route name
+ * only; never include owner text, request paths with IDs, or query strings.
+ */
+export function trackRouteTelemetry(
+  input: RouteTelemetryInput,
+  options: TrackOptions = {}
+): Promise<void> {
+  const durationMs = Math.max(0, Date.now() - input.startedAtMs);
+  const properties: SafeProperties = {
+    routeName: input.routeName,
+    statusCode: input.statusCode,
+    durationMs,
+  };
+
+  if (input.errorCode) {
+    properties.errorCode = input.errorCode;
+  }
+
+  return trackEvent(
+    {
+      name: input.errorCode ? "route.error" : "route.request",
+      properties,
+      measurements: { durationMs },
+    },
+    options
+  );
+}
+
+/**
+ * Track an unhandled exception by stable error code only.
+ * Raw Error objects are intentionally not accepted because their messages or
+ * stacks can contain owner-provided text.
+ * Silent no-op in demo mode.
+ */
+export async function trackException(
+  errorCode: string,
+  context?: Pick<SafeProperties, "routeName">,
+  options: TrackOptions = {}
+): Promise<void> {
+  try {
+    const connectionString = await getAppInsightsConnectionString(options);
+    if (!connectionString) return;
+
+    await sendEnvelope(
+      connectionString,
+      (instrumentationKey) => ({
+        name: `Microsoft.ApplicationInsights.${instrumentationKey}.Exception`,
+        time: new Date().toISOString(),
+        iKey: instrumentationKey,
+        data: {
+          baseType: "ExceptionData",
+          baseData: {
+            ver: 2,
+            exceptions: [
+              {
+                typeName: "PawVitalTelemetryError",
+                message: errorCode,
+                hasFullStack: false,
+              },
+            ],
+            properties: serializeProperties({
+              ...context,
+              errorCode,
+            }),
+          },
+        },
+      }),
+      options.transport
+    );
+  } catch {
+    // Intentionally swallowed
+  }
+}

--- a/tests/admin-telemetry.route.test.ts
+++ b/tests/admin-telemetry.route.test.ts
@@ -1,5 +1,7 @@
 const mockGetAdminRequestContext = jest.fn();
 const mockLoadAdminTelemetryDashboardData = jest.fn();
+const mockTrackRouteTelemetry = jest.fn();
+const mockTrackException = jest.fn();
 
 jest.mock("@/lib/admin-auth", () => ({
   getAdminRequestContext: (...args: unknown[]) =>
@@ -9,6 +11,11 @@ jest.mock("@/lib/admin-auth", () => ({
 jest.mock("@/lib/admin-telemetry", () => ({
   loadAdminTelemetryDashboardData: (...args: unknown[]) =>
     mockLoadAdminTelemetryDashboardData(...args),
+}));
+
+jest.mock("@/lib/azure/telemetry", () => ({
+  trackRouteTelemetry: (...args: unknown[]) => mockTrackRouteTelemetry(...args),
+  trackException: (...args: unknown[]) => mockTrackException(...args),
 }));
 
 function buildTelemetryPayload() {
@@ -83,6 +90,12 @@ describe("admin telemetry route", () => {
 
     expect(response.status).toBe(401);
     expect(payload.error).toContain("Unauthorized");
+    expect(mockTrackRouteTelemetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        routeName: "api.admin.telemetry",
+        statusCode: 401,
+      })
+    );
   });
 
   it("returns the production telemetry contract for admins", async () => {
@@ -104,6 +117,12 @@ describe("admin telemetry route", () => {
     expect(payload.recentServiceCalls).toBeUndefined();
     expect(payload.recentShadowComparisons).toBeUndefined();
     expect(serialized).not.toContain("question_state=");
+    expect(mockTrackRouteTelemetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        routeName: "api.admin.telemetry",
+        statusCode: 200,
+      })
+    );
   });
 
   it("returns 500 when telemetry loading throws", async () => {
@@ -120,5 +139,16 @@ describe("admin telemetry route", () => {
 
     expect(response.status).toBe(500);
     expect(payload.error).toContain("Internal Server Error");
+    expect(mockTrackRouteTelemetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        routeName: "api.admin.telemetry",
+        statusCode: 500,
+        errorCode: "admin_telemetry_unhandled",
+      })
+    );
+    expect(mockTrackException).toHaveBeenCalledWith(
+      "admin_telemetry_unhandled",
+      { routeName: "api.admin.telemetry" }
+    );
   });
 });

--- a/tests/azure-telemetry.test.ts
+++ b/tests/azure-telemetry.test.ts
@@ -1,0 +1,318 @@
+/**
+ * AZ-003 regression tests — App Insights telemetry wrapper
+ *
+ * Covers:
+ *   - demo-mode no-op (no connection string → silent return)
+ *   - event sent with correct prefixed name and properties
+ *   - numeric/boolean properties serialised to strings
+ *   - measurements passed through unchanged
+ *   - never throws even when the telemetry transport throws
+ *   - trackException sends stable error-code context only
+ *   - exception tracking is a no-op in demo mode
+ */
+
+import {
+  trackEvent,
+  trackException,
+  trackRouteTelemetry,
+  type TelemetryEnvelope,
+  type TelemetryTransportRequest,
+} from "@/lib/azure/telemetry";
+import type { SecretClientLike } from "@/lib/azure";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Fake SP credentials — required by getAzureRuntimeConfig before the
+ *  secretClientFactory is ever invoked. Must be present in every non-demo test. */
+const CONFIGURED_ENV = {
+  AZURE_TENANT_ID: "test-tenant-id",
+  AZURE_CLIENT_ID: "test-client-id",
+  AZURE_CLIENT_SECRET: "test-client-secret",
+  AZURE_KEY_VAULT_NAME: "test-vault",
+};
+
+const TEST_CONNECTION_STRING =
+  "InstrumentationKey=test-key-000;IngestionEndpoint=https://test.in.applicationinsights.azure.com/";
+
+function makeSecretClient(
+  secrets: Record<string, string>
+): SecretClientLike {
+  return {
+    getSecret: async (name: string) => ({ value: secrets[name] ?? null }),
+  };
+}
+
+function makeConnectedSecretClient(): SecretClientLike {
+  return makeSecretClient({
+    "appinsights-connection-string": TEST_CONNECTION_STRING,
+  });
+}
+
+type EventEnvelope = Extract<
+  TelemetryEnvelope,
+  { data: { baseType: "EventData" } }
+>;
+type ExceptionEnvelope = Extract<
+  TelemetryEnvelope,
+  { data: { baseType: "ExceptionData" } }
+>;
+
+function makeMockTransport() {
+  return jest.fn(async () => undefined);
+}
+
+function getEventEnvelope(transport: jest.Mock): EventEnvelope {
+  const request = transport.mock.calls[0]?.[0] as
+    | TelemetryTransportRequest
+    | undefined;
+  if (!request || request.envelope.data.baseType !== "EventData") {
+    throw new Error("Expected EventData envelope");
+  }
+  return request.envelope as EventEnvelope;
+}
+
+function getExceptionEnvelope(transport: jest.Mock): ExceptionEnvelope {
+  const request = transport.mock.calls[0]?.[0] as
+    | TelemetryTransportRequest
+    | undefined;
+  if (!request || request.envelope.data.baseType !== "ExceptionData") {
+    throw new Error("Expected ExceptionData envelope");
+  }
+  return request.envelope as ExceptionEnvelope;
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// trackEvent
+// ---------------------------------------------------------------------------
+
+describe("trackEvent", () => {
+  it("is a silent no-op in demo mode (no connection string)", async () => {
+    const transport = makeMockTransport();
+    await trackEvent(
+      { name: "route.request" },
+      { transport }
+      // no secretClientFactory => getAppInsightsConnectionString returns null
+    );
+    expect(transport).not.toHaveBeenCalled();
+  });
+
+  it("sends event prefixed with 'pawvital.' when connection string is present", async () => {
+    const transport = makeMockTransport();
+    await trackEvent(
+      { name: "triage.urgency.determined" },
+      {
+        env: CONFIGURED_ENV,
+        secretClientFactory: () => makeConnectedSecretClient(),
+        transport,
+      }
+    );
+    expect(transport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: "https://test.in.applicationinsights.azure.com/v2.1/track",
+      })
+    );
+    expect(getEventEnvelope(transport).data.baseData.name).toBe(
+      "pawvital.triage.urgency.determined"
+    );
+  });
+
+  it("serialises numeric and boolean properties to strings", async () => {
+    const transport = makeMockTransport();
+    await trackEvent(
+      {
+        name: "route.request",
+        properties: { statusCode: 200, demoMode: true, urgencyTier: "emergency" },
+      },
+      {
+        env: CONFIGURED_ENV,
+        secretClientFactory: () => makeConnectedSecretClient(),
+        transport,
+      }
+    );
+    expect(getEventEnvelope(transport).data.baseData.properties).toEqual({
+      statusCode: "200",
+      demoMode: "true",
+      urgencyTier: "emergency",
+    });
+  });
+
+  it("passes measurements through unchanged", async () => {
+    const transport = makeMockTransport();
+    await trackEvent(
+      { name: "ai.model.called", measurements: { durationMs: 123, tokens: 42 } },
+      {
+        env: CONFIGURED_ENV,
+        secretClientFactory: () => makeConnectedSecretClient(),
+        transport,
+      }
+    );
+    expect(getEventEnvelope(transport).data.baseData.measurements).toEqual({
+      durationMs: 123,
+      tokens: 42,
+    });
+  });
+
+  it("never throws even when the telemetry transport throws", async () => {
+    const brokenTransport = () => {
+      throw new Error("simulated network failure");
+    };
+    await expect(
+      trackEvent(
+        { name: "route.error" },
+        {
+          env: CONFIGURED_ENV,
+          secretClientFactory: () => makeConnectedSecretClient(),
+          transport: brokenTransport,
+        }
+      )
+    ).resolves.toBeUndefined();
+  });
+
+  it("omits properties key entirely when no properties are given", async () => {
+    const transport = makeMockTransport();
+    await trackEvent(
+      { name: "sidecar.health.checked" },
+      {
+        env: CONFIGURED_ENV,
+        secretClientFactory: () => makeConnectedSecretClient(),
+        transport,
+      }
+    );
+    expect(getEventEnvelope(transport).data.baseData.properties).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// trackRouteTelemetry
+// ---------------------------------------------------------------------------
+
+describe("trackRouteTelemetry", () => {
+  it("tracks sanitized route status and latency without request payloads", async () => {
+    const transport = makeMockTransport();
+    jest.spyOn(Date, "now").mockReturnValue(1_250);
+
+    await trackRouteTelemetry(
+      {
+        routeName: "api.ai.symptom-chat",
+        statusCode: 200,
+        startedAtMs: 1_000,
+      },
+      {
+        env: CONFIGURED_ENV,
+        secretClientFactory: () => makeConnectedSecretClient(),
+        transport,
+      }
+    );
+
+    const envelope = getEventEnvelope(transport);
+    expect(envelope.data.baseData).toEqual({
+      ver: 2,
+      name: "pawvital.route.request",
+      properties: {
+        routeName: "api.ai.symptom-chat",
+        statusCode: "200",
+        durationMs: "250",
+      },
+      measurements: { durationMs: 250 },
+    });
+  });
+
+  it("tracks route errors with fixed error codes only", async () => {
+    const transport = makeMockTransport();
+    jest.spyOn(Date, "now").mockReturnValue(2_010);
+
+    await trackRouteTelemetry(
+      {
+        routeName: "api.admin.telemetry",
+        statusCode: 500,
+        startedAtMs: 2_000,
+        errorCode: "admin_telemetry_unhandled",
+      },
+      {
+        env: CONFIGURED_ENV,
+        secretClientFactory: () => makeConnectedSecretClient(),
+        transport,
+      }
+    );
+
+    const envelope = getEventEnvelope(transport);
+    expect(envelope.data.baseData.name).toBe("pawvital.route.error");
+    expect(envelope.data.baseData.properties).toEqual({
+      routeName: "api.admin.telemetry",
+      statusCode: "500",
+      durationMs: "10",
+      errorCode: "admin_telemetry_unhandled",
+    });
+    expect(JSON.stringify(envelope)).not.toContain("symptom");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// trackException
+// ---------------------------------------------------------------------------
+
+describe("trackException", () => {
+  it("is a silent no-op in demo mode", async () => {
+    const transport = makeMockTransport();
+    await trackException("clinical_error", undefined, {
+      transport,
+    });
+    expect(transport).not.toHaveBeenCalled();
+  });
+
+  it("sends exception with safe context when connection string is present", async () => {
+    const transport = makeMockTransport();
+    await trackException(
+      "route_handler_crashed",
+      { routeName: "symptom-chat" },
+      {
+        env: CONFIGURED_ENV,
+        secretClientFactory: () => makeConnectedSecretClient(),
+        transport,
+      }
+    );
+    const exceptionData = getExceptionEnvelope(transport).data.baseData;
+    expect(exceptionData.exceptions).toEqual([
+      {
+        typeName: "PawVitalTelemetryError",
+        message: "route_handler_crashed",
+        hasFullStack: false,
+      },
+    ]);
+    expect(exceptionData.properties).toEqual({
+      routeName: "symptom-chat",
+      errorCode: "route_handler_crashed",
+    });
+  });
+
+  it("sends exception with error code only when context is omitted", async () => {
+    const transport = makeMockTransport();
+    await trackException("unhandled", undefined, {
+      env: CONFIGURED_ENV,
+      secretClientFactory: () => makeConnectedSecretClient(),
+      transport,
+    });
+    expect(getExceptionEnvelope(transport).data.baseData.properties).toEqual({
+      errorCode: "unhandled",
+    });
+  });
+
+  it("never throws even when the telemetry transport throws", async () => {
+    const brokenTransport = () => {
+      throw new Error("transport crash");
+    };
+    await expect(
+      trackException("test", { routeName: "triage" }, {
+        env: CONFIGURED_ENV,
+        secretClientFactory: () => makeConnectedSecretClient(),
+        transport: brokenTransport,
+      })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/tests/symptom-chat.route.test.ts
+++ b/tests/symptom-chat.route.test.ts
@@ -54,6 +54,8 @@ const mockSaveTesterFeedbackCaseLedgerToDB = jest.fn(async () => ({
 }));
 const mockEmit = jest.fn();
 const mockCalibrateDiagnosticConfidence = jest.fn();
+const mockTrackRouteTelemetry = jest.fn();
+const mockTrackException = jest.fn();
 const mockEventType = {
   REPORT_READY: "REPORT_READY",
   URGENCY_HIGH: "URGENCY_HIGH",
@@ -231,6 +233,11 @@ jest.mock("@/lib/events/event-bus", () => ({
 }));
 
 jest.mock("@/lib/events/notification-handler", () => ({}));
+
+jest.mock("@/lib/azure/telemetry", () => ({
+  trackRouteTelemetry: (...args: unknown[]) => mockTrackRouteTelemetry(...args),
+  trackException: (...args: unknown[]) => mockTrackException(...args),
+}));
 
 const PET = {
   name: "Bruno",
@@ -654,6 +661,33 @@ describe("symptom-chat mixed text + image routing", () => {
     });
     mockEvaluateImageGate.mockResolvedValue(null);
     mockShouldAnalyzeWoundImage.mockReturnValue(false);
+  });
+
+  it("records sanitized route telemetry for rate-limited symptom-chat requests", async () => {
+    mockCheckRateLimit.mockResolvedValue({
+      success: false,
+      reset: Date.now() + 60_000,
+    });
+
+    const { POST } = await import("@/app/api/ai/symptom-chat/route");
+    const response = await POST(
+      makeTextOnlyRequest(
+        createSession(),
+        "My dog is coughing and breathing strangely."
+      )
+    );
+
+    expect(response.status).toBe(429);
+    expect(mockTrackRouteTelemetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        routeName: "api.ai.symptom-chat",
+        statusCode: 429,
+      })
+    );
+    expect(JSON.stringify(mockTrackRouteTelemetry.mock.calls)).not.toContain(
+      "coughing"
+    );
+    expect(mockTrackException).not.toHaveBeenCalled();
   });
 
   it("fuses a direct leg answer with wound-photo evidence and pivots to wound follow-up", async () => {


### PR DESCRIPTION
## What changed
- Added `src/lib/azure/telemetry.ts`, a privacy-safe Application Insights wrapper that reads the connection string through the AZ-002 Key Vault layer and no-ops in demo mode.
- Sends sanitized App Insights ingestion envelopes through server-side `fetch` with an injectable test transport. No `applicationinsights` SDK dependency is added because the SDK currently pulls vulnerable production dependencies.
- Added sanitized `trackRouteTelemetry()` and `trackException(errorCode)` helpers. Exception telemetry accepts stable error codes only, not raw Error objects.
- Wired route latency/status telemetry into `api.admin.telemetry` and `api.ai.symptom-chat` without changing clinical decisions.
- Added regression coverage for demo mode, property serialization, route telemetry, sanitized exception telemetry, admin route telemetry, and symptom-chat rate-limit telemetry.

## Privacy boundary
- No raw symptoms, owner names, pet names, full chat transcripts, request bodies, dynamic request paths, or raw Error objects are sent to App Insights.
- Route callers only pass stable route names, status codes, duration, and fixed error codes.

## Verification
- `node node_modules\\jest\\bin\\jest.js --verbose --runInBand --runTestsByPath tests/azure-telemetry.test.ts tests/admin-telemetry.route.test.ts` -> 2 suites / 15 tests passed
- `node node_modules\\typescript\\bin\\tsc --noEmit --pretty false` -> passed
- `node node_modules\\eslint\\bin\\eslint.js src/lib/azure/telemetry.ts src/app/api/admin/telemetry/route.ts src/app/api/ai/symptom-chat/route.ts tests/azure-telemetry.test.ts tests/admin-telemetry.route.test.ts tests/symptom-chat.route.test.ts` -> 0 errors, 3 pre-existing warnings in `symptom-chat/route.ts`
- `git diff --check` -> passed
- `npm run security:secrets` -> passed
- `npm audit --omit=dev` -> 0 vulnerabilities
- `node node_modules\\jest\\bin\\jest.js --verbose --runInBand --testPathPatterns=symptom-chat` -> 11 suites / 578 tests passed

## Notes
- Used `G:\\MY Website\\pawvital-ai-azure-platform` as the isolated worktree after the main worktree switched branches during verification.
- The first pushed version used `applicationinsights@^3.15.0`; CI rejected it through `npm audit --omit=dev`, so this revision removed the SDK and keeps dependency audit clean.