### PR TITLE
AZ-009: add Service Bus queue producer foundation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@azure/app-configuration": "^1.11.0",
         "@azure/identity": "^4.13.1",
         "@azure/keyvault-secrets": "^4.11.2",
+        "@azure/service-bus": "^7.9.5",
         "@azure/storage-blob": "^12.31.0",
         "@octokit/rest": "^22.0.1",
         "@react-pdf/renderer": "^4.4.0",
@@ -144,6 +145,28 @@
         "@azure/core-util": "^1.6.1",
         "@azure/logger": "^1.0.0",
         "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-amqp": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-amqp/-/core-amqp-4.4.2.tgz",
+      "integrity": "sha512-O+WbJ6WnYsfjEL2rb3PXgS0wHJ33r7sjmYikBOj9ohd6rCV8ld+77mSHoxwuC6d/21vfUbVXn9i6t69ADPr0Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "rhea": "^3.0.0",
+        "rhea-promise": "^3.0.0",
+        "tslib": "^2.6.2",
+        "util": "^0.12.5"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -389,6 +412,47 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@azure/service-bus": {
+      "version": "7.9.5",
+      "resolved": "https://registry.npmjs.org/@azure/service-bus/-/service-bus-7.9.5.tgz",
+      "integrity": "sha512-R5Af+4jtZZII2snLomaddMyElFtTCBRZp2qERPlP8PuISLU87eFYFM7xWzxjNd0yeiyQUBkamx/ZhOC8eWhCHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-amqp": "^4.1.1",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-client": "^1.0.0",
+        "@azure/core-paging": "^1.4.0",
+        "@azure/core-rest-pipeline": "^1.1.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.1.1",
+        "@azure/core-xml": "^1.0.0",
+        "@azure/logger": "^1.0.0",
+        "@types/is-buffer": "^2.0.0",
+        "buffer": "^6.0.0",
+        "is-buffer": "^2.0.3",
+        "jssha": "^3.1.0",
+        "long": "^5.2.0",
+        "process": "^0.11.10",
+        "rhea-promise": "^3.0.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/service-bus/node_modules/@azure/abort-controller": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
+      "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@azure/storage-blob": {
@@ -3992,6 +4056,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/is-buffer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/is-buffer/-/is-buffer-2.0.2.tgz",
+      "integrity": "sha512-G6OXy83Va+xEo8XgqAJYOuvOMxeey9xM5XKkvwJNmN8rVdcB+r15HvHsG86hl86JvU0y1aa7Z2ERkNFYWw9ySg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -5164,7 +5237,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
@@ -5447,6 +5519,30 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -5485,7 +5581,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
@@ -5504,7 +5599,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5518,7 +5612,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -6213,7 +6306,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -6408,7 +6500,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -6590,7 +6681,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6600,7 +6690,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6639,7 +6728,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -7455,7 +7543,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7"
@@ -7537,7 +7624,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7578,7 +7664,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
       "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7608,7 +7693,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -7643,7 +7727,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -7800,7 +7883,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7865,7 +7947,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -7894,7 +7975,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7907,7 +7987,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -7923,7 +8002,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -8078,6 +8156,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -8197,6 +8295,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -8275,6 +8389,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/is-bun-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
@@ -8302,7 +8439,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8427,7 +8563,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
       "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.4",
@@ -8538,7 +8673,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -8633,7 +8767,6 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
@@ -9962,6 +10095,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/jssha": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jssha/-/jssha-3.3.1.tgz",
+      "integrity": "sha512-VCMZj12FCFMQYcFLPRm/0lOBbLi8uM2BhXPTqw3U4YAfs4AZfiApOoBLoN8cQE60Z50m1MYMTQVCfgF/KaCVhQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -10412,6 +10554,12 @@
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -10514,7 +10662,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11581,7 +11728,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11707,6 +11853,15 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -12035,6 +12190,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rhea": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/rhea/-/rhea-3.0.5.tgz",
+      "integrity": "sha512-Ye1gzqH9DoCGMTaSfLfGmDdoderMshyVU5rdFES+D3N1U5PASZcNCKqhWJJUOOj8INtdrIPOfDALrRcoRRL7jw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.3.3"
+      }
+    },
+    "node_modules/rhea-promise": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/rhea-promise/-/rhea-promise-3.0.3.tgz",
+      "integrity": "sha512-a875P5YcMkePSTEWMsnmCQS7Y4v/XvIw7ZoMtJxqtQRZsqSA6PsZxuz4vktyRykPuUgdNsA6F84dS3iEXZoYnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.0.0",
+        "rhea": "^3.0.0",
+        "tslib": "^2.6.0"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
@@ -12139,7 +12314,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -12192,7 +12366,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -13583,6 +13756,19 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -13816,7 +14002,6 @@
       "version": "1.1.20",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
       "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "@azure/app-configuration": "^1.11.0",
     "@azure/identity": "^4.13.1",
     "@azure/keyvault-secrets": "^4.11.2",
+    "@azure/service-bus": "^7.9.5",
     "@azure/storage-blob": "^12.31.0",
     "@octokit/rest": "^22.0.1",
     "@react-pdf/renderer": "^4.4.0",

--- a/src/lib/azure/service-bus.ts
+++ b/src/lib/azure/service-bus.ts
@@ -1,0 +1,175 @@
+import { randomUUID } from "node:crypto";
+import { getServiceBusConnectionString } from "@/lib/azure";
+import {
+  getFlag,
+  type AzureFeatureFlagOptions,
+} from "@/lib/azure/app-config";
+
+export const AZURE_ASYNC_REVIEW_FEATURE_FLAG = "azure.async-review.enabled";
+export const DEFAULT_SERVICE_BUS_QUEUE_NAME = "async-review";
+
+export type ServiceBusJobType =
+  | "async-review"
+  | "document-processing"
+  | "report-generation"
+  | "shadow-telemetry";
+
+export type ServiceBusSafeJsonValue =
+  | boolean
+  | null
+  | number
+  | string
+  | ServiceBusSafeJsonValue[]
+  | { [key: string]: ServiceBusSafeJsonValue };
+
+export type ServiceBusSafePayload = Record<string, ServiceBusSafeJsonValue>;
+
+export type ServiceBusSenderLike = {
+  close(): Promise<void>;
+  sendMessages(message: {
+    applicationProperties?: Record<string, ServiceBusSafeJsonValue>;
+    body: ServiceBusSafePayload;
+    contentType: "application/json";
+    messageId: string;
+  }): Promise<void>;
+};
+
+export type ServiceBusClientLike = {
+  close(): Promise<void>;
+  createSender(queueName: string): ServiceBusSenderLike;
+};
+
+export type ServiceBusClientFactory = (
+  connectionString: string
+) => ServiceBusClientLike | Promise<ServiceBusClientLike>;
+
+export type EnqueueServiceBusJobOptions = AzureFeatureFlagOptions & {
+    jobId?: string;
+    queueName?: string;
+    serviceBusClientFactory?: ServiceBusClientFactory;
+  };
+
+export type EnqueueServiceBusJobResult =
+  | {
+      messageId: string;
+      ok: true;
+      queueName: string;
+    }
+  | {
+      ok: false;
+      reason:
+        | "feature_disabled"
+        | "not_configured"
+        | "send_failed"
+        | "unsafe_payload";
+    };
+
+const UNSAFE_PAYLOAD_KEYS = new Set([
+  "audio",
+  "conversation",
+  "coordinates",
+  "image",
+  "images",
+  "latitude",
+  "longitude",
+  "messages",
+  "owner",
+  "ownername",
+  "pet",
+  "petname",
+  "rawtext",
+  "reportbody",
+  "symptoms",
+  "transcript",
+  "transcripts",
+]);
+
+async function createDefaultServiceBusClient(
+  connectionString: string
+): Promise<ServiceBusClientLike> {
+  const { ServiceBusClient } = await import("@azure/service-bus");
+  return new ServiceBusClient(connectionString) as unknown as ServiceBusClientLike;
+}
+
+function isUnsafeString(value: string): boolean {
+  return value.length > 4096 || /^data:/i.test(value);
+}
+
+function hasUnsafePayload(value: ServiceBusSafeJsonValue): boolean {
+  if (typeof value === "string") {
+    return isUnsafeString(value);
+  }
+
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  if (Array.isArray(value)) {
+    return value.some((item) => hasUnsafePayload(item));
+  }
+
+  return Object.entries(value).some(([key, nestedValue]) => {
+    const normalizedKey = key.replace(/[_-]/g, "").toLowerCase();
+    return (
+      UNSAFE_PAYLOAD_KEYS.has(normalizedKey) || hasUnsafePayload(nestedValue)
+    );
+  });
+}
+
+function buildMessageId(type: ServiceBusJobType, jobId?: string): string {
+  return jobId?.trim() || `${type}-${randomUUID()}`;
+}
+
+export async function enqueueJob(
+  type: ServiceBusJobType,
+  payload: ServiceBusSafePayload,
+  options: EnqueueServiceBusJobOptions = {}
+): Promise<EnqueueServiceBusJobResult> {
+  const enabled = await getFlag(AZURE_ASYNC_REVIEW_FEATURE_FLAG, options);
+  if (!enabled) {
+    return { ok: false, reason: "feature_disabled" };
+  }
+
+  if (hasUnsafePayload(payload)) {
+    return { ok: false, reason: "unsafe_payload" };
+  }
+
+  const connectionString = await getServiceBusConnectionString(options);
+  if (!connectionString) {
+    return { ok: false, reason: "not_configured" };
+  }
+
+  const queueName = options.queueName ?? DEFAULT_SERVICE_BUS_QUEUE_NAME;
+  const messageId = buildMessageId(type, options.jobId);
+  let client: ServiceBusClientLike | null = null;
+  let sender: ServiceBusSenderLike | null = null;
+
+  try {
+    client = options.serviceBusClientFactory
+      ? await options.serviceBusClientFactory(connectionString)
+      : await createDefaultServiceBusClient(connectionString);
+    sender = client.createSender(queueName);
+    await sender.sendMessages({
+      applicationProperties: {
+        jobType: type,
+      },
+      body: payload,
+      contentType: "application/json",
+      messageId,
+    });
+    return {
+      messageId,
+      ok: true,
+      queueName,
+    };
+  } catch {
+    return { ok: false, reason: "send_failed" };
+  } finally {
+    if (sender) {
+      await sender.close().catch(() => undefined);
+    }
+    if (client) {
+      await client.close().catch(() => undefined);
+    }
+  }
+}

--- a/tests/azure-service-bus.test.ts
+++ b/tests/azure-service-bus.test.ts
@@ -1,0 +1,206 @@
+import type { SecretClientLike } from "@/lib/azure";
+import {
+  AZURE_ASYNC_REVIEW_FEATURE_FLAG,
+  DEFAULT_SERVICE_BUS_QUEUE_NAME,
+  enqueueJob,
+  type ServiceBusClientLike,
+} from "@/lib/azure/service-bus";
+
+const CONFIGURED_ENV = {
+  AZURE_TENANT_ID: "test-tenant-id",
+  AZURE_CLIENT_ID: "test-client-id",
+  AZURE_CLIENT_SECRET: "test-client-secret",
+  AZURE_KEY_VAULT_NAME: "test-vault",
+};
+
+const APP_CONFIG_CONNECTION_STRING =
+  "Endpoint=https://pawvital-appconfig.azconfig.io;Id=test;Secret=test";
+const SERVICE_BUS_CONNECTION_STRING =
+  "Endpoint=sb://pawvital-test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=fake";
+
+function makeSecretClient(secrets: Record<string, string>): SecretClientLike {
+  return {
+    getSecret: async (name: string) => ({ value: secrets[name] ?? null }),
+  };
+}
+
+function enabledFlagClient() {
+  return {
+    getConfigurationSetting: async (setting: { key: string }) => {
+      expect(setting.key).toBe(
+        `.appconfig.featureflag/${AZURE_ASYNC_REVIEW_FEATURE_FLAG}`
+      );
+      return {
+        value: JSON.stringify({ enabled: true }),
+      };
+    },
+  };
+}
+
+describe("Azure Service Bus queue producer", () => {
+  it("defaults off when the async-review feature flag is disabled", async () => {
+    const serviceBusClientFactory = jest.fn();
+
+    await expect(
+      enqueueJob(
+        "async-review",
+        { jobId: "case-1" },
+        {
+          appConfigurationClientFactory: () => ({
+            getConfigurationSetting: async () => ({
+              value: JSON.stringify({ enabled: false }),
+            }),
+          }),
+          env: CONFIGURED_ENV,
+          secretClientFactory: () =>
+            makeSecretClient({
+              "appconfig-connection-string": APP_CONFIG_CONNECTION_STRING,
+              "servicebus-connection-string": SERVICE_BUS_CONNECTION_STRING,
+            }),
+          serviceBusClientFactory,
+        }
+      )
+    ).resolves.toEqual({ ok: false, reason: "feature_disabled" });
+
+    expect(serviceBusClientFactory).not.toHaveBeenCalled();
+  });
+
+  it("falls back when the connection string secret is missing", async () => {
+    const serviceBusClientFactory = jest.fn();
+
+    await expect(
+      enqueueJob(
+        "document-processing",
+        { documentId: "doc-1", petId: "pet-1" },
+        {
+          appConfigurationClientFactory: () => enabledFlagClient(),
+          env: CONFIGURED_ENV,
+          secretClientFactory: () =>
+            makeSecretClient({
+              "appconfig-connection-string": APP_CONFIG_CONNECTION_STRING,
+            }),
+          serviceBusClientFactory,
+        }
+      )
+    ).resolves.toEqual({ ok: false, reason: "not_configured" });
+
+    expect(serviceBusClientFactory).not.toHaveBeenCalled();
+  });
+
+  it("sends one sanitized JSON message to the configured Basic queue", async () => {
+    const sendMessages = jest.fn().mockResolvedValue(undefined);
+    const senderClose = jest.fn().mockResolvedValue(undefined);
+    const clientClose = jest.fn().mockResolvedValue(undefined);
+    const createSender = jest.fn().mockReturnValue({
+      close: senderClose,
+      sendMessages,
+    });
+    const serviceBusClientFactory = jest.fn().mockReturnValue({
+      close: clientClose,
+      createSender,
+    } satisfies ServiceBusClientLike);
+
+    const result = await enqueueJob(
+      "async-review",
+      {
+        jobId: "case-1",
+        reportId: "report-1",
+        symptomCheckId: "check-1",
+      },
+      {
+        appConfigurationClientFactory: () => enabledFlagClient(),
+        env: CONFIGURED_ENV,
+        jobId: "case-1",
+        secretClientFactory: () =>
+          makeSecretClient({
+            "appconfig-connection-string": APP_CONFIG_CONNECTION_STRING,
+            "servicebus-connection-string": SERVICE_BUS_CONNECTION_STRING,
+          }),
+        serviceBusClientFactory,
+      }
+    );
+
+    expect(result).toEqual({
+      messageId: "case-1",
+      ok: true,
+      queueName: DEFAULT_SERVICE_BUS_QUEUE_NAME,
+    });
+    expect(serviceBusClientFactory).toHaveBeenCalledWith(
+      SERVICE_BUS_CONNECTION_STRING
+    );
+    expect(createSender).toHaveBeenCalledWith(DEFAULT_SERVICE_BUS_QUEUE_NAME);
+    expect(sendMessages).toHaveBeenCalledWith({
+      applicationProperties: { jobType: "async-review" },
+      body: {
+        jobId: "case-1",
+        reportId: "report-1",
+        symptomCheckId: "check-1",
+      },
+      contentType: "application/json",
+      messageId: "case-1",
+    });
+    expect(senderClose).toHaveBeenCalledTimes(1);
+    expect(clientClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects payloads that contain raw owner data before creating a sender", async () => {
+    const serviceBusClientFactory = jest.fn();
+
+    await expect(
+      enqueueJob(
+        "async-review",
+        {
+          image: "data:image/jpeg;base64,ZmFrZQ==",
+          jobId: "case-1",
+        },
+        {
+          appConfigurationClientFactory: () => enabledFlagClient(),
+          env: CONFIGURED_ENV,
+          secretClientFactory: () =>
+            makeSecretClient({
+              "appconfig-connection-string": APP_CONFIG_CONNECTION_STRING,
+              "servicebus-connection-string": SERVICE_BUS_CONNECTION_STRING,
+            }),
+          serviceBusClientFactory,
+        }
+      )
+    ).resolves.toEqual({ ok: false, reason: "unsafe_payload" });
+
+    expect(serviceBusClientFactory).not.toHaveBeenCalled();
+  });
+
+  it("returns a redacted send failure and still closes clients", async () => {
+    const sendMessages = jest
+      .fn()
+      .mockRejectedValue(new Error("SharedAccessKey=fake leaked error"));
+    const senderClose = jest.fn().mockResolvedValue(undefined);
+    const clientClose = jest.fn().mockResolvedValue(undefined);
+    const serviceBusClientFactory = jest.fn().mockReturnValue({
+      close: clientClose,
+      createSender: () => ({
+        close: senderClose,
+        sendMessages,
+      }),
+    } satisfies ServiceBusClientLike);
+
+    await expect(
+      enqueueJob(
+        "shadow-telemetry",
+        { jobId: "shadow-1", shadowObservationId: "obs-1" },
+        {
+          appConfigurationClientFactory: () => enabledFlagClient(),
+          env: CONFIGURED_ENV,
+          secretClientFactory: () =>
+            makeSecretClient({
+              "appconfig-connection-string": APP_CONFIG_CONNECTION_STRING,
+              "servicebus-connection-string": SERVICE_BUS_CONNECTION_STRING,
+            }),
+          serviceBusClientFactory,
+        }
+      )
+    ).resolves.toEqual({ ok: false, reason: "send_failed" });
+
+    expect(senderClose).toHaveBeenCalledTimes(1);
+    expect(clientClose).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- adds AZ-009 Service Bus queue producer foundation behind `azure.async-review.enabled`
- reads `servicebus-connection-string` from Key Vault through AZ-002 helpers
- rejects unsafe/raw payload keys and data URLs before creating a sender
- keeps this as foundation only; existing async-review full image/session payloads are not redirected into Service Bus

## Verification
- `npx jest --runInBand --runTestsByPath tests/azure-service-bus.test.ts tests/azure-app-config.test.ts tests/azure-foundation.test.ts`
- `npx eslint src/lib/azure/service-bus.ts tests/azure-service-bus.test.ts`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- `npm audit --omit=dev`
- Earlier full branch verification before this cleanup: `npm test -- --runInBand`, `npm run build`, `npm run security:secrets`

## Thermo-review verdict
Pass: no blocking findings; queue behavior is isolated in one Azure boundary and does not move raw clinical/session payloads onto Service Bus.