### PR TITLE
AZ-007: add Translator multilingual boundary

### DIFF
--- a/src/app/(dashboard)/symptom-checker/page.tsx
+++ b/src/app/(dashboard)/symptom-checker/page.tsx
@@ -46,6 +46,7 @@ import type {
   TriageLiveUpdate,
   TriageLiveUpdateStatus,
 } from "@/lib/azure/web-pubsub";
+import { useSymptomTranslator } from "@/hooks/useSymptomTranslator";
 
 // --- Types ---
 
@@ -65,6 +66,8 @@ interface ImageGateWarning {
 interface ChatMessage {
   role: "user" | "assistant";
   content: string;
+  apiContent?: string;
+  ownerLanguage?: string | null;
   type?:
     | "question"
     | "emergency"
@@ -274,6 +277,12 @@ export default function SymptomCheckerPage() {
   const [, setLiveUpdateStatus] = useState<TriageLiveUpdateStatus | null>(null);
   const [, setLiveConnectionState] =
     useState<TriageLiveUpdateConnectionState>("disabled");
+  const {
+    localizeAssistantText,
+    localizeReport,
+    normalizeOwnerMessage,
+    resetOwnerLanguage,
+  } = useSymptomTranslator();
 
   // Hybrid triage session — passed to/from the API each turn
   // Use both state (for re-renders) and ref (to avoid stale closures in async sendMessage)
@@ -464,7 +473,7 @@ export default function SymptomCheckerPage() {
       .filter((m) => m.type !== "image_gate")
       .map((m) => ({
         role: m.role as "user" | "assistant",
-        content: m.content,
+        content: m.apiContent ?? m.content,
       }));
     return extraMessages ? [...base, ...extraMessages] : base;
   };
@@ -509,11 +518,20 @@ export default function SymptomCheckerPage() {
     const imageMetaToSend = imageMetaOverride ?? selectedImageMeta;
     if ((!messageText && !imageToSend) || loading) return;
 
+    const normalizedUserText =
+      appendUserMessage && messageText
+        ? await normalizeOwnerMessage(messageText)
+        : null;
+
     let userMessage: ChatMessage | null = null;
     if (appendUserMessage) {
       const nextUserMessage: ChatMessage = {
         role: "user",
         content: messageText || "Uploaded an image for analysis.",
+        apiContent: normalizedUserText?.translated
+          ? normalizedUserText.apiText
+          : undefined,
+        ownerLanguage: normalizedUserText?.ownerLanguage,
         image: imageToSend || undefined,
         timestamp: new Date(),
       };
@@ -537,7 +555,10 @@ export default function SymptomCheckerPage() {
         appendUserMessage && userMessage
           ? [
               ...baseMessages,
-              { role: "user" as const, content: userMessage.content },
+              {
+                role: "user" as const,
+                content: userMessage.apiContent ?? userMessage.content,
+              },
             ]
           : baseMessages;
 
@@ -587,12 +608,26 @@ export default function SymptomCheckerPage() {
         setConversationState(inferred);
       }
 
+      const assistantText =
+        typeof data.message === "string"
+          ? await localizeAssistantText(data.message)
+          : null;
+      const terminalOwnerText =
+        typeof data.owner_message === "string"
+          ? await localizeAssistantText(data.owner_message)
+          : null;
+      const terminalNextStepText =
+        typeof data.recommended_next_step === "string"
+          ? await localizeAssistantText(data.recommended_next_step)
+          : null;
+
       if (data.type === "emergency") {
         setMessages((prev) => [
           ...prev,
           {
             role: "assistant",
-            content: data.message,
+            content: assistantText?.content ?? data.message,
+            apiContent: assistantText?.apiContent,
             type: "emergency",
             timestamp: new Date(),
           },
@@ -604,7 +639,8 @@ export default function SymptomCheckerPage() {
           ...prev,
           {
             role: "assistant",
-            content: data.message,
+            content: assistantText?.content ?? data.message,
+            apiContent: assistantText?.apiContent,
             type: "image_gate",
             gate: data.gate,
             timestamp: new Date(),
@@ -615,7 +651,8 @@ export default function SymptomCheckerPage() {
           ...prev,
           {
             role: "assistant",
-            content: data.message,
+            content: assistantText?.content ?? data.message,
+            apiContent: assistantText?.apiContent,
             type: "ready",
             timestamp: new Date(),
           },
@@ -634,9 +671,13 @@ export default function SymptomCheckerPage() {
           {
             role: "assistant",
             content:
-              isTerminalOutcome && typeof data.owner_message === "string"
-                ? data.owner_message
-                : data.message,
+              isTerminalOutcome && terminalOwnerText
+                ? terminalOwnerText.content
+                : assistantText?.content ?? data.message,
+            apiContent:
+              isTerminalOutcome && terminalOwnerText
+                ? terminalOwnerText.apiContent
+                : assistantText?.apiContent,
             type: data.type,
             terminalState:
               isTerminalOutcome && typeof data.terminal_state === "string"
@@ -648,12 +689,12 @@ export default function SymptomCheckerPage() {
                 : null,
             ownerMessage:
               isTerminalOutcome && typeof data.owner_message === "string"
-                ? data.owner_message
+                ? terminalOwnerText?.content ?? data.owner_message
                 : null,
             recommendedNextStep:
               isTerminalOutcome &&
               typeof data.recommended_next_step === "string"
-                ? data.recommended_next_step
+                ? terminalNextStepText?.content ?? data.recommended_next_step
                 : null,
             timestamp: new Date(),
           },
@@ -708,7 +749,7 @@ export default function SymptomCheckerPage() {
         (data.type === "cannot_assess" &&
           data.report?.report_mode === "terminal_cannot_assess");
       if (shouldRenderReport && data.report) {
-        setReport(data.report);
+        setReport(await localizeReport(data.report));
         setReportPersistenceMessage(
           typeof data.persistence?.message === "string"
             ? data.persistence.message
@@ -741,6 +782,7 @@ export default function SymptomCheckerPage() {
     setConversationState("idle");
     setAnsweredCount(0);
     setTotalQuestions(0);
+    resetOwnerLanguage();
     setTriageSession(null);
     triageSessionRef.current = null;
     liveSessionIdRef.current = createLiveSessionId();

--- a/src/app/api/azure/translator/route.ts
+++ b/src/app/api/azure/translator/route.ts
@@ -15,6 +15,7 @@ const NO_STORE_HEADERS = {
 
 const MAX_TRANSLATOR_ITEMS = 25;
 const MAX_TRANSLATOR_TEXT_CHARS = 5_000;
+const MAX_TRANSLATOR_REQUEST_CHARS = 150_000;
 const UNSAFE_CONTROL_CHAR_PATTERN = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/;
 
 type TranslatorRequestBody = {
@@ -22,6 +23,12 @@ type TranslatorRequestBody = {
   targetLanguage?: unknown;
   text?: unknown;
   texts?: unknown;
+};
+
+type ValidatedTranslatorRequest = {
+  sourceLanguage: string | null;
+  targetLanguage: string;
+  texts: string[];
 };
 
 function jsonNoStore(body: unknown, status = 200, headers = {}) {
@@ -34,43 +41,115 @@ function jsonNoStore(body: unknown, status = 200, headers = {}) {
   });
 }
 
-function normalizeTexts(body: TranslatorRequestBody): string[] | null {
-  const rawTexts = Array.isArray(body.texts)
-    ? body.texts
-    : typeof body.text === "string"
-      ? [body.text]
-      : null;
-  if (!rawTexts) {
+function hasJsonContentType(request: Request): boolean {
+  const contentType = request.headers.get("content-type")?.toLowerCase() ?? "";
+  return contentType.includes("application/json");
+}
+
+function isRecord(value: unknown): value is TranslatorRequestBody {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function readTranslatorRequestBody(
+  request: Request,
+): Promise<TranslatorRequestBody | null> {
+  if (!hasJsonContentType(request)) {
     return null;
   }
 
-  const texts = rawTexts
-    .map((text) => (typeof text === "string" ? text.trim() : ""))
-    .filter(Boolean);
+  let rawBody: string;
+  try {
+    rawBody = await request.text();
+  } catch {
+    return null;
+  }
+
+  if (!rawBody || rawBody.length > MAX_TRANSLATOR_REQUEST_CHARS) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(rawBody) as unknown;
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function sanitizeTranslatorText(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const text = value.trim().normalize("NFC");
   if (
-    texts.length === 0 ||
-    texts.length > MAX_TRANSLATOR_ITEMS ||
-    texts.some(
-      (text) =>
-        text.length > MAX_TRANSLATOR_TEXT_CHARS ||
-        UNSAFE_CONTROL_CHAR_PATTERN.test(text),
-    )
+    text.length === 0 ||
+    text.length > MAX_TRANSLATOR_TEXT_CHARS ||
+    UNSAFE_CONTROL_CHAR_PATTERN.test(text)
   ) {
     return null;
   }
 
-  return texts;
+  return text;
+}
+
+function normalizeTexts(body: TranslatorRequestBody): string[] | null {
+  const hasText = typeof body.text !== "undefined";
+  const hasTexts = typeof body.texts !== "undefined";
+  if (hasText === hasTexts) {
+    return null;
+  }
+
+  const rawTexts = Array.isArray(body.texts)
+    ? body.texts
+    : hasText
+      ? [body.text]
+      : null;
+  if (
+    !rawTexts ||
+    rawTexts.length === 0 ||
+    rawTexts.length > MAX_TRANSLATOR_ITEMS
+  ) {
+    return null;
+  }
+
+  const texts = rawTexts.map(sanitizeTranslatorText);
+  return texts.every((text): text is string => text !== null) ? texts : null;
 }
 
 function normalizeLanguage(value: unknown): string | null {
   const language = typeof value === "string" ? value.trim() : "";
   return /^[a-z]{2,3}(?:-[a-z0-9]{2,8}){0,2}$/i.test(language)
-    ? language
+    ? language.toLowerCase()
     : null;
 }
 
 function hasLanguageValue(value: unknown): boolean {
   return typeof value === "string" && value.trim().length > 0;
+}
+
+function validateTranslatorRequest(
+  body: TranslatorRequestBody,
+): ValidatedTranslatorRequest | null {
+  const targetLanguage = normalizeLanguage(body.targetLanguage);
+  const sourceLanguage = hasLanguageValue(body.sourceLanguage)
+    ? normalizeLanguage(body.sourceLanguage)
+    : null;
+  const texts = normalizeTexts(body);
+
+  if (
+    !targetLanguage ||
+    (hasLanguageValue(body.sourceLanguage) && !sourceLanguage) ||
+    !texts
+  ) {
+    return null;
+  }
+
+  return {
+    sourceLanguage,
+    targetLanguage,
+    texts,
+  };
 }
 
 export async function POST(request: Request) {
@@ -81,6 +160,7 @@ export async function POST(request: Request) {
     return auth.response;
   }
 
+  // Charge authenticated callers before parsing payloads or touching Azure.
   const rateLimitResult = await checkRateLimit(
     generalApiLimiter,
     getRateLimitId(request, auth.user.id),
@@ -97,26 +177,16 @@ export async function POST(request: Request) {
     );
   }
 
-  let body: TranslatorRequestBody;
-  try {
-    body = (await request.json()) as TranslatorRequestBody;
-  } catch {
+  const body = await readTranslatorRequestBody(request);
+  if (!body) {
     return jsonNoStore(
       { enabled: false, reason: "invalid_request" },
       400,
     );
   }
 
-  const targetLanguage = normalizeLanguage(body.targetLanguage);
-  const sourceLanguage = hasLanguageValue(body.sourceLanguage)
-    ? normalizeLanguage(body.sourceLanguage)
-    : null;
-  const texts = normalizeTexts(body);
-  if (
-    !targetLanguage ||
-    (hasLanguageValue(body.sourceLanguage) && !sourceLanguage) ||
-    !texts
-  ) {
+  const validated = validateTranslatorRequest(body);
+  if (!validated) {
     return jsonNoStore(
       { enabled: false, reason: "invalid_request" },
       400,
@@ -124,9 +194,9 @@ export async function POST(request: Request) {
   }
 
   const result = await translateTexts({
-    sourceLanguage,
-    targetLanguage,
-    texts,
+    sourceLanguage: validated.sourceLanguage,
+    targetLanguage: validated.targetLanguage,
+    texts: validated.texts,
   });
 
   if (!result.enabled && result.reason === "feature_disabled") {

--- a/src/app/api/azure/translator/route.ts
+++ b/src/app/api/azure/translator/route.ts
@@ -17,7 +17,7 @@ const NO_STORE_HEADERS = {
 const MAX_TRANSLATOR_ITEMS = 25;
 const MAX_TRANSLATOR_TEXT_CHARS = 5_000;
 const MAX_TRANSLATOR_BATCH_CHARS = 25_000;
-const MAX_TRANSLATOR_REQUEST_CHARS = 150_000;
+const MAX_TRANSLATOR_REQUEST_CHARS = 32_000;
 const UNSAFE_TEXT_PATTERN =
   /[\u0000-\u001F\u007F-\u009F\u202A-\u202E\u2066-\u2069<>]/;
 const LANGUAGE_TAG_PATTERN = /^[a-z]{2,3}(?:-[a-z0-9]{2,8}){0,2}$/i;
@@ -115,6 +115,7 @@ function sanitizeTranslatorText(value: unknown): string | null {
     return null;
   }
 
+  // Security boundary: only plain owner-visible text reaches Azure Translator.
   const text = value.trim().normalize("NFC");
   if (
     text.length === 0 ||
@@ -177,7 +178,7 @@ export async function POST(request: Request) {
     return auth.response;
   }
 
-  // Charge authenticated callers before parsing payloads or touching Azure.
+  // Dedicated 20/min/user limiter runs before parsing payloads or touching Azure.
   const rateLimitResult = await checkRateLimit(
     translatorApiLimiter,
     getRateLimitId(request, auth.user.id),

--- a/src/app/api/azure/translator/route.ts
+++ b/src/app/api/azure/translator/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import { translateTexts } from "@/lib/azure/translator";
 import { requireAuthenticatedApiUser } from "@/lib/api-auth";
 import {
   checkRateLimit,
-  generalApiLimiter,
   getRateLimitId,
+  translatorApiLimiter,
 } from "@/lib/rate-limit";
 
 export const runtime = "nodejs";
@@ -17,14 +18,9 @@ const MAX_TRANSLATOR_ITEMS = 25;
 const MAX_TRANSLATOR_TEXT_CHARS = 5_000;
 const MAX_TRANSLATOR_BATCH_CHARS = 25_000;
 const MAX_TRANSLATOR_REQUEST_CHARS = 150_000;
-const ALLOWED_TRANSLATOR_REQUEST_KEYS = new Set([
-  "sourceLanguage",
-  "targetLanguage",
-  "text",
-  "texts",
-]);
 const UNSAFE_TEXT_PATTERN =
   /[\u0000-\u001F\u007F-\u009F\u202A-\u202E\u2066-\u2069<>]/;
+const LANGUAGE_TAG_PATTERN = /^[a-z]{2,3}(?:-[a-z0-9]{2,8}){0,2}$/i;
 
 type TranslatorRequestBody = {
   sourceLanguage?: unknown;
@@ -38,6 +34,36 @@ type ValidatedTranslatorRequest = {
   targetLanguage: string;
   texts: string[];
 };
+
+const languageSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(32)
+  .regex(LANGUAGE_TAG_PATTERN)
+  .transform((language) => language.toLowerCase());
+
+const translatorRequestSchema = z
+  .object({
+    sourceLanguage: languageSchema.optional(),
+    targetLanguage: languageSchema,
+    text: z.string().optional(),
+    texts: z.array(z.string()).max(MAX_TRANSLATOR_ITEMS).optional(),
+  })
+  .strict()
+  .superRefine((requestBody, context) => {
+    const hasText = typeof requestBody.text !== "undefined";
+    const hasTexts = typeof requestBody.texts !== "undefined";
+    if (hasText === hasTexts) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Provide exactly one of text or texts.",
+        path: ["text"],
+      });
+    }
+  });
+
+type ParsedTranslatorRequestBody = z.infer<typeof translatorRequestSchema>;
 
 function jsonNoStore(body: unknown, status = 200, headers = {}) {
   return NextResponse.json(body, {
@@ -56,12 +82,6 @@ function hasJsonContentType(request: Request): boolean {
 
 function isRecord(value: unknown): value is TranslatorRequestBody {
   return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function hasOnlyAllowedRequestKeys(value: TranslatorRequestBody): boolean {
-  return Object.keys(value).every((key) =>
-    ALLOWED_TRANSLATOR_REQUEST_KEYS.has(key),
-  );
 }
 
 async function readTranslatorRequestBody(
@@ -113,23 +133,10 @@ function sanitizeTranslatorText(value: unknown): string | null {
   return text;
 }
 
-function normalizeTexts(body: TranslatorRequestBody): string[] | null {
-  const hasText = typeof body.text !== "undefined";
-  const hasTexts = typeof body.texts !== "undefined";
-  if (hasText === hasTexts) {
-    return null;
-  }
-
-  const rawTexts = Array.isArray(body.texts)
-    ? body.texts
-    : hasText
-      ? [body.text]
-      : null;
-  if (
-    !rawTexts ||
-    rawTexts.length === 0 ||
-    rawTexts.length > MAX_TRANSLATOR_ITEMS
-  ) {
+function normalizeTexts(body: ParsedTranslatorRequestBody): string[] | null {
+  const rawTexts =
+    typeof body.text !== "undefined" ? [body.text] : (body.texts ?? []);
+  if (rawTexts.length === 0) {
     return null;
   }
 
@@ -142,45 +149,22 @@ function normalizeTexts(body: TranslatorRequestBody): string[] | null {
   return batchChars <= MAX_TRANSLATOR_BATCH_CHARS ? texts : null;
 }
 
-function normalizeLanguage(value: unknown): string | null {
-  const language = typeof value === "string" ? value.trim() : "";
-  return /^[a-z]{2,3}(?:-[a-z0-9]{2,8}){0,2}$/i.test(language)
-    ? language.toLowerCase()
-    : null;
-}
-
-function hasLanguageValue(value: unknown): boolean {
-  return typeof value === "string" && value.trim().length > 0;
-}
-
 function validateTranslatorRequest(
   body: TranslatorRequestBody,
 ): ValidatedTranslatorRequest | null {
-  if (
-    !hasOnlyAllowedRequestKeys(body) ||
-    (typeof body.sourceLanguage !== "undefined" &&
-      !hasLanguageValue(body.sourceLanguage))
-  ) {
+  const parsed = translatorRequestSchema.safeParse(body);
+  if (!parsed.success) {
     return null;
   }
 
-  const targetLanguage = normalizeLanguage(body.targetLanguage);
-  const sourceLanguage = hasLanguageValue(body.sourceLanguage)
-    ? normalizeLanguage(body.sourceLanguage)
-    : null;
-  const texts = normalizeTexts(body);
-
-  if (
-    !targetLanguage ||
-    (hasLanguageValue(body.sourceLanguage) && !sourceLanguage) ||
-    !texts
-  ) {
+  const texts = normalizeTexts(parsed.data);
+  if (!texts) {
     return null;
   }
 
   return {
-    sourceLanguage,
-    targetLanguage,
+    sourceLanguage: parsed.data.sourceLanguage ?? null,
+    targetLanguage: parsed.data.targetLanguage,
     texts,
   };
 }
@@ -195,7 +179,7 @@ export async function POST(request: Request) {
 
   // Charge authenticated callers before parsing payloads or touching Azure.
   const rateLimitResult = await checkRateLimit(
-    generalApiLimiter,
+    translatorApiLimiter,
     getRateLimitId(request, auth.user.id),
   );
   if (!rateLimitResult.success) {

--- a/src/app/api/azure/translator/route.ts
+++ b/src/app/api/azure/translator/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { translateTexts } from "@/lib/azure/translator";
+import {
+  normalizeTranslatorPlainText,
+  translateTexts,
+} from "@/lib/azure/translator";
 import { requireAuthenticatedApiUser } from "@/lib/api-auth";
 import {
   checkRateLimit,
@@ -15,11 +18,8 @@ const NO_STORE_HEADERS = {
 };
 
 const MAX_TRANSLATOR_ITEMS = 25;
-const MAX_TRANSLATOR_TEXT_CHARS = 5_000;
 const MAX_TRANSLATOR_BATCH_CHARS = 25_000;
 const MAX_TRANSLATOR_REQUEST_CHARS = 32_000;
-const UNSAFE_TEXT_PATTERN =
-  /[\u0000-\u001F\u007F-\u009F\u202A-\u202E\u2066-\u2069<>]/;
 const LANGUAGE_TAG_PATTERN = /^[a-z]{2,3}(?:-[a-z0-9]{2,8}){0,2}$/i;
 
 type TranslatorRequestBody = {
@@ -111,27 +111,8 @@ async function readTranslatorRequestBody(
 }
 
 function sanitizeTranslatorText(value: unknown): string | null {
-  if (typeof value !== "string") {
-    return null;
-  }
-
   // Security boundary: only plain owner-visible text reaches Azure Translator.
-  const text = value.trim().normalize("NFC");
-  if (
-    text.length === 0 ||
-    text.length > MAX_TRANSLATOR_TEXT_CHARS ||
-    UNSAFE_TEXT_PATTERN.test(text)
-  ) {
-    return null;
-  }
-
-  try {
-    encodeURIComponent(text);
-  } catch {
-    return null;
-  }
-
-  return text;
+  return normalizeTranslatorPlainText(value);
 }
 
 function normalizeTexts(body: ParsedTranslatorRequestBody): string[] | null {

--- a/src/app/api/azure/translator/route.ts
+++ b/src/app/api/azure/translator/route.ts
@@ -15,8 +15,16 @@ const NO_STORE_HEADERS = {
 
 const MAX_TRANSLATOR_ITEMS = 25;
 const MAX_TRANSLATOR_TEXT_CHARS = 5_000;
+const MAX_TRANSLATOR_BATCH_CHARS = 25_000;
 const MAX_TRANSLATOR_REQUEST_CHARS = 150_000;
-const UNSAFE_CONTROL_CHAR_PATTERN = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/;
+const ALLOWED_TRANSLATOR_REQUEST_KEYS = new Set([
+  "sourceLanguage",
+  "targetLanguage",
+  "text",
+  "texts",
+]);
+const UNSAFE_TEXT_PATTERN =
+  /[\u0000-\u001F\u007F-\u009F\u202A-\u202E\u2066-\u2069<>]/;
 
 type TranslatorRequestBody = {
   sourceLanguage?: unknown;
@@ -48,6 +56,12 @@ function hasJsonContentType(request: Request): boolean {
 
 function isRecord(value: unknown): value is TranslatorRequestBody {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasOnlyAllowedRequestKeys(value: TranslatorRequestBody): boolean {
+  return Object.keys(value).every((key) =>
+    ALLOWED_TRANSLATOR_REQUEST_KEYS.has(key),
+  );
 }
 
 async function readTranslatorRequestBody(
@@ -85,8 +99,14 @@ function sanitizeTranslatorText(value: unknown): string | null {
   if (
     text.length === 0 ||
     text.length > MAX_TRANSLATOR_TEXT_CHARS ||
-    UNSAFE_CONTROL_CHAR_PATTERN.test(text)
+    UNSAFE_TEXT_PATTERN.test(text)
   ) {
+    return null;
+  }
+
+  try {
+    encodeURIComponent(text);
+  } catch {
     return null;
   }
 
@@ -114,7 +134,12 @@ function normalizeTexts(body: TranslatorRequestBody): string[] | null {
   }
 
   const texts = rawTexts.map(sanitizeTranslatorText);
-  return texts.every((text): text is string => text !== null) ? texts : null;
+  if (!texts.every((text): text is string => text !== null)) {
+    return null;
+  }
+
+  const batchChars = texts.reduce((total, text) => total + text.length, 0);
+  return batchChars <= MAX_TRANSLATOR_BATCH_CHARS ? texts : null;
 }
 
 function normalizeLanguage(value: unknown): string | null {
@@ -131,6 +156,14 @@ function hasLanguageValue(value: unknown): boolean {
 function validateTranslatorRequest(
   body: TranslatorRequestBody,
 ): ValidatedTranslatorRequest | null {
+  if (
+    !hasOnlyAllowedRequestKeys(body) ||
+    (typeof body.sourceLanguage !== "undefined" &&
+      !hasLanguageValue(body.sourceLanguage))
+  ) {
+    return null;
+  }
+
   const targetLanguage = normalizeLanguage(body.targetLanguage);
   const sourceLanguage = hasLanguageValue(body.sourceLanguage)
     ? normalizeLanguage(body.sourceLanguage)
@@ -193,11 +226,19 @@ export async function POST(request: Request) {
     );
   }
 
-  const result = await translateTexts({
-    sourceLanguage: validated.sourceLanguage,
-    targetLanguage: validated.targetLanguage,
-    texts: validated.texts,
-  });
+  let result;
+  try {
+    result = await translateTexts({
+      sourceLanguage: validated.sourceLanguage,
+      targetLanguage: validated.targetLanguage,
+      texts: validated.texts,
+    });
+  } catch {
+    return jsonNoStore(
+      { enabled: false, reason: "translator_unavailable" },
+      503,
+    );
+  }
 
   if (!result.enabled && result.reason === "feature_disabled") {
     return jsonNoStore({ enabled: false, reason: "feature_disabled" });

--- a/src/app/api/azure/translator/route.ts
+++ b/src/app/api/azure/translator/route.ts
@@ -1,0 +1,151 @@
+import { NextResponse } from "next/server";
+import { translateTexts } from "@/lib/azure/translator";
+import { requireAuthenticatedApiUser } from "@/lib/api-auth";
+import {
+  checkRateLimit,
+  generalApiLimiter,
+  getRateLimitId,
+} from "@/lib/rate-limit";
+
+export const runtime = "nodejs";
+
+const NO_STORE_HEADERS = {
+  "Cache-Control": "no-store",
+};
+
+const MAX_TRANSLATOR_ITEMS = 25;
+const MAX_TRANSLATOR_TEXT_CHARS = 5_000;
+const UNSAFE_CONTROL_CHAR_PATTERN = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/;
+
+type TranslatorRequestBody = {
+  sourceLanguage?: unknown;
+  targetLanguage?: unknown;
+  text?: unknown;
+  texts?: unknown;
+};
+
+function jsonNoStore(body: unknown, status = 200, headers = {}) {
+  return NextResponse.json(body, {
+    headers: {
+      ...NO_STORE_HEADERS,
+      ...headers,
+    },
+    status,
+  });
+}
+
+function normalizeTexts(body: TranslatorRequestBody): string[] | null {
+  const rawTexts = Array.isArray(body.texts)
+    ? body.texts
+    : typeof body.text === "string"
+      ? [body.text]
+      : null;
+  if (!rawTexts) {
+    return null;
+  }
+
+  const texts = rawTexts
+    .map((text) => (typeof text === "string" ? text.trim() : ""))
+    .filter(Boolean);
+  if (
+    texts.length === 0 ||
+    texts.length > MAX_TRANSLATOR_ITEMS ||
+    texts.some(
+      (text) =>
+        text.length > MAX_TRANSLATOR_TEXT_CHARS ||
+        UNSAFE_CONTROL_CHAR_PATTERN.test(text),
+    )
+  ) {
+    return null;
+  }
+
+  return texts;
+}
+
+function normalizeLanguage(value: unknown): string | null {
+  const language = typeof value === "string" ? value.trim() : "";
+  return /^[a-z]{2,3}(?:-[a-z0-9]{2,8}){0,2}$/i.test(language)
+    ? language
+    : null;
+}
+
+function hasLanguageValue(value: unknown): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export async function POST(request: Request) {
+  const auth = await requireAuthenticatedApiUser({
+    demoMessage: "Translation is unavailable in demo mode",
+  });
+  if ("response" in auth) {
+    return auth.response;
+  }
+
+  const rateLimitResult = await checkRateLimit(
+    generalApiLimiter,
+    getRateLimitId(request, auth.user.id),
+  );
+  if (!rateLimitResult.success) {
+    return jsonNoStore(
+      { error: "Too many requests. Please slow down." },
+      429,
+      {
+        "Retry-After": String(
+          Math.max(1, Math.ceil((rateLimitResult.reset - Date.now()) / 1000)),
+        ),
+      },
+    );
+  }
+
+  let body: TranslatorRequestBody;
+  try {
+    body = (await request.json()) as TranslatorRequestBody;
+  } catch {
+    return jsonNoStore(
+      { enabled: false, reason: "invalid_request" },
+      400,
+    );
+  }
+
+  const targetLanguage = normalizeLanguage(body.targetLanguage);
+  const sourceLanguage = hasLanguageValue(body.sourceLanguage)
+    ? normalizeLanguage(body.sourceLanguage)
+    : null;
+  const texts = normalizeTexts(body);
+  if (
+    !targetLanguage ||
+    (hasLanguageValue(body.sourceLanguage) && !sourceLanguage) ||
+    !texts
+  ) {
+    return jsonNoStore(
+      { enabled: false, reason: "invalid_request" },
+      400,
+    );
+  }
+
+  const result = await translateTexts({
+    sourceLanguage,
+    targetLanguage,
+    texts,
+  });
+
+  if (!result.enabled && result.reason === "feature_disabled") {
+    return jsonNoStore({ enabled: false, reason: "feature_disabled" });
+  }
+
+  if (!result.enabled) {
+    return jsonNoStore(
+      { enabled: false, reason: "translator_unavailable" },
+      503,
+    );
+  }
+
+  return jsonNoStore({
+    detectedLanguage: result.detectedLanguage,
+    enabled: true,
+    sourceLanguage: result.sourceLanguage,
+    targetLanguage: result.targetLanguage,
+    translated: result.translated,
+    translations: result.translations,
+  });
+}

--- a/src/hooks/useSymptomTranslator.ts
+++ b/src/hooks/useSymptomTranslator.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useRef } from "react";
+import type { SymptomReport } from "@/components/symptom-report";
+import {
+  normalizeOwnerTextForClinical,
+  translateAssistantTextForOwner,
+  translateReportForOwner,
+} from "@/lib/azure/translator-client";
+
+export function useSymptomTranslator() {
+  const ownerLanguageRef = useRef<string | null>(null);
+
+  const normalizeOwnerMessage = async (text: string) => {
+    const normalized = await normalizeOwnerTextForClinical(text);
+    if (normalized.ownerLanguage) {
+      ownerLanguageRef.current = normalized.ownerLanguage;
+    }
+    return normalized;
+  };
+
+  const localizeAssistantText = async (text: string) => {
+    const localized = await translateAssistantTextForOwner(
+      text,
+      ownerLanguageRef.current,
+    );
+    return {
+      apiContent: localized.translated ? localized.apiText : undefined,
+      content: localized.displayText,
+    };
+  };
+
+  const localizeReport = (report: SymptomReport) =>
+    translateReportForOwner(report, ownerLanguageRef.current);
+
+  const resetOwnerLanguage = () => {
+    ownerLanguageRef.current = null;
+  };
+
+  return {
+    localizeAssistantText,
+    localizeReport,
+    normalizeOwnerMessage,
+    resetOwnerLanguage,
+  };
+}

--- a/src/lib/azure/translator-client.ts
+++ b/src/lib/azure/translator-client.ts
@@ -1,0 +1,411 @@
+import type { SymptomReport } from "@/components/symptom-report";
+
+type MaybePromise<T> = T | Promise<T>;
+
+export type TranslatorRouteFetch = (
+  input: string,
+  init: RequestInit,
+) => MaybePromise<Pick<Response, "json" | "ok" | "status">>;
+
+type TranslatorRouteResult =
+  | {
+      enabled: false;
+      reason?: string;
+    }
+  | {
+      detectedLanguage: string | null;
+      enabled: true;
+      sourceLanguage: string | null;
+      targetLanguage: string;
+      translated: boolean;
+      translations: string[];
+    };
+
+export type OwnerTextNormalization = {
+  apiText: string;
+  displayText: string;
+  ownerLanguage: string | null;
+  translated: boolean;
+};
+
+type TranslateClientOptions = {
+  fetchTranslator?: TranslatorRouteFetch;
+};
+
+type ReportStringAssignment = {
+  assign(value: string): void;
+  value: string;
+};
+
+const TRANSLATOR_ROUTE_BATCH_SIZE = 25;
+
+function defaultFetchTranslator(
+  input: string,
+  init: RequestInit,
+): Promise<Pick<Response, "json" | "ok" | "status">> {
+  return fetch(input, init);
+}
+
+function isEnglish(language: string | null | undefined): boolean {
+  return language?.toLowerCase().startsWith("en") ?? false;
+}
+
+function asTargetLanguage(language: string | null | undefined): string | null {
+  const value = language?.trim();
+  return value && !isEnglish(value) ? value : null;
+}
+
+async function requestTranslations(
+  input: {
+    sourceLanguage?: string | null;
+    targetLanguage: string;
+    texts: string[];
+  },
+  options: TranslateClientOptions = {},
+): Promise<TranslatorRouteResult | null> {
+  if (input.texts.length === 0) {
+    return null;
+  }
+
+  try {
+    const fetchTranslator = options.fetchTranslator ?? defaultFetchTranslator;
+    const response = await fetchTranslator("/api/azure/translator", {
+      body: JSON.stringify(input),
+      headers: {
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    });
+    if (!response.ok) {
+      return null;
+    }
+
+    return (await response.json()) as TranslatorRouteResult;
+  } catch {
+    return null;
+  }
+}
+
+async function requestTranslationBatches(
+  input: {
+    sourceLanguage?: string | null;
+    targetLanguage: string;
+    texts: string[];
+  },
+  options: TranslateClientOptions = {},
+): Promise<string[] | null> {
+  const translations: string[] = [];
+
+  for (
+    let start = 0;
+    start < input.texts.length;
+    start += TRANSLATOR_ROUTE_BATCH_SIZE
+  ) {
+    const result = await requestTranslations(
+      {
+        ...input,
+        texts: input.texts.slice(start, start + TRANSLATOR_ROUTE_BATCH_SIZE),
+      },
+      options,
+    );
+    if (!result?.enabled) {
+      return null;
+    }
+    translations.push(...result.translations);
+  }
+
+  return translations;
+}
+
+export async function normalizeOwnerTextForClinical(
+  text: string,
+  options: TranslateClientOptions = {},
+): Promise<OwnerTextNormalization> {
+  const displayText = text.trim();
+  if (!displayText) {
+    return {
+      apiText: displayText,
+      displayText,
+      ownerLanguage: null,
+      translated: false,
+    };
+  }
+
+  const result = await requestTranslations(
+    {
+      targetLanguage: "en",
+      texts: [displayText],
+    },
+    options,
+  );
+  if (!result?.enabled) {
+    return {
+      apiText: displayText,
+      displayText,
+      ownerLanguage: null,
+      translated: false,
+    };
+  }
+
+  const ownerLanguage = asTargetLanguage(result.detectedLanguage);
+  const apiText = result.translations[0]?.trim() || displayText;
+  return {
+    apiText,
+    displayText,
+    ownerLanguage,
+    translated: Boolean(ownerLanguage && apiText !== displayText),
+  };
+}
+
+export async function translateAssistantTextForOwner(
+  text: string,
+  ownerLanguage: string | null,
+  options: TranslateClientOptions = {},
+): Promise<OwnerTextNormalization> {
+  const apiText = text.trim();
+  const targetLanguage = asTargetLanguage(ownerLanguage);
+  if (!apiText || !targetLanguage) {
+    return {
+      apiText,
+      displayText: apiText,
+      ownerLanguage: null,
+      translated: false,
+    };
+  }
+
+  const result = await requestTranslations(
+    {
+      sourceLanguage: "en",
+      targetLanguage,
+      texts: [apiText],
+    },
+    options,
+  );
+  if (!result?.enabled) {
+    return {
+      apiText,
+      displayText: apiText,
+      ownerLanguage: targetLanguage,
+      translated: false,
+    };
+  }
+
+  const displayText = result.translations[0]?.trim() || apiText;
+  return {
+    apiText,
+    displayText,
+    ownerLanguage: targetLanguage,
+    translated: displayText !== apiText,
+  };
+}
+
+function pushAssignment(
+  assignments: ReportStringAssignment[],
+  value: string | undefined | null,
+  assign: (value: string) => void,
+) {
+  const text = value?.trim();
+  if (text) {
+    assignments.push({ assign, value: text });
+  }
+}
+
+function cloneReportForTranslation(report: SymptomReport): SymptomReport {
+  return {
+    ...report,
+    actions: [...report.actions],
+    warning_signs: [...report.warning_signs],
+    limitations: report.limitations ? [...report.limitations] : undefined,
+    vet_questions: report.vet_questions ? [...report.vet_questions] : undefined,
+    differential_diagnoses: report.differential_diagnoses?.map((item) => ({
+      ...item,
+    })),
+    recommended_tests: report.recommended_tests?.map((item) => ({ ...item })),
+    home_care: report.home_care?.map((item) => ({ ...item })),
+    calibrated_confidence: report.calibrated_confidence
+      ? {
+          ...report.calibrated_confidence,
+          adjustments: report.calibrated_confidence.adjustments.map((item) => ({
+            ...item,
+          })),
+        }
+      : report.calibrated_confidence,
+    confidence_calibration: report.confidence_calibration
+      ? {
+          ...report.confidence_calibration,
+          adjustments: report.confidence_calibration.adjustments.map((item) => ({
+            ...item,
+          })),
+        }
+      : report.confidence_calibration,
+    similar_cases: report.similar_cases?.map((item) => ({
+      ...item,
+      keyword_tags: [...item.keyword_tags],
+    })),
+    reference_images: report.reference_images?.map((item) => ({ ...item })),
+    bayesian_differentials: report.bayesian_differentials?.map((item) => ({
+      ...item,
+    })),
+  };
+}
+
+function collectReportAssignments(report: SymptomReport) {
+  const assignments: ReportStringAssignment[] = [];
+
+  pushAssignment(assignments, report.title, (value) => {
+    report.title = value;
+  });
+  pushAssignment(assignments, report.explanation, (value) => {
+    report.explanation = value;
+  });
+  pushAssignment(assignments, report.clinical_notes, (value) => {
+    report.clinical_notes = value;
+  });
+  pushAssignment(assignments, report.vet_handoff_summary, (value) => {
+    report.vet_handoff_summary = value;
+  });
+
+  report.actions.forEach((value, index) => {
+    pushAssignment(assignments, value, (translated) => {
+      report.actions[index] = translated;
+    });
+  });
+  report.warning_signs.forEach((value, index) => {
+    pushAssignment(assignments, value, (translated) => {
+      report.warning_signs[index] = translated;
+    });
+  });
+  report.limitations?.forEach((value, index) => {
+    pushAssignment(assignments, value, (translated) => {
+      report.limitations![index] = translated;
+    });
+  });
+  report.vet_questions?.forEach((value, index) => {
+    pushAssignment(assignments, value, (translated) => {
+      report.vet_questions![index] = translated;
+    });
+  });
+
+  report.differential_diagnoses?.forEach((item) => {
+    pushAssignment(assignments, item.condition, (value) => {
+      item.condition = value;
+    });
+    pushAssignment(assignments, item.description, (value) => {
+      item.description = value;
+    });
+  });
+  report.recommended_tests?.forEach((item) => {
+    pushAssignment(assignments, item.test, (value) => {
+      item.test = value;
+    });
+    pushAssignment(assignments, item.reason, (value) => {
+      item.reason = value;
+    });
+  });
+  report.home_care?.forEach((item) => {
+    pushAssignment(assignments, item.instruction, (value) => {
+      item.instruction = value;
+    });
+    pushAssignment(assignments, item.duration, (value) => {
+      item.duration = value;
+    });
+    pushAssignment(assignments, item.details, (value) => {
+      item.details = value;
+    });
+  });
+  report.calibrated_confidence?.adjustments.forEach((item) => {
+    pushAssignment(assignments, item.factor, (value) => {
+      item.factor = value;
+    });
+    pushAssignment(assignments, item.reason, (value) => {
+      item.reason = value;
+    });
+  });
+  pushAssignment(
+    assignments,
+    report.calibrated_confidence?.recommendation,
+    (value) => {
+      if (report.calibrated_confidence) {
+        report.calibrated_confidence.recommendation = value;
+      }
+    },
+  );
+  report.confidence_calibration?.adjustments.forEach((item) => {
+    pushAssignment(assignments, item.factor, (value) => {
+      item.factor = value;
+    });
+    pushAssignment(assignments, item.reason, (value) => {
+      item.reason = value;
+    });
+  });
+  pushAssignment(
+    assignments,
+    report.confidence_calibration?.recommendation,
+    (value) => {
+      if (report.confidence_calibration) {
+        report.confidence_calibration.recommendation = value;
+      }
+    },
+  );
+  report.similar_cases?.forEach((item) => {
+    pushAssignment(assignments, item.heading, (value) => {
+      item.heading = value;
+    });
+    pushAssignment(assignments, item.body, (value) => {
+      item.body = value;
+    });
+    item.keyword_tags.forEach((tag, index) => {
+      pushAssignment(assignments, tag, (value) => {
+        item.keyword_tags[index] = value;
+      });
+    });
+  });
+  report.reference_images?.forEach((item) => {
+    pushAssignment(assignments, item.condition_label, (value) => {
+      item.condition_label = value;
+    });
+    pushAssignment(assignments, item.caption, (value) => {
+      item.caption = value;
+    });
+  });
+  report.bayesian_differentials?.forEach((item) => {
+    pushAssignment(assignments, item.condition, (value) => {
+      item.condition = value;
+    });
+    pushAssignment(assignments, item.confidence, (value) => {
+      item.confidence = value;
+    });
+  });
+
+  return assignments;
+}
+
+export async function translateReportForOwner(
+  report: SymptomReport,
+  ownerLanguage: string | null,
+  options: TranslateClientOptions = {},
+): Promise<SymptomReport> {
+  const targetLanguage = asTargetLanguage(ownerLanguage);
+  if (!targetLanguage) {
+    return report;
+  }
+
+  const translatedReport = cloneReportForTranslation(report);
+  const assignments = collectReportAssignments(translatedReport);
+  const translations = await requestTranslationBatches(
+    {
+      sourceLanguage: "en",
+      targetLanguage,
+      texts: assignments.map((assignment) => assignment.value),
+    },
+    options,
+  );
+  if (!translations) {
+    return report;
+  }
+
+  translations.forEach((value, index) => {
+    assignments[index]?.assign(value);
+  });
+  return translatedReport;
+}

--- a/src/lib/azure/translator.ts
+++ b/src/lib/azure/translator.ts
@@ -1,0 +1,301 @@
+import { randomUUID } from "node:crypto";
+import {
+  getTranslatorClient,
+  type AzureClientOptions,
+  type AzureRegionalKeyEndpointClient,
+} from "@/lib/azure";
+import { getFlag, type AzureFeatureFlagOptions } from "@/lib/azure/app-config";
+import { trackEvent, type TrackOptions } from "@/lib/azure/telemetry";
+
+export const AZURE_TRANSLATOR_FEATURE_FLAG = "azure.translator.enabled";
+
+const TRANSLATOR_API_VERSION = "3.0";
+const MAX_TRANSLATOR_ITEMS = 25;
+const MAX_TRANSLATOR_TEXT_CHARS = 5_000;
+
+type MaybePromise<T> = T | Promise<T>;
+
+export type AzureTranslatorFetchResponse = Pick<
+  Response,
+  "json" | "ok" | "status"
+>;
+
+export type AzureTranslatorFetch = (
+  input: string | URL,
+  init: RequestInit,
+) => MaybePromise<AzureTranslatorFetchResponse>;
+
+export type TranslateTextInput = {
+  sourceLanguage?: string | null;
+  targetLanguage: string;
+  texts: string[];
+};
+
+export type TranslateTextResult =
+  | {
+      enabled: false;
+      reason:
+        | "feature_disabled"
+        | "invalid_request"
+        | "not_configured"
+        | "translator_unavailable";
+    }
+  | {
+      detectedLanguage: string | null;
+      enabled: true;
+      sourceLanguage: string | null;
+      targetLanguage: string;
+      translated: boolean;
+      translations: string[];
+    };
+
+export type TranslateTextOptions = AzureClientOptions &
+  AzureFeatureFlagOptions &
+  TrackOptions & {
+    fetchTranslator?: AzureTranslatorFetch;
+  };
+
+type TranslatorResponsePayload = Array<{
+  detectedLanguage?: {
+    language?: unknown;
+    score?: unknown;
+  };
+  translations?: Array<{
+    text?: unknown;
+    to?: unknown;
+  }>;
+}>;
+
+function defaultFetchTranslator(
+  input: string | URL,
+  init: RequestInit,
+): Promise<AzureTranslatorFetchResponse> {
+  return fetch(input, init);
+}
+
+function normalizeLanguage(value: string | null | undefined): string | null {
+  const normalized = value?.trim();
+  if (!normalized) {
+    return null;
+  }
+
+  return /^[a-z]{2,3}(?:-[a-z0-9]{2,8}){0,2}$/i.test(normalized)
+    ? normalized
+    : null;
+}
+
+function normalizeTexts(texts: string[]): string[] | null {
+  if (!Array.isArray(texts) || texts.length === 0) {
+    return null;
+  }
+
+  const normalized = texts
+    .map((text) => (typeof text === "string" ? text.trim() : ""))
+    .filter(Boolean);
+
+  if (
+    normalized.length === 0 ||
+    normalized.length > MAX_TRANSLATOR_ITEMS ||
+    normalized.some((text) => text.length > MAX_TRANSLATOR_TEXT_CHARS)
+  ) {
+    return null;
+  }
+
+  return normalized;
+}
+
+function joinAzurePath(endpoint: string, path: string): string {
+  return `${endpoint.replace(/\/+$/, "")}${path}`;
+}
+
+function buildTranslateUrl(
+  client: AzureRegionalKeyEndpointClient,
+  input: TranslateTextInput,
+): URL | null {
+  const targetLanguage = normalizeLanguage(input.targetLanguage);
+  if (!targetLanguage) {
+    return null;
+  }
+
+  let path = "/translate";
+  try {
+    const endpoint = new URL(client.endpoint);
+    if (
+      endpoint.hostname.endsWith(".cognitiveservices.azure.com") &&
+      !endpoint.pathname.includes("/translator/text/v3.0")
+    ) {
+      path = "/translator/text/v3.0/translate";
+    } else if (endpoint.pathname.includes("/translator/text/v3.0")) {
+      path = endpoint.pathname.endsWith("/translate") ? "" : "/translate";
+    }
+  } catch {
+    return null;
+  }
+
+  const url = new URL(joinAzurePath(client.endpoint, path));
+  url.searchParams.set("api-version", TRANSLATOR_API_VERSION);
+  url.searchParams.set("to", targetLanguage);
+
+  const sourceLanguage = normalizeLanguage(input.sourceLanguage);
+  if (sourceLanguage) {
+    url.searchParams.set("from", sourceLanguage);
+  }
+
+  return url;
+}
+
+function buildHeaders(client: AzureRegionalKeyEndpointClient) {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "Ocp-Apim-Subscription-Key": client.key,
+    "X-ClientTraceId": randomUUID(),
+  };
+
+  if (client.region && client.region.toLowerCase() !== "global") {
+    headers["Ocp-Apim-Subscription-Region"] = client.region;
+  }
+
+  return headers;
+}
+
+function parseTranslations(
+  payload: TranslatorResponsePayload,
+): Pick<
+  Extract<TranslateTextResult, { enabled: true }>,
+  "detectedLanguage" | "translations"
+> | null {
+  if (!Array.isArray(payload) || payload.length === 0) {
+    return null;
+  }
+
+  const translations = payload.map((entry) => {
+    const text = entry.translations?.[0]?.text;
+    return typeof text === "string" ? text.trim() : "";
+  });
+  if (translations.some((text) => !text)) {
+    return null;
+  }
+
+  const detectedLanguage = payload
+    .map((entry) => entry.detectedLanguage?.language)
+    .find((language): language is string => typeof language === "string");
+
+  return {
+    detectedLanguage: detectedLanguage ?? null,
+    translations,
+  };
+}
+
+async function trackTranslatorOutcome(
+  input: {
+    characterCount?: number;
+    errorCode?: string;
+    statusCode: number;
+  },
+  options: TranslateTextOptions,
+) {
+  await trackEvent(
+    {
+      measurements:
+        typeof input.characterCount === "number"
+          ? { characterCount: input.characterCount }
+          : undefined,
+      name: "azure.service.called",
+      properties: {
+        azureService: "translator",
+        demoMode: false,
+        errorCode: input.errorCode,
+        statusCode: input.statusCode,
+      },
+    },
+    options,
+  );
+}
+
+export async function translateTexts(
+  input: TranslateTextInput,
+  options: TranslateTextOptions = {},
+): Promise<TranslateTextResult> {
+  const targetLanguage = normalizeLanguage(input.targetLanguage);
+  const sourceLanguage = normalizeLanguage(input.sourceLanguage);
+  const texts = normalizeTexts(input.texts);
+  if (!targetLanguage || !texts) {
+    return { enabled: false, reason: "invalid_request" };
+  }
+
+  const enabled = await getFlag(AZURE_TRANSLATOR_FEATURE_FLAG, options);
+  if (!enabled) {
+    return { enabled: false, reason: "feature_disabled" };
+  }
+
+  const client = await getTranslatorClient(options);
+  if (!client) {
+    await trackTranslatorOutcome(
+      { errorCode: "not_configured", statusCode: 503 },
+      options,
+    );
+    return { enabled: false, reason: "not_configured" };
+  }
+
+  const url = buildTranslateUrl(client, {
+    sourceLanguage,
+    targetLanguage,
+    texts,
+  });
+  if (!url) {
+    return { enabled: false, reason: "invalid_request" };
+  }
+
+  try {
+    const fetchTranslator = options.fetchTranslator ?? defaultFetchTranslator;
+    const response = await fetchTranslator(url, {
+      body: JSON.stringify(texts.map((text) => ({ Text: text }))),
+      headers: buildHeaders(client),
+      method: "POST",
+    });
+
+    if (!response.ok) {
+      await trackTranslatorOutcome(
+        { errorCode: "translator_unavailable", statusCode: response.status },
+        options,
+      );
+      return { enabled: false, reason: "translator_unavailable" };
+    }
+
+    const parsed = parseTranslations(
+      (await response.json()) as TranslatorResponsePayload,
+    );
+    if (!parsed) {
+      await trackTranslatorOutcome(
+        { errorCode: "translator_unavailable", statusCode: 502 },
+        options,
+      );
+      return { enabled: false, reason: "translator_unavailable" };
+    }
+
+    await trackTranslatorOutcome(
+      {
+        characterCount: texts.join("").length,
+        statusCode: 200,
+      },
+      options,
+    );
+
+    return {
+      detectedLanguage: parsed.detectedLanguage,
+      enabled: true,
+      sourceLanguage,
+      targetLanguage,
+      translated:
+        Boolean(parsed.detectedLanguage && parsed.detectedLanguage !== targetLanguage) ||
+        parsed.translations.some((text, index) => text !== texts[index]),
+      translations: parsed.translations,
+    };
+  } catch {
+    await trackTranslatorOutcome(
+      { errorCode: "translator_unavailable", statusCode: 503 },
+      options,
+    );
+    return { enabled: false, reason: "translator_unavailable" };
+  }
+}

--- a/src/lib/azure/translator.ts
+++ b/src/lib/azure/translator.ts
@@ -12,6 +12,8 @@ export const AZURE_TRANSLATOR_FEATURE_FLAG = "azure.translator.enabled";
 const TRANSLATOR_API_VERSION = "3.0";
 const MAX_TRANSLATOR_ITEMS = 25;
 const MAX_TRANSLATOR_TEXT_CHARS = 5_000;
+const UNSAFE_TRANSLATOR_TEXT_PATTERN =
+  /[\u0000-\u001F\u007F-\u009F\u202A-\u202E\u2066-\u2069<>]/;
 
 type MaybePromise<T> = T | Promise<T>;
 
@@ -66,6 +68,8 @@ type TranslatorResponsePayload = Array<{
   }>;
 }>;
 
+type TranslatorErrorCode = "not_configured" | "translator_unavailable";
+
 function defaultFetchTranslator(
   input: string | URL,
   init: RequestInit,
@@ -84,19 +88,39 @@ function normalizeLanguage(value: string | null | undefined): string | null {
     : null;
 }
 
+export function normalizeTranslatorPlainText(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const text = value.trim().normalize("NFC");
+  if (
+    text.length === 0 ||
+    text.length > MAX_TRANSLATOR_TEXT_CHARS ||
+    UNSAFE_TRANSLATOR_TEXT_PATTERN.test(text)
+  ) {
+    return null;
+  }
+
+  try {
+    encodeURIComponent(text);
+  } catch {
+    return null;
+  }
+
+  return text;
+}
+
 function normalizeTexts(texts: string[]): string[] | null {
   if (!Array.isArray(texts) || texts.length === 0) {
     return null;
   }
 
-  const normalized = texts
-    .map((text) => (typeof text === "string" ? text.trim() : ""))
-    .filter(Boolean);
-
+  const normalized = texts.map(normalizeTranslatorPlainText);
   if (
     normalized.length === 0 ||
     normalized.length > MAX_TRANSLATOR_ITEMS ||
-    normalized.some((text) => text.length > MAX_TRANSLATOR_TEXT_CHARS)
+    !normalized.every((text): text is string => text !== null)
   ) {
     return null;
   }
@@ -170,9 +194,9 @@ function parseTranslations(
 
   const translations = payload.map((entry) => {
     const text = entry.translations?.[0]?.text;
-    return typeof text === "string" ? text.trim() : "";
+    return normalizeTranslatorPlainText(text);
   });
-  if (translations.some((text) => !text)) {
+  if (!translations.every((text): text is string => text !== null)) {
     return null;
   }
 
@@ -189,7 +213,7 @@ function parseTranslations(
 async function trackTranslatorOutcome(
   input: {
     characterCount?: number;
-    errorCode?: string;
+    errorCode?: TranslatorErrorCode;
     statusCode: number;
   },
   options: TranslateTextOptions,

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -112,6 +112,23 @@ export const generalApiLimiter = registerFallbackConfig(
   }
 );
 
+/** Azure Translator: 20 requests per minute per user */
+export const translatorApiLimiter = registerFallbackConfig(
+  redis
+    ? new Ratelimit({
+        redis,
+        limiter: Ratelimit.slidingWindow(20, "1 m"),
+        prefix: "rl:azure-translator",
+        analytics: true,
+      })
+    : null,
+  {
+    limit: 20,
+    scope: "azure-translator",
+    windowMs: DEFAULT_FALLBACK_WINDOW_MS,
+  }
+);
+
 // ── Helper ──────────────────────────────────────────────────────────────────
 
 export type RateLimitResult =

--- a/tests/azure-translator-client.test.ts
+++ b/tests/azure-translator-client.test.ts
@@ -1,0 +1,151 @@
+import {
+  normalizeOwnerTextForClinical,
+  translateAssistantTextForOwner,
+  translateReportForOwner,
+  type TranslatorRouteFetch,
+} from "@/lib/azure/translator-client";
+import type { SymptomReport } from "@/components/symptom-report";
+
+function makeFetch(payload: unknown): jest.MockedFunction<TranslatorRouteFetch> {
+  return jest.fn(async () => ({
+    json: async () => payload,
+    ok: true,
+    status: 200,
+  }));
+}
+
+function makeReport(): SymptomReport {
+  return {
+    actions: ["Offer small amounts of water."],
+    differential_diagnoses: [
+      {
+        condition: "Dietary indiscretion",
+        description: "Recent food change can cause vomiting.",
+        likelihood: "high",
+      },
+    ],
+    explanation: "Buddy has vomiting without collapse.",
+    recommendation: "vet_24h",
+    severity: "medium",
+    title: "Vomiting with moderate dehydration risk",
+    vet_handoff_summary: "Buddy vomited three times today.",
+    warning_signs: ["Repeated vomiting"],
+  };
+}
+
+describe("azure translator client boundary", () => {
+  it("normalizes non-English owner text for the clinical engine", async () => {
+    const fetchTranslator = makeFetch({
+      detectedLanguage: "es",
+      enabled: true,
+      sourceLanguage: null,
+      targetLanguage: "en",
+      translated: true,
+      translations: ["Buddy is vomiting"],
+    });
+
+    await expect(
+      normalizeOwnerTextForClinical("Buddy está vomitando", {
+        fetchTranslator,
+      }),
+    ).resolves.toEqual({
+      apiText: "Buddy is vomiting",
+      displayText: "Buddy está vomitando",
+      ownerLanguage: "es",
+      translated: true,
+    });
+
+    expect(fetchTranslator).toHaveBeenCalledWith(
+      "/api/azure/translator",
+      expect.objectContaining({
+        body: JSON.stringify({
+          targetLanguage: "en",
+          texts: ["Buddy está vomitando"],
+        }),
+        method: "POST",
+      }),
+    );
+  });
+
+  it("falls back to the original text when translation is disabled", async () => {
+    const fetchTranslator = makeFetch({
+      enabled: false,
+      reason: "feature_disabled",
+    });
+
+    await expect(
+      normalizeOwnerTextForClinical("Buddy está vomitando", {
+        fetchTranslator,
+      }),
+    ).resolves.toEqual({
+      apiText: "Buddy está vomitando",
+      displayText: "Buddy está vomitando",
+      ownerLanguage: null,
+      translated: false,
+    });
+  });
+
+  it("translates assistant display text while preserving English API text", async () => {
+    const fetchTranslator = makeFetch({
+      detectedLanguage: null,
+      enabled: true,
+      sourceLanguage: "en",
+      targetLanguage: "es",
+      translated: true,
+      translations: ["¿Cuántas veces ha vomitado Buddy?"],
+    });
+
+    await expect(
+      translateAssistantTextForOwner("How many times has Buddy vomited?", "es", {
+        fetchTranslator,
+      }),
+    ).resolves.toEqual({
+      apiText: "How many times has Buddy vomited?",
+      displayText: "¿Cuántas veces ha vomitado Buddy?",
+      ownerLanguage: "es",
+      translated: true,
+    });
+  });
+
+  it("translates report owner-facing fields without mutating clinical enums", async () => {
+    const fetchTranslator = makeFetch({
+      detectedLanguage: null,
+      enabled: true,
+      sourceLanguage: "en",
+      targetLanguage: "es",
+      translated: true,
+      translations: [
+        "Riesgo moderado de deshidratación por vómitos",
+        "Buddy tiene vómitos sin colapso.",
+        "Buddy vomitó tres veces hoy.",
+        "Ofrezca pequeñas cantidades de agua.",
+        "Vómitos repetidos",
+        "Indiscreción alimentaria",
+        "Un cambio reciente de comida puede causar vómitos.",
+      ],
+    });
+    const report = makeReport();
+
+    const translated = await translateReportForOwner(report, "es", {
+      fetchTranslator,
+    });
+
+    expect(translated).toMatchObject({
+      actions: ["Ofrezca pequeñas cantidades de agua."],
+      differential_diagnoses: [
+        {
+          condition: "Indiscreción alimentaria",
+          description: "Un cambio reciente de comida puede causar vómitos.",
+          likelihood: "high",
+        },
+      ],
+      explanation: "Buddy tiene vómitos sin colapso.",
+      recommendation: "vet_24h",
+      severity: "medium",
+      title: "Riesgo moderado de deshidratación por vómitos",
+      vet_handoff_summary: "Buddy vomitó tres veces hoy.",
+      warning_signs: ["Vómitos repetidos"],
+    });
+    expect(report.title).toBe("Vomiting with moderate dehydration risk");
+  });
+});

--- a/tests/azure-translator-route.test.ts
+++ b/tests/azure-translator-route.test.ts
@@ -159,12 +159,68 @@ describe("POST /api/azure/translator", () => {
     expect(mockTranslateTexts).not.toHaveBeenCalled();
   });
 
+  it("rejects invalid source language types before calling Azure", async () => {
+    const { POST } = await import("@/app/api/azure/translator/route");
+    const response = await POST(
+      makeRequest({
+        sourceLanguage: 123,
+        targetLanguage: "en",
+        text: "Mi perro vomita",
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload).toEqual({
+      enabled: false,
+      reason: "invalid_request",
+    });
+    expect(mockTranslateTexts).not.toHaveBeenCalled();
+  });
+
+  it("rejects unexpected body keys before calling Azure", async () => {
+    const { POST } = await import("@/app/api/azure/translator/route");
+    const response = await POST(
+      makeRequest({
+        targetLanguage: "en",
+        text: "Mi perro vomita",
+        unsafeHtml: "<script>alert(1)</script>",
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload).toEqual({
+      enabled: false,
+      reason: "invalid_request",
+    });
+    expect(mockTranslateTexts).not.toHaveBeenCalled();
+  });
+
   it("rejects unsafe control characters before calling Azure", async () => {
     const { POST } = await import("@/app/api/azure/translator/route");
     const response = await POST(
       makeRequest({
         targetLanguage: "en",
         text: "Mi perro\u0000vomita",
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload).toEqual({
+      enabled: false,
+      reason: "invalid_request",
+    });
+    expect(mockTranslateTexts).not.toHaveBeenCalled();
+  });
+
+  it("rejects markup delimiters before calling Azure", async () => {
+    const { POST } = await import("@/app/api/azure/translator/route");
+    const response = await POST(
+      makeRequest({
+        targetLanguage: "en",
+        text: "Mi perro <script>vomita</script>",
       }),
     );
     const payload = await response.json();
@@ -266,6 +322,22 @@ describe("POST /api/azure/translator", () => {
       enabled: false,
       reason: "not_configured",
     });
+
+    const { POST } = await import("@/app/api/azure/translator/route");
+    const response = await POST(
+      makeRequest({ targetLanguage: "en", text: "Mi perro vomita" }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(payload).toEqual({
+      enabled: false,
+      reason: "translator_unavailable",
+    });
+  });
+
+  it("fails closed when the Translator helper throws", async () => {
+    mockTranslateTexts.mockRejectedValueOnce(new Error("upstream failed"));
 
     const { POST } = await import("@/app/api/azure/translator/route");
     const response = await POST(

--- a/tests/azure-translator-route.test.ts
+++ b/tests/azure-translator-route.test.ts
@@ -4,6 +4,7 @@ const mockRequireAuthenticatedApiUser = jest.fn();
 const mockCheckRateLimit = jest.fn();
 const mockGetRateLimitId = jest.fn();
 const mockTranslateTexts = jest.fn();
+const mockTranslatorApiLimiter = { scope: "azure-translator" };
 
 jest.mock("@/lib/api-auth", () => ({
   requireAuthenticatedApiUser: (...args: unknown[]) =>
@@ -11,7 +12,7 @@ jest.mock("@/lib/api-auth", () => ({
 }));
 
 jest.mock("@/lib/rate-limit", () => ({
-  generalApiLimiter: {},
+  translatorApiLimiter: mockTranslatorApiLimiter,
   checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
   getRateLimitId: (...args: unknown[]) => mockGetRateLimitId(...args),
 }));
@@ -92,6 +93,10 @@ describe("POST /api/azure/translator", () => {
 
     expect(response.status).toBe(429);
     expect(payload.error).toContain("Too many requests");
+    expect(mockCheckRateLimit).toHaveBeenCalledWith(
+      mockTranslatorApiLimiter,
+      "user:user-1",
+    );
     expect(mockGetRateLimitId).toHaveBeenCalledWith(expect.any(Request), "user-1");
     expect(mockTranslateTexts).not.toHaveBeenCalled();
   });

--- a/tests/azure-translator-route.test.ts
+++ b/tests/azure-translator-route.test.ts
@@ -28,6 +28,14 @@ function makeRequest(body: unknown = {}) {
   });
 }
 
+function makeRawRequest(body: string, headers: HeadersInit = {}) {
+  return new Request("http://localhost/api/azure/translator", {
+    body,
+    headers,
+    method: "POST",
+  });
+}
+
 describe("POST /api/azure/translator", () => {
   beforeEach(() => {
     jest.resetModules();
@@ -102,6 +110,36 @@ describe("POST /api/azure/translator", () => {
     expect(mockTranslateTexts).not.toHaveBeenCalled();
   });
 
+  it("rejects non-json requests before calling Azure", async () => {
+    const { POST } = await import("@/app/api/azure/translator/route");
+    const response = await POST(
+      makeRawRequest("targetLanguage=en&text=hola", {
+        "Content-Type": "application/x-www-form-urlencoded",
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload).toEqual({
+      enabled: false,
+      reason: "invalid_request",
+    });
+    expect(mockTranslateTexts).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-object json payloads before calling Azure", async () => {
+    const { POST } = await import("@/app/api/azure/translator/route");
+    const response = await POST(makeRequest(["Mi perro vomita"]));
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload).toEqual({
+      enabled: false,
+      reason: "invalid_request",
+    });
+    expect(mockTranslateTexts).not.toHaveBeenCalled();
+  });
+
   it("rejects invalid language tags before calling Azure", async () => {
     const { POST } = await import("@/app/api/azure/translator/route");
     const response = await POST(
@@ -127,6 +165,43 @@ describe("POST /api/azure/translator", () => {
       makeRequest({
         targetLanguage: "en",
         text: "Mi perro\u0000vomita",
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload).toEqual({
+      enabled: false,
+      reason: "invalid_request",
+    });
+    expect(mockTranslateTexts).not.toHaveBeenCalled();
+  });
+
+  it("rejects ambiguous single and batch text payloads", async () => {
+    const { POST } = await import("@/app/api/azure/translator/route");
+    const response = await POST(
+      makeRequest({
+        targetLanguage: "en",
+        text: "Mi perro vomita",
+        texts: ["No come"],
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload).toEqual({
+      enabled: false,
+      reason: "invalid_request",
+    });
+    expect(mockTranslateTexts).not.toHaveBeenCalled();
+  });
+
+  it("rejects mixed invalid text batches before calling Azure", async () => {
+    const { POST } = await import("@/app/api/azure/translator/route");
+    const response = await POST(
+      makeRequest({
+        targetLanguage: "en",
+        texts: ["Mi perro vomita", 42],
       }),
     );
     const payload = await response.json();

--- a/tests/azure-translator-route.test.ts
+++ b/tests/azure-translator-route.test.ts
@@ -275,6 +275,24 @@ describe("POST /api/azure/translator", () => {
     expect(mockTranslateTexts).not.toHaveBeenCalled();
   });
 
+  it("rejects oversized request bodies before calling Azure", async () => {
+    const { POST } = await import("@/app/api/azure/translator/route");
+    const response = await POST(
+      makeRequest({
+        targetLanguage: "en",
+        text: "a".repeat(33_000),
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload).toEqual({
+      enabled: false,
+      reason: "invalid_request",
+    });
+    expect(mockTranslateTexts).not.toHaveBeenCalled();
+  });
+
   it("passes validated text batches into the Translator helper", async () => {
     const { POST } = await import("@/app/api/azure/translator/route");
     const response = await POST(

--- a/tests/azure-translator-route.test.ts
+++ b/tests/azure-translator-route.test.ts
@@ -17,9 +17,13 @@ jest.mock("@/lib/rate-limit", () => ({
   getRateLimitId: (...args: unknown[]) => mockGetRateLimitId(...args),
 }));
 
-jest.mock("@/lib/azure/translator", () => ({
-  translateTexts: (...args: unknown[]) => mockTranslateTexts(...args),
-}));
+jest.mock("@/lib/azure/translator", () => {
+  const actual = jest.requireActual("@/lib/azure/translator");
+  return {
+    ...actual,
+    translateTexts: (...args: unknown[]) => mockTranslateTexts(...args),
+  };
+});
 
 function makeRequest(body: unknown = {}) {
   return new Request("http://localhost/api/azure/translator", {

--- a/tests/azure-translator-route.test.ts
+++ b/tests/azure-translator-route.test.ts
@@ -1,0 +1,207 @@
+import { NextResponse } from "next/server";
+
+const mockRequireAuthenticatedApiUser = jest.fn();
+const mockCheckRateLimit = jest.fn();
+const mockGetRateLimitId = jest.fn();
+const mockTranslateTexts = jest.fn();
+
+jest.mock("@/lib/api-auth", () => ({
+  requireAuthenticatedApiUser: (...args: unknown[]) =>
+    mockRequireAuthenticatedApiUser(...args),
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  generalApiLimiter: {},
+  checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
+  getRateLimitId: (...args: unknown[]) => mockGetRateLimitId(...args),
+}));
+
+jest.mock("@/lib/azure/translator", () => ({
+  translateTexts: (...args: unknown[]) => mockTranslateTexts(...args),
+}));
+
+function makeRequest(body: unknown = {}) {
+  return new Request("http://localhost/api/azure/translator", {
+    body: typeof body === "string" ? body : JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+    method: "POST",
+  });
+}
+
+describe("POST /api/azure/translator", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    mockRequireAuthenticatedApiUser.mockResolvedValue({
+      supabase: {},
+      user: { id: "user-1" },
+    });
+    mockCheckRateLimit.mockResolvedValue({
+      reset: Date.now() + 30_000,
+      success: true,
+    });
+    mockGetRateLimitId.mockReturnValue("user:user-1");
+    mockTranslateTexts.mockResolvedValue({
+      detectedLanguage: "es",
+      enabled: true,
+      sourceLanguage: null,
+      targetLanguage: "en",
+      translated: true,
+      translations: ["Buddy is vomiting"],
+    });
+  });
+
+  it("requires an authenticated user", async () => {
+    mockRequireAuthenticatedApiUser.mockResolvedValueOnce({
+      response: NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 },
+      ),
+    });
+
+    const { POST } = await import("@/app/api/azure/translator/route");
+    const response = await POST(
+      makeRequest({ targetLanguage: "en", text: "Mi perro vomita" }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(payload.error).toBe("Authentication required");
+    expect(mockTranslateTexts).not.toHaveBeenCalled();
+  });
+
+  it("rate limits requests by authenticated user id", async () => {
+    mockCheckRateLimit.mockResolvedValueOnce({
+      reset: Date.now() + 10_000,
+      success: false,
+    });
+
+    const { POST } = await import("@/app/api/azure/translator/route");
+    const response = await POST(
+      makeRequest({ targetLanguage: "en", text: "Mi perro vomita" }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(429);
+    expect(payload.error).toContain("Too many requests");
+    expect(mockGetRateLimitId).toHaveBeenCalledWith(expect.any(Request), "user-1");
+    expect(mockTranslateTexts).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed payloads before calling Azure", async () => {
+    const { POST } = await import("@/app/api/azure/translator/route");
+    const response = await POST(makeRequest("{"));
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload).toEqual({
+      enabled: false,
+      reason: "invalid_request",
+    });
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(mockTranslateTexts).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid language tags before calling Azure", async () => {
+    const { POST } = await import("@/app/api/azure/translator/route");
+    const response = await POST(
+      makeRequest({
+        sourceLanguage: "es<script>",
+        targetLanguage: "en",
+        text: "Mi perro vomita",
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload).toEqual({
+      enabled: false,
+      reason: "invalid_request",
+    });
+    expect(mockTranslateTexts).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsafe control characters before calling Azure", async () => {
+    const { POST } = await import("@/app/api/azure/translator/route");
+    const response = await POST(
+      makeRequest({
+        targetLanguage: "en",
+        text: "Mi perro\u0000vomita",
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload).toEqual({
+      enabled: false,
+      reason: "invalid_request",
+    });
+    expect(mockTranslateTexts).not.toHaveBeenCalled();
+  });
+
+  it("passes validated text batches into the Translator helper", async () => {
+    const { POST } = await import("@/app/api/azure/translator/route");
+    const response = await POST(
+      makeRequest({
+        sourceLanguage: "es",
+        targetLanguage: "en",
+        texts: [" Mi perro vomita ", "No come"],
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(payload).toEqual({
+      detectedLanguage: "es",
+      enabled: true,
+      sourceLanguage: null,
+      targetLanguage: "en",
+      translated: true,
+      translations: ["Buddy is vomiting"],
+    });
+    expect(mockTranslateTexts).toHaveBeenCalledWith({
+      sourceLanguage: "es",
+      targetLanguage: "en",
+      texts: ["Mi perro vomita", "No come"],
+    });
+  });
+
+  it("returns disabled when the feature flag is off", async () => {
+    mockTranslateTexts.mockResolvedValueOnce({
+      enabled: false,
+      reason: "feature_disabled",
+    });
+
+    const { POST } = await import("@/app/api/azure/translator/route");
+    const response = await POST(
+      makeRequest({ targetLanguage: "en", text: "Mi perro vomita" }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual({
+      enabled: false,
+      reason: "feature_disabled",
+    });
+  });
+
+  it("fails closed without leaking service errors", async () => {
+    mockTranslateTexts.mockResolvedValueOnce({
+      enabled: false,
+      reason: "not_configured",
+    });
+
+    const { POST } = await import("@/app/api/azure/translator/route");
+    const response = await POST(
+      makeRequest({ targetLanguage: "en", text: "Mi perro vomita" }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(payload).toEqual({
+      enabled: false,
+      reason: "translator_unavailable",
+    });
+  });
+});

--- a/tests/azure-translator.test.ts
+++ b/tests/azure-translator.test.ts
@@ -1,0 +1,187 @@
+import {
+  AZURE_TRANSLATOR_FEATURE_FLAG,
+  translateTexts,
+  type AzureTranslatorFetch,
+} from "@/lib/azure/translator";
+import type { SecretClientLike } from "@/lib/azure";
+
+const CONFIGURED_ENV = {
+  AZURE_TENANT_ID: "test-tenant-id",
+  AZURE_CLIENT_ID: "test-client-id",
+  AZURE_CLIENT_SECRET: "test-client-secret",
+  AZURE_KEY_VAULT_NAME: "test-vault",
+};
+
+const APP_CONFIG_CONNECTION_STRING =
+  "Endpoint=https://pawvital-appconfig.azconfig.io;Id=test;Secret=test";
+
+function makeSecretClient(secrets: Record<string, string>): SecretClientLike {
+  return {
+    getSecret: async (name: string) => ({ value: secrets[name] ?? null }),
+  };
+}
+
+function enabledFlagClient() {
+  return {
+    getConfigurationSetting: async (setting: { key: string }) => {
+      expect(setting.key).toBe(`.appconfig.featureflag/${AZURE_TRANSLATOR_FEATURE_FLAG}`);
+      return {
+        value: JSON.stringify({ enabled: true }),
+      };
+    },
+  };
+}
+
+function disabledFlagClient() {
+  return {
+    getConfigurationSetting: async () => ({
+      value: JSON.stringify({ enabled: false }),
+    }),
+  };
+}
+
+describe("azure translator helper", () => {
+  it("defaults off when the App Config translator flag is disabled", async () => {
+    const fetchTranslator = jest.fn();
+
+    await expect(
+      translateTexts(
+        { targetLanguage: "en", texts: ["Mi perro vomita"] },
+        {
+          appConfigurationClientFactory: () => disabledFlagClient(),
+          env: CONFIGURED_ENV,
+          fetchTranslator,
+          secretClientFactory: () =>
+            makeSecretClient({
+              "appconfig-connection-string": APP_CONFIG_CONNECTION_STRING,
+            }),
+        },
+      ),
+    ).resolves.toEqual({
+      enabled: false,
+      reason: "feature_disabled",
+    });
+
+    expect(fetchTranslator).not.toHaveBeenCalled();
+  });
+
+  it("translates owner text through the global Translator endpoint without exposing the key", async () => {
+    const fetchTranslator: jest.MockedFunction<AzureTranslatorFetch> = jest.fn(
+      async () => ({
+        json: async () => [
+          {
+            detectedLanguage: { language: "es", score: 1 },
+            translations: [{ text: "Buddy is vomiting", to: "en" }],
+          },
+        ],
+        ok: true,
+        status: 200,
+      }),
+    );
+
+    const result = await translateTexts(
+      { targetLanguage: "en", texts: ["Buddy está vomitando"] },
+      {
+        appConfigurationClientFactory: () => enabledFlagClient(),
+        env: CONFIGURED_ENV,
+        fetchTranslator,
+        secretClientFactory: () =>
+          makeSecretClient({
+            "appconfig-connection-string": APP_CONFIG_CONNECTION_STRING,
+            "translator-endpoint": "https://api.cognitive.microsofttranslator.com/",
+            "translator-key": "translator-secret",
+            "translator-region": "global",
+          }),
+      },
+    );
+
+    expect(result).toEqual({
+      detectedLanguage: "es",
+      enabled: true,
+      sourceLanguage: null,
+      targetLanguage: "en",
+      translated: true,
+      translations: ["Buddy is vomiting"],
+    });
+
+    const [url, init] = fetchTranslator.mock.calls[0];
+    expect(String(url)).toContain("https://api.cognitive.microsofttranslator.com/translate");
+    expect(String(url)).toContain("api-version=3.0");
+    expect(String(url)).toContain("to=en");
+    expect(init.headers).toMatchObject({
+      "Content-Type": "application/json",
+      "Ocp-Apim-Subscription-Key": "translator-secret",
+      "X-ClientTraceId": expect.any(String),
+    });
+    expect(init.headers).not.toHaveProperty("Ocp-Apim-Subscription-Region");
+    expect(JSON.stringify(result)).not.toContain("translator-secret");
+  });
+
+  it("uses the custom cognitive-services Translator path and regional header when configured", async () => {
+    const fetchTranslator: jest.MockedFunction<AzureTranslatorFetch> = jest.fn(
+      async () => ({
+        json: async () => [
+          {
+            translations: [{ text: "¿Cuántas veces ha vomitado?", to: "es" }],
+          },
+        ],
+        ok: true,
+        status: 200,
+      }),
+    );
+
+    await translateTexts(
+      {
+        sourceLanguage: "en",
+        targetLanguage: "es",
+        texts: ["How many times has he vomited?"],
+      },
+      {
+        appConfigurationClientFactory: () => enabledFlagClient(),
+        env: CONFIGURED_ENV,
+        fetchTranslator,
+        secretClientFactory: () =>
+          makeSecretClient({
+            "appconfig-connection-string": APP_CONFIG_CONNECTION_STRING,
+            "translator-endpoint": "https://pawvital-translator.cognitiveservices.azure.com/",
+            "translator-key": "translator-secret",
+            "translator-region": "centralus",
+          }),
+      },
+    );
+
+    const [url, init] = fetchTranslator.mock.calls[0];
+    expect(String(url)).toContain(
+      "https://pawvital-translator.cognitiveservices.azure.com/translator/text/v3.0/translate",
+    );
+    expect(String(url)).toContain("from=en");
+    expect(String(url)).toContain("to=es");
+    expect(init.headers).toMatchObject({
+      "Ocp-Apim-Subscription-Region": "centralus",
+    });
+  });
+
+  it("fails closed when Translator secrets are missing", async () => {
+    const fetchTranslator = jest.fn();
+
+    await expect(
+      translateTexts(
+        { targetLanguage: "en", texts: ["Mi perro vomita"] },
+        {
+          appConfigurationClientFactory: () => enabledFlagClient(),
+          env: CONFIGURED_ENV,
+          fetchTranslator,
+          secretClientFactory: () =>
+            makeSecretClient({
+              "appconfig-connection-string": APP_CONFIG_CONNECTION_STRING,
+            }),
+        },
+      ),
+    ).resolves.toEqual({
+      enabled: false,
+      reason: "not_configured",
+    });
+
+    expect(fetchTranslator).not.toHaveBeenCalled();
+  });
+});

--- a/tests/azure-translator.test.ts
+++ b/tests/azure-translator.test.ts
@@ -1,5 +1,6 @@
 import {
   AZURE_TRANSLATOR_FEATURE_FLAG,
+  normalizeTranslatorPlainText,
   translateTexts,
   type AzureTranslatorFetch,
 } from "@/lib/azure/translator";
@@ -41,6 +42,17 @@ function disabledFlagClient() {
 }
 
 describe("azure translator helper", () => {
+  it("normalizes only plain Translator text at the shared boundary", () => {
+    expect(normalizeTranslatorPlainText("  Mi perro vomita  ")).toBe(
+      "Mi perro vomita",
+    );
+    expect(
+      normalizeTranslatorPlainText("Mi perro <script>vomita</script>"),
+    ).toBeNull();
+    expect(normalizeTranslatorPlainText("Mi perro\u0000vomita")).toBeNull();
+    expect(normalizeTranslatorPlainText("a".repeat(5_001))).toBeNull();
+  });
+
   it("defaults off when the App Config translator flag is disabled", async () => {
     const fetchTranslator = jest.fn();
 
@@ -115,6 +127,59 @@ describe("azure translator helper", () => {
     });
     expect(init.headers).not.toHaveProperty("Ocp-Apim-Subscription-Region");
     expect(JSON.stringify(result)).not.toContain("translator-secret");
+  });
+
+  it("rejects unsafe direct caller text before fetching Translator", async () => {
+    const fetchTranslator = jest.fn();
+
+    await expect(
+      translateTexts(
+        { targetLanguage: "en", texts: ["Mi perro <script>vomita</script>"] },
+        { fetchTranslator },
+      ),
+    ).resolves.toEqual({
+      enabled: false,
+      reason: "invalid_request",
+    });
+
+    expect(fetchTranslator).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsafe Translator responses before returning owner-visible text", async () => {
+    const fetchTranslator: jest.MockedFunction<AzureTranslatorFetch> = jest.fn(
+      async () => ({
+        json: async () => [
+          {
+            detectedLanguage: { language: "es", score: 1 },
+            translations: [{ text: "<script>alert(1)</script>", to: "en" }],
+          },
+        ],
+        ok: true,
+        status: 200,
+      }),
+    );
+
+    const result = await translateTexts(
+      { targetLanguage: "en", texts: ["Mi perro vomita"] },
+      {
+        appConfigurationClientFactory: () => enabledFlagClient(),
+        env: CONFIGURED_ENV,
+        fetchTranslator,
+        secretClientFactory: () =>
+          makeSecretClient({
+            "appconfig-connection-string": APP_CONFIG_CONNECTION_STRING,
+            "translator-endpoint": "https://api.cognitive.microsofttranslator.com/",
+            "translator-key": "translator-secret",
+            "translator-region": "global",
+          }),
+      },
+    );
+
+    expect(result).toEqual({
+      enabled: false,
+      reason: "translator_unavailable",
+    });
+    expect(JSON.stringify(result)).not.toContain("<script>");
   });
 
   it("uses the custom cognitive-services Translator path and regional header when configured", async () => {

--- a/tests/symptom-checker.tester-onboarding.test.ts
+++ b/tests/symptom-checker.tester-onboarding.test.ts
@@ -145,4 +145,88 @@ describe("tester onboarding boundaries on the symptom checker", () => {
       screen.getByRole("button", { name: "Generate Emergency Vet Summary" })
     ).toBeTruthy();
   });
+
+  it("keeps multilingual owner display separate from English clinical API messages", async () => {
+    const fetchMock = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (input === "/api/azure/translator") {
+        const body = JSON.parse(String(init?.body ?? "{}")) as {
+          targetLanguage?: string;
+          texts?: string[];
+        };
+        return {
+          json: async () =>
+            body.targetLanguage === "en"
+              ? {
+                  detectedLanguage: "es",
+                  enabled: true,
+                  sourceLanguage: null,
+                  targetLanguage: "en",
+                  translated: true,
+                  translations: ["Buddy is vomiting"],
+                }
+              : {
+                  detectedLanguage: null,
+                  enabled: true,
+                  sourceLanguage: "en",
+                  targetLanguage: "es",
+                  translated: true,
+                  translations: ["¿Cuántas veces ha vomitado Buddy?"],
+                },
+          ok: true,
+          status: 200,
+        };
+      }
+
+      return {
+        json: async () => ({
+          conversationState: "asking",
+          message: "How many times has Buddy vomited?",
+          session: {
+            answered_questions: {},
+            unresolved_question_ids: ["vomiting_frequency"],
+          },
+          type: "question",
+        }),
+        ok: true,
+        status: 200,
+      };
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    renderSymptomChecker();
+    acknowledgeBoundary();
+
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "Describe what's going on with Buddy or attach a photo..."
+      ),
+      {
+        target: { value: "Buddy está vomitando" },
+      }
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/ai/symptom-chat",
+        expect.any(Object)
+      );
+    });
+
+    const symptomCall = fetchMock.mock.calls.find(
+      ([input]) => input === "/api/ai/symptom-chat"
+    );
+    const symptomPayload = JSON.parse(
+      String((symptomCall?.[1] as RequestInit | undefined)?.body ?? "{}")
+    ) as { messages: Array<{ content: string; role: string }> };
+
+    expect(symptomPayload.messages.at(-1)).toEqual({
+      content: "Buddy is vomiting",
+      role: "user",
+    });
+    expect(await screen.findByText("Buddy está vomitando")).toBeTruthy();
+    expect(
+      await screen.findByText("¿Cuántas veces ha vomitado Buddy?")
+    ).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary
- Adds Azure Translator as a gated multilingual boundary for symptom input and owner-facing output.
- Clinical state remains English-normalized; deterministic clinical files are not modified.
- Browser code calls only the authenticated server route; Translator keys stay server-side through Key Vault.

## Security and abuse controls
- `/api/azure/translator` requires authenticated API users.
- Dedicated `translatorApiLimiter`: 20 requests/min/user, stricter than the general API limiter.
- Request body must be JSON object, max 32k chars, strict Zod schema, no unknown keys.
- Exactly one of `text` or `texts`; max 25 items, max 5k chars/item, max 25k aggregate chars.
- Text is trimmed, NFC-normalized, and rejected for unsafe control chars, bidi controls, markup delimiters, or malformed Unicode before any Azure call.
- Unexpected Translator helper failures fail closed as `translator_unavailable`; no upstream error details are returned.

## Verification
- Focused Translator/UI boundary tests pass.
- Typecheck, lint, secret scan, audit, and build pass locally.