### PR TITLE
AZ-011: add Web PubSub live update scaffold

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@azure/keyvault-secrets": "^4.11.2",
         "@azure/service-bus": "^7.9.5",
         "@azure/storage-blob": "^12.31.0",
+        "@azure/web-pubsub": "^1.2.0",
         "@octokit/rest": "^22.0.1",
         "@react-pdf/renderer": "^4.4.0",
         "@stripe/stripe-js": "^8.11.0",
@@ -498,6 +499,25 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/web-pubsub": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/web-pubsub/-/web-pubsub-1.2.0.tgz",
+      "integrity": "sha512-s5QYFVpXy6fl8ppv1vTKyTTgOaKo7fx9WGxORRQukKKZovuOXA1jQ3zdRIBF9DjwggZCqwxHzbzZrUJYmelK2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-paging": "^1.6.2",
+        "@azure/core-rest-pipeline": "^1.19.0",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/logger": "^1.1.4",
+        "jsonwebtoken": "^9.0.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "@azure/keyvault-secrets": "^4.11.2",
     "@azure/service-bus": "^7.9.5",
     "@azure/storage-blob": "^12.31.0",
+    "@azure/web-pubsub": "^1.2.0",
     "@octokit/rest": "^22.0.1",
     "@react-pdf/renderer": "^4.4.0",
     "@stripe/stripe-js": "^8.11.0",

--- a/src/app/(dashboard)/symptom-checker/page.tsx
+++ b/src/app/(dashboard)/symptom-checker/page.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useState, useRef, useEffect, useSyncExternalStore } from "react";
+import {
+  useCallback,
+  useState,
+  useRef,
+  useEffect,
+  useSyncExternalStore,
+} from "react";
 import {
   Stethoscope,
   AlertTriangle,
@@ -32,6 +38,14 @@ import { useAppStore } from "@/store/app-store";
 import { FullReport, type SymptomReport } from "@/components/symptom-report";
 import { SpeechInputButton } from "@/components/symptom-checker/speech-input-button";
 import { VetRecordIntakeButton } from "@/components/symptom-checker/vet-record-intake-button";
+import {
+  useWebPubSubLiveUpdates,
+  type TriageLiveUpdateConnectionState,
+} from "@/components/symptom-checker/use-webpubsub-live-updates";
+import type {
+  TriageLiveUpdate,
+  TriageLiveUpdateStatus,
+} from "@/lib/azure/web-pubsub";
 
 // --- Types ---
 
@@ -95,6 +109,14 @@ const quickSymptoms = [
 
 function subscribeToHydration() {
   return () => {};
+}
+
+function createLiveSessionId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+
+  return `triage-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
 
 // --- Components ---
@@ -248,6 +270,10 @@ export default function SymptomCheckerPage() {
   const reportRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const liveSessionIdRef = useRef<string>(createLiveSessionId());
+  const [, setLiveUpdateStatus] = useState<TriageLiveUpdateStatus | null>(null);
+  const [, setLiveConnectionState] =
+    useState<TriageLiveUpdateConnectionState>("disabled");
 
   // Hybrid triage session — passed to/from the API each turn
   // Use both state (for re-renders) and ref (to avoid stale closures in async sendMessage)
@@ -283,6 +309,24 @@ export default function SymptomCheckerPage() {
       block: "start",
     });
   }, [report]);
+
+  const handleLiveUpdate = useCallback((update: TriageLiveUpdate) => {
+    setLiveUpdateStatus(update.status);
+  }, []);
+
+  const handleLiveConnectionState = useCallback(
+    (state: TriageLiveUpdateConnectionState) => {
+      setLiveConnectionState(state);
+    },
+    [],
+  );
+
+  useWebPubSubLiveUpdates({
+    enabled: sessionStarted,
+    onConnectionState: handleLiveConnectionState,
+    onUpdate: handleLiveUpdate,
+    sessionId: liveSessionIdRef.current,
+  });
 
   const clearComposerImage = () => {
     setSelectedImage(null);
@@ -505,6 +549,7 @@ export default function SymptomCheckerPage() {
           pet,
           action: "chat",
           session: triageSessionRef.current,
+          liveSessionId: liveSessionIdRef.current,
           image: imageToSend, // Send the base64 image here
           imageMeta: imageMetaToSend,
           gateOverride,
@@ -653,6 +698,7 @@ export default function SymptomCheckerPage() {
           pet,
           action: "generate_report",
           session: overrideSession || triageSessionRef.current,
+          liveSessionId: liveSessionIdRef.current,
         }),
       });
 
@@ -697,6 +743,9 @@ export default function SymptomCheckerPage() {
     setTotalQuestions(0);
     setTriageSession(null);
     triageSessionRef.current = null;
+    liveSessionIdRef.current = createLiveSessionId();
+    setLiveUpdateStatus(null);
+    setLiveConnectionState("disabled");
     setInput("");
     clearComposerImage();
     clearPendingGateImage();

--- a/src/app/(dashboard)/symptom-checker/page.tsx
+++ b/src/app/(dashboard)/symptom-checker/page.tsx
@@ -322,7 +322,7 @@ export default function SymptomCheckerPage() {
   );
 
   useWebPubSubLiveUpdates({
-    enabled: sessionStarted,
+    enabled: Boolean(pet),
     onConnectionState: handleLiveConnectionState,
     onUpdate: handleLiveUpdate,
     sessionId: liveSessionIdRef.current,

--- a/src/app/api/ai/symptom-chat/route.ts
+++ b/src/app/api/ai/symptom-chat/route.ts
@@ -166,7 +166,7 @@ import {
   trackRouteTelemetry,
 } from "@/lib/azure/telemetry";
 import {
-  normalizeWebPubSubSafeId,
+  normalizeWebPubSubSessionId,
   publishTriageLiveUpdate,
   type TriageLiveUpdateStatus,
 } from "@/lib/azure/web-pubsub";
@@ -1149,7 +1149,7 @@ export async function POST(request: Request) {
     // can be emitted with a trusted userId. Falls back to null in demo mode or
     // when the session cookie is absent — emissions are skipped in that case.
     const verifiedUserId = await resolveVerifiedUserId();
-    const safeLiveSessionId = normalizeWebPubSubSafeId(liveSessionId);
+    const safeLiveSessionId = normalizeWebPubSubSessionId(liveSessionId);
     if (verifiedUserId && safeLiveSessionId) {
       liveUpdateTarget = {
         action,

--- a/src/app/api/ai/symptom-chat/route.ts
+++ b/src/app/api/ai/symptom-chat/route.ts
@@ -1077,6 +1077,16 @@ export async function POST(request: Request) {
   let statusCode = 200;
   let errorCode: string | undefined;
   let liveUpdateTarget: LiveUpdateTarget | null = null;
+  let liveUpdateChain: Promise<void> = Promise.resolve();
+  const queueTriageLiveUpdate = (
+    target: LiveUpdateTarget | null,
+    status: TriageLiveUpdateStatus
+  ): Promise<void> => {
+    liveUpdateChain = liveUpdateChain.then(() =>
+      scheduleTriageLiveUpdate(target, status)
+    );
+    return liveUpdateChain;
+  };
 
   try {
     // ── Rate limiting ─────────────────────────────────────────────────────
@@ -1156,7 +1166,7 @@ export async function POST(request: Request) {
         sessionId: safeLiveSessionId,
         userId: verifiedUserId,
       };
-      void scheduleTriageLiveUpdate(liveUpdateTarget, "processing");
+      void queueTriageLiveUpdate(liveUpdateTarget, "processing");
     }
 
     if (action === "generate_report") {
@@ -2585,7 +2595,7 @@ export async function POST(request: Request) {
     if (errorCode) {
       void trackException(errorCode, { routeName: ROUTE_NAME });
     }
-    await scheduleTriageLiveUpdate(
+    await queueTriageLiveUpdate(
       liveUpdateTarget,
       errorCode
         ? "failed"

--- a/src/app/api/ai/symptom-chat/route.ts
+++ b/src/app/api/ai/symptom-chat/route.ts
@@ -208,20 +208,24 @@ type LiveUpdateTarget = {
   userId: string;
 };
 
-function scheduleTriageLiveUpdate(
+async function scheduleTriageLiveUpdate(
   target: LiveUpdateTarget | null,
   status: TriageLiveUpdateStatus
-) {
+): Promise<void> {
   if (!target) {
     return;
   }
 
-  void publishTriageLiveUpdate({
-    action: target.action,
-    sessionId: target.sessionId,
-    status,
-    userId: target.userId,
-  });
+  try {
+    await publishTriageLiveUpdate({
+      action: target.action,
+      sessionId: target.sessionId,
+      status,
+      userId: target.userId,
+    });
+  } catch {
+    // Live status is an enhancement; never let Web PubSub affect triage output.
+  }
 }
 
 async function persistChatShadowTelemetrySnapshot({
@@ -1152,7 +1156,7 @@ export async function POST(request: Request) {
         sessionId: safeLiveSessionId,
         userId: verifiedUserId,
       };
-      scheduleTriageLiveUpdate(liveUpdateTarget, "processing");
+      void scheduleTriageLiveUpdate(liveUpdateTarget, "processing");
     }
 
     if (action === "generate_report") {
@@ -2581,7 +2585,7 @@ export async function POST(request: Request) {
     if (errorCode) {
       void trackException(errorCode, { routeName: ROUTE_NAME });
     }
-    scheduleTriageLiveUpdate(
+    await scheduleTriageLiveUpdate(
       liveUpdateTarget,
       errorCode
         ? "failed"

--- a/src/app/api/ai/symptom-chat/route.ts
+++ b/src/app/api/ai/symptom-chat/route.ts
@@ -166,6 +166,7 @@ import {
   trackRouteTelemetry,
 } from "@/lib/azure/telemetry";
 import {
+  normalizeWebPubSubSafeId,
   publishTriageLiveUpdate,
   type TriageLiveUpdateStatus,
 } from "@/lib/azure/web-pubsub";
@@ -1144,10 +1145,11 @@ export async function POST(request: Request) {
     // can be emitted with a trusted userId. Falls back to null in demo mode or
     // when the session cookie is absent — emissions are skipped in that case.
     const verifiedUserId = await resolveVerifiedUserId();
-    if (verifiedUserId && liveSessionId) {
+    const safeLiveSessionId = normalizeWebPubSubSafeId(liveSessionId);
+    if (verifiedUserId && safeLiveSessionId) {
       liveUpdateTarget = {
         action,
-        sessionId: liveSessionId,
+        sessionId: safeLiveSessionId,
         userId: verifiedUserId,
       };
       scheduleTriageLiveUpdate(liveUpdateTarget, "processing");

--- a/src/app/api/ai/symptom-chat/route.ts
+++ b/src/app/api/ai/symptom-chat/route.ts
@@ -165,6 +165,10 @@ import {
   trackException,
   trackRouteTelemetry,
 } from "@/lib/azure/telemetry";
+import {
+  publishTriageLiveUpdate,
+  type TriageLiveUpdateStatus,
+} from "@/lib/azure/web-pubsub";
 
 // =============================================================================
 // HYBRID STATE MACHINE API — 4-Model NVIDIA NIM Pipeline
@@ -191,9 +195,32 @@ interface RequestBody {
   pet: PetProfile;
   action: "chat" | "generate_report";
   session?: TriageSession;
+  liveSessionId?: string;
   image?: string; // base64 image data (with or without data URL prefix)
   imageMeta?: ImageMeta;
   gateOverride?: boolean;
+}
+
+type LiveUpdateTarget = {
+  action: "chat" | "generate_report";
+  sessionId: string;
+  userId: string;
+};
+
+function scheduleTriageLiveUpdate(
+  target: LiveUpdateTarget | null,
+  status: TriageLiveUpdateStatus
+) {
+  if (!target) {
+    return;
+  }
+
+  void publishTriageLiveUpdate({
+    action: target.action,
+    sessionId: target.sessionId,
+    status,
+    userId: target.userId,
+  });
 }
 
 async function persistChatShadowTelemetrySnapshot({
@@ -1044,6 +1071,7 @@ export async function POST(request: Request) {
   const startedAtMs = Date.now();
   let statusCode = 200;
   let errorCode: string | undefined;
+  let liveUpdateTarget: LiveUpdateTarget | null = null;
 
   try {
     // ── Rate limiting ─────────────────────────────────────────────────────
@@ -1072,6 +1100,7 @@ export async function POST(request: Request) {
       pet,
       action,
       session: clientSession,
+      liveSessionId,
       image,
       imageMeta,
       gateOverride,
@@ -1115,6 +1144,14 @@ export async function POST(request: Request) {
     // can be emitted with a trusted userId. Falls back to null in demo mode or
     // when the session cookie is absent — emissions are skipped in that case.
     const verifiedUserId = await resolveVerifiedUserId();
+    if (verifiedUserId && liveSessionId) {
+      liveUpdateTarget = {
+        action,
+        sessionId: liveSessionId,
+        userId: verifiedUserId,
+      };
+      scheduleTriageLiveUpdate(liveUpdateTarget, "processing");
+    }
 
     if (action === "generate_report") {
       const reportBlockingCriticalInfo = findReportBlockingCriticalInfo(session);
@@ -2542,5 +2579,13 @@ export async function POST(request: Request) {
     if (errorCode) {
       void trackException(errorCode, { routeName: ROUTE_NAME });
     }
+    scheduleTriageLiveUpdate(
+      liveUpdateTarget,
+      errorCode
+        ? "failed"
+        : liveUpdateTarget?.action === "generate_report"
+          ? "report_ready"
+          : "response_ready"
+    );
   }
 }

--- a/src/app/api/azure/webpubsub/negotiate/route.ts
+++ b/src/app/api/azure/webpubsub/negotiate/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from "next/server";
+import { negotiateTriageLiveUpdates } from "@/lib/azure/web-pubsub";
+import { requireAuthenticatedApiUser } from "@/lib/api-auth";
+import {
+  checkRateLimit,
+  generalApiLimiter,
+  getRateLimitId,
+} from "@/lib/rate-limit";
+
+export const runtime = "nodejs";
+
+const NO_STORE_HEADERS = {
+  "Cache-Control": "no-store",
+};
+
+function jsonNoStore(body: unknown, status = 200, headers = {}) {
+  return NextResponse.json(body, {
+    headers: {
+      ...NO_STORE_HEADERS,
+      ...headers,
+    },
+    status,
+  });
+}
+
+export async function GET(request: Request) {
+  const auth = await requireAuthenticatedApiUser({
+    demoMessage: "Live updates are unavailable in demo mode",
+  });
+  if ("response" in auth) {
+    return auth.response;
+  }
+
+  const rateLimitResult = await checkRateLimit(
+    generalApiLimiter,
+    getRateLimitId(request, auth.user.id),
+  );
+  if (!rateLimitResult.success) {
+    return jsonNoStore(
+      { error: "Too many requests. Please slow down." },
+      429,
+      {
+        "Retry-After": String(
+          Math.max(1, Math.ceil((rateLimitResult.reset - Date.now()) / 1000)),
+        ),
+      },
+    );
+  }
+
+  const sessionId = new URL(request.url).searchParams.get("sessionId") ?? "";
+  const result = await negotiateTriageLiveUpdates({
+    sessionId,
+    userId: auth.user.id,
+  });
+
+  if (!result.enabled && result.reason === "feature_disabled") {
+    return jsonNoStore({ enabled: false, reason: "feature_disabled" });
+  }
+
+  if (!result.enabled && result.reason === "invalid_request") {
+    return jsonNoStore({ enabled: false, reason: "invalid_request" }, 400);
+  }
+
+  if (!result.enabled) {
+    return jsonNoStore({ enabled: false, reason: "webpubsub_unavailable" }, 503);
+  }
+
+  return jsonNoStore({
+    enabled: true,
+    sessionId: result.sessionId,
+    url: result.url,
+  });
+}

--- a/src/app/api/azure/webpubsub/negotiate/route.ts
+++ b/src/app/api/azure/webpubsub/negotiate/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import {
   negotiateTriageLiveUpdates,
-  normalizeWebPubSubSafeId,
+  normalizeWebPubSubSessionId,
 } from "@/lib/azure/web-pubsub";
 import { requireAuthenticatedApiUser } from "@/lib/api-auth";
 import {
@@ -52,7 +52,7 @@ export async function GET(request: Request) {
 
   const unsafeSessionId =
     new URL(request.url).searchParams.get("sessionId") ?? "";
-  const sessionId = normalizeWebPubSubSafeId(unsafeSessionId);
+  const sessionId = normalizeWebPubSubSessionId(unsafeSessionId);
   if (!sessionId) {
     return jsonNoStore({ enabled: false, reason: "invalid_request" }, 400);
   }

--- a/src/app/api/azure/webpubsub/negotiate/route.ts
+++ b/src/app/api/azure/webpubsub/negotiate/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from "next/server";
-import { negotiateTriageLiveUpdates } from "@/lib/azure/web-pubsub";
+import {
+  negotiateTriageLiveUpdates,
+  normalizeWebPubSubSafeId,
+} from "@/lib/azure/web-pubsub";
 import { requireAuthenticatedApiUser } from "@/lib/api-auth";
 import {
   checkRateLimit,
@@ -47,7 +50,13 @@ export async function GET(request: Request) {
     );
   }
 
-  const sessionId = new URL(request.url).searchParams.get("sessionId") ?? "";
+  const unsafeSessionId =
+    new URL(request.url).searchParams.get("sessionId") ?? "";
+  const sessionId = normalizeWebPubSubSafeId(unsafeSessionId);
+  if (!sessionId) {
+    return jsonNoStore({ enabled: false, reason: "invalid_request" }, 400);
+  }
+
   const result = await negotiateTriageLiveUpdates({
     sessionId,
     userId: auth.user.id,

--- a/src/components/symptom-checker/use-webpubsub-live-updates.ts
+++ b/src/components/symptom-checker/use-webpubsub-live-updates.ts
@@ -34,6 +34,8 @@ const TRIAGE_LIVE_UPDATE_KEYS = new Set([
   "status",
   "type",
 ]);
+const LIVE_SESSION_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function isTriageLiveUpdate(value: unknown): value is TriageLiveUpdate {
   if (!value || typeof value !== "object") {
@@ -48,6 +50,7 @@ function isTriageLiveUpdate(value: unknown): value is TriageLiveUpdate {
   return (
     update.type === "triage_update" &&
     typeof update.sessionId === "string" &&
+    LIVE_SESSION_ID_PATTERN.test(update.sessionId) &&
     typeof update.generatedAt === "string" &&
     (update.action === "chat" || update.action === "generate_report") &&
     (update.status === "processing" ||

--- a/src/components/symptom-checker/use-webpubsub-live-updates.ts
+++ b/src/components/symptom-checker/use-webpubsub-live-updates.ts
@@ -57,6 +57,18 @@ function isTriageLiveUpdate(value: unknown): value is TriageLiveUpdate {
   );
 }
 
+function isSuccessfulNegotiation(
+  value: NegotiationResponse,
+  sessionId: string,
+): value is Extract<NegotiationResponse, { enabled: true }> {
+  return (
+    value.enabled === true &&
+    value.sessionId === sessionId &&
+    typeof value.url === "string" &&
+    value.url.startsWith("wss://")
+  );
+}
+
 export function parseTriageLiveUpdate(data: unknown): TriageLiveUpdate | null {
   const parsed =
     typeof data === "string"
@@ -110,6 +122,11 @@ export function useWebPubSubLiveUpdates({
         const body = (await response.json()) as NegotiationResponse;
         if (!body.enabled) {
           onConnectionState?.("disabled");
+          return;
+        }
+
+        if (!isSuccessfulNegotiation(body, sessionId)) {
+          onConnectionState?.("fallback");
           return;
         }
 

--- a/src/components/symptom-checker/use-webpubsub-live-updates.ts
+++ b/src/components/symptom-checker/use-webpubsub-live-updates.ts
@@ -1,0 +1,145 @@
+"use client";
+
+import { useEffect } from "react";
+import type { TriageLiveUpdate } from "@/lib/azure/web-pubsub";
+
+type NegotiationResponse =
+  | {
+      enabled: true;
+      sessionId: string;
+      url: string;
+    }
+  | {
+      enabled: false;
+      reason?: string;
+    };
+
+export type TriageLiveUpdateConnectionState =
+  | "disabled"
+  | "connected"
+  | "connecting"
+  | "fallback";
+
+export type UseWebPubSubLiveUpdatesOptions = {
+  enabled: boolean;
+  onConnectionState?: (state: TriageLiveUpdateConnectionState) => void;
+  onUpdate: (update: TriageLiveUpdate) => void;
+  sessionId: string;
+};
+
+const TRIAGE_LIVE_UPDATE_KEYS = new Set([
+  "action",
+  "generatedAt",
+  "sessionId",
+  "status",
+  "type",
+]);
+
+function isTriageLiveUpdate(value: unknown): value is TriageLiveUpdate {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  if (Object.keys(value).some((key) => !TRIAGE_LIVE_UPDATE_KEYS.has(key))) {
+    return false;
+  }
+
+  const update = value as Partial<TriageLiveUpdate>;
+  return (
+    update.type === "triage_update" &&
+    typeof update.sessionId === "string" &&
+    typeof update.generatedAt === "string" &&
+    (update.action === "chat" || update.action === "generate_report") &&
+    (update.status === "processing" ||
+      update.status === "response_ready" ||
+      update.status === "report_ready" ||
+      update.status === "failed")
+  );
+}
+
+export function parseTriageLiveUpdate(data: unknown): TriageLiveUpdate | null {
+  const parsed =
+    typeof data === "string"
+      ? (() => {
+          try {
+            return JSON.parse(data) as unknown;
+          } catch {
+            return null;
+          }
+        })()
+      : data;
+
+  return isTriageLiveUpdate(parsed) ? parsed : null;
+}
+
+export function useWebPubSubLiveUpdates({
+  enabled,
+  onConnectionState,
+  onUpdate,
+  sessionId,
+}: UseWebPubSubLiveUpdatesOptions) {
+  useEffect(() => {
+    if (!enabled || typeof window === "undefined" || !("WebSocket" in window)) {
+      onConnectionState?.("disabled");
+      return undefined;
+    }
+
+    const controller = new AbortController();
+    let socket: WebSocket | null = null;
+    let closed = false;
+
+    onConnectionState?.("connecting");
+
+    async function connect() {
+      try {
+        const response = await fetch(
+          `/api/azure/webpubsub/negotiate?sessionId=${encodeURIComponent(
+            sessionId,
+          )}`,
+          {
+            cache: "no-store",
+            credentials: "same-origin",
+            signal: controller.signal,
+          },
+        );
+        if (!response.ok) {
+          onConnectionState?.("fallback");
+          return;
+        }
+
+        const body = (await response.json()) as NegotiationResponse;
+        if (!body.enabled) {
+          onConnectionState?.("disabled");
+          return;
+        }
+
+        socket = new WebSocket(body.url);
+        socket.onopen = () => onConnectionState?.("connected");
+        socket.onerror = () => onConnectionState?.("fallback");
+        socket.onclose = () => {
+          if (!closed) {
+            onConnectionState?.("fallback");
+          }
+        };
+        socket.onmessage = (event) => {
+          const update = parseTriageLiveUpdate(event.data);
+          if (update?.sessionId === sessionId) {
+            onUpdate(update);
+          }
+        };
+      } catch {
+        if (!controller.signal.aborted) {
+          onConnectionState?.("fallback");
+        }
+      }
+    }
+
+    void connect();
+
+    return () => {
+      closed = true;
+      controller.abort();
+      socket?.close();
+    };
+  }, [enabled, onConnectionState, onUpdate, sessionId]);
+}

--- a/src/lib/azure/web-pubsub.ts
+++ b/src/lib/azure/web-pubsub.ts
@@ -83,7 +83,7 @@ export type PublishTriageLiveUpdateResult =
         | "publish_failed";
     };
 
-function normalizeSafeId(value: unknown): string | null {
+export function normalizeWebPubSubSafeId(value: unknown): string | null {
   if (typeof value !== "string") {
     return null;
   }
@@ -137,8 +137,8 @@ export async function negotiateTriageLiveUpdates(
   input: { sessionId: string; userId: string },
   options: WebPubSubOptions = {},
 ): Promise<NegotiateTriageLiveUpdatesResult> {
-  const userId = normalizeSafeId(input.userId);
-  const sessionId = normalizeSafeId(input.sessionId);
+  const userId = normalizeWebPubSubSafeId(input.userId);
+  const sessionId = normalizeWebPubSubSafeId(input.sessionId);
   if (!userId || !sessionId) {
     await trackWebPubSubEvent(
       { errorCode: "invalid_request", statusCode: 400 },
@@ -203,8 +203,8 @@ export async function publishTriageLiveUpdate(
   },
   options: WebPubSubOptions = {},
 ): Promise<PublishTriageLiveUpdateResult> {
-  const userId = normalizeSafeId(input.userId);
-  const sessionId = normalizeSafeId(input.sessionId);
+  const userId = normalizeWebPubSubSafeId(input.userId);
+  const sessionId = normalizeWebPubSubSafeId(input.sessionId);
   if (!userId || !sessionId) {
     await trackWebPubSubEvent(
       { errorCode: "invalid_request", statusCode: 400 },

--- a/src/lib/azure/web-pubsub.ts
+++ b/src/lib/azure/web-pubsub.ts
@@ -8,7 +8,9 @@ import { trackEvent, type TrackOptions } from "@/lib/azure/telemetry";
 export const AZURE_WEB_PUBSUB_FEATURE_FLAG = "azure.webpubsub.enabled";
 export const DEFAULT_WEB_PUBSUB_HUB_NAME = "pawvital_triage";
 
-const SAFE_ID_PATTERN = /^[A-Za-z0-9:_@.-]{1,128}$/;
+const SAFE_USER_ID_PATTERN = /^[A-Za-z0-9:_@.-]{1,128}$/;
+const SAFE_SESSION_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 type WebPubSubErrorCode =
   | "feature_disabled"
@@ -83,13 +85,22 @@ export type PublishTriageLiveUpdateResult =
         | "publish_failed";
     };
 
-export function normalizeWebPubSubSafeId(value: unknown): string | null {
+export function normalizeWebPubSubUserId(value: unknown): string | null {
   if (typeof value !== "string") {
     return null;
   }
 
   const trimmed = value.trim();
-  return SAFE_ID_PATTERN.test(trimmed) ? trimmed : null;
+  return SAFE_USER_ID_PATTERN.test(trimmed) ? trimmed : null;
+}
+
+export function normalizeWebPubSubSessionId(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return SAFE_SESSION_ID_PATTERN.test(trimmed) ? trimmed.toLowerCase() : null;
 }
 
 async function createDefaultWebPubSubClient(
@@ -137,8 +148,8 @@ export async function negotiateTriageLiveUpdates(
   input: { sessionId: string; userId: string },
   options: WebPubSubOptions = {},
 ): Promise<NegotiateTriageLiveUpdatesResult> {
-  const userId = normalizeWebPubSubSafeId(input.userId);
-  const sessionId = normalizeWebPubSubSafeId(input.sessionId);
+  const userId = normalizeWebPubSubUserId(input.userId);
+  const sessionId = normalizeWebPubSubSessionId(input.sessionId);
   if (!userId || !sessionId) {
     await trackWebPubSubEvent(
       { errorCode: "invalid_request", statusCode: 400 },
@@ -203,8 +214,8 @@ export async function publishTriageLiveUpdate(
   },
   options: WebPubSubOptions = {},
 ): Promise<PublishTriageLiveUpdateResult> {
-  const userId = normalizeWebPubSubSafeId(input.userId);
-  const sessionId = normalizeWebPubSubSafeId(input.sessionId);
+  const userId = normalizeWebPubSubUserId(input.userId);
+  const sessionId = normalizeWebPubSubSessionId(input.sessionId);
   if (!userId || !sessionId) {
     await trackWebPubSubEvent(
       { errorCode: "invalid_request", statusCode: 400 },

--- a/src/lib/azure/web-pubsub.ts
+++ b/src/lib/azure/web-pubsub.ts
@@ -1,0 +1,252 @@
+import { getWebPubSubConnectionString } from "@/lib/azure";
+import {
+  getFlag,
+  type AzureFeatureFlagOptions,
+} from "@/lib/azure/app-config";
+import { trackEvent, type TrackOptions } from "@/lib/azure/telemetry";
+
+export const AZURE_WEB_PUBSUB_FEATURE_FLAG = "azure.webpubsub.enabled";
+export const DEFAULT_WEB_PUBSUB_HUB_NAME = "pawvital_triage";
+
+const SAFE_ID_PATTERN = /^[A-Za-z0-9:_@.-]{1,128}$/;
+
+type WebPubSubErrorCode =
+  | "feature_disabled"
+  | "invalid_request"
+  | "negotiate_failed"
+  | "not_configured"
+  | "publish_failed";
+
+export type TriageLiveUpdateStatus =
+  | "processing"
+  | "response_ready"
+  | "report_ready"
+  | "failed";
+
+export type TriageLiveUpdate = {
+  action: "chat" | "generate_report";
+  generatedAt: string;
+  sessionId: string;
+  status: TriageLiveUpdateStatus;
+  type: "triage_update";
+};
+
+type ClientAccessToken = {
+  url?: string;
+};
+
+export type WebPubSubServiceClientLike = {
+  getClientAccessToken(options?: {
+    expirationTimeInMinutes?: number;
+    userId?: string;
+  }): Promise<ClientAccessToken>;
+  sendToUser(userId: string, message: TriageLiveUpdate): Promise<void>;
+};
+
+export type WebPubSubServiceClientFactory = (
+  connectionString: string,
+  hubName: string,
+) => Promise<WebPubSubServiceClientLike> | WebPubSubServiceClientLike;
+
+export type WebPubSubOptions = AzureFeatureFlagOptions &
+  TrackOptions & {
+    hubName?: string;
+    webPubSubClientFactory?: WebPubSubServiceClientFactory;
+  };
+
+export type NegotiateTriageLiveUpdatesResult =
+  | {
+      enabled: true;
+      sessionId: string;
+      url: string;
+    }
+  | {
+      enabled: false;
+      reason:
+        | "feature_disabled"
+        | "invalid_request"
+        | "negotiate_failed"
+        | "not_configured";
+    };
+
+export type PublishTriageLiveUpdateResult =
+  | {
+      enabled: true;
+      published: true;
+    }
+  | {
+      enabled: false;
+      reason:
+        | "feature_disabled"
+        | "invalid_request"
+        | "not_configured"
+        | "publish_failed";
+    };
+
+function normalizeSafeId(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return SAFE_ID_PATTERN.test(trimmed) ? trimmed : null;
+}
+
+async function createDefaultWebPubSubClient(
+  connectionString: string,
+  hubName: string,
+): Promise<WebPubSubServiceClientLike> {
+  const { WebPubSubServiceClient } = await import("@azure/web-pubsub");
+  return new WebPubSubServiceClient(
+    connectionString,
+    hubName,
+  ) as unknown as WebPubSubServiceClientLike;
+}
+
+async function getWebPubSubClient(
+  connectionString: string,
+  options: WebPubSubOptions,
+): Promise<WebPubSubServiceClientLike> {
+  const hubName = options.hubName ?? DEFAULT_WEB_PUBSUB_HUB_NAME;
+  return options.webPubSubClientFactory
+    ? await options.webPubSubClientFactory(connectionString, hubName)
+    : createDefaultWebPubSubClient(connectionString, hubName);
+}
+
+async function trackWebPubSubEvent(
+  input: {
+    errorCode?: WebPubSubErrorCode;
+    statusCode: number;
+  },
+  options: WebPubSubOptions,
+): Promise<void> {
+  await trackEvent(
+    {
+      name: "azure.service.called",
+      properties: {
+        azureService: "webpubsub",
+        errorCode: input.errorCode,
+        statusCode: input.statusCode,
+      },
+    },
+    options,
+  );
+}
+
+export async function negotiateTriageLiveUpdates(
+  input: { sessionId: string; userId: string },
+  options: WebPubSubOptions = {},
+): Promise<NegotiateTriageLiveUpdatesResult> {
+  const userId = normalizeSafeId(input.userId);
+  const sessionId = normalizeSafeId(input.sessionId);
+  if (!userId || !sessionId) {
+    await trackWebPubSubEvent(
+      { errorCode: "invalid_request", statusCode: 400 },
+      options,
+    );
+    return { enabled: false, reason: "invalid_request" };
+  }
+
+  const enabled = await getFlag(AZURE_WEB_PUBSUB_FEATURE_FLAG, options);
+  if (!enabled) {
+    await trackWebPubSubEvent(
+      { errorCode: "feature_disabled", statusCode: 204 },
+      options,
+    );
+    return { enabled: false, reason: "feature_disabled" };
+  }
+
+  const connectionString = await getWebPubSubConnectionString(options);
+  if (!connectionString) {
+    await trackWebPubSubEvent(
+      { errorCode: "not_configured", statusCode: 503 },
+      options,
+    );
+    return { enabled: false, reason: "not_configured" };
+  }
+
+  try {
+    const client = await getWebPubSubClient(connectionString, options);
+    const token = await client.getClientAccessToken({
+      expirationTimeInMinutes: 60,
+      userId,
+    });
+    if (!token.url) {
+      await trackWebPubSubEvent(
+        { errorCode: "negotiate_failed", statusCode: 502 },
+        options,
+      );
+      return { enabled: false, reason: "negotiate_failed" };
+    }
+
+    await trackWebPubSubEvent({ statusCode: 200 }, options);
+    return {
+      enabled: true,
+      sessionId,
+      url: token.url,
+    };
+  } catch {
+    await trackWebPubSubEvent(
+      { errorCode: "negotiate_failed", statusCode: 503 },
+      options,
+    );
+    return { enabled: false, reason: "negotiate_failed" };
+  }
+}
+
+export async function publishTriageLiveUpdate(
+  input: {
+    action: "chat" | "generate_report";
+    sessionId: string;
+    status: TriageLiveUpdateStatus;
+    userId: string | null;
+  },
+  options: WebPubSubOptions = {},
+): Promise<PublishTriageLiveUpdateResult> {
+  const userId = normalizeSafeId(input.userId);
+  const sessionId = normalizeSafeId(input.sessionId);
+  if (!userId || !sessionId) {
+    await trackWebPubSubEvent(
+      { errorCode: "invalid_request", statusCode: 400 },
+      options,
+    );
+    return { enabled: false, reason: "invalid_request" };
+  }
+
+  const enabled = await getFlag(AZURE_WEB_PUBSUB_FEATURE_FLAG, options);
+  if (!enabled) {
+    await trackWebPubSubEvent(
+      { errorCode: "feature_disabled", statusCode: 204 },
+      options,
+    );
+    return { enabled: false, reason: "feature_disabled" };
+  }
+
+  const connectionString = await getWebPubSubConnectionString(options);
+  if (!connectionString) {
+    await trackWebPubSubEvent(
+      { errorCode: "not_configured", statusCode: 503 },
+      options,
+    );
+    return { enabled: false, reason: "not_configured" };
+  }
+
+  try {
+    const client = await getWebPubSubClient(connectionString, options);
+    await client.sendToUser(userId, {
+      action: input.action,
+      generatedAt: new Date().toISOString(),
+      sessionId,
+      status: input.status,
+      type: "triage_update",
+    });
+    await trackWebPubSubEvent({ statusCode: 200 }, options);
+    return { enabled: true, published: true };
+  } catch {
+    await trackWebPubSubEvent(
+      { errorCode: "publish_failed", statusCode: 503 },
+      options,
+    );
+    return { enabled: false, reason: "publish_failed" };
+  }
+}

--- a/tests/azure-web-pubsub.test.ts
+++ b/tests/azure-web-pubsub.test.ts
@@ -1,0 +1,259 @@
+import type { SecretClientLike } from "@/lib/azure";
+import {
+  AZURE_WEB_PUBSUB_FEATURE_FLAG,
+  DEFAULT_WEB_PUBSUB_HUB_NAME,
+  negotiateTriageLiveUpdates,
+  publishTriageLiveUpdate,
+  type WebPubSubServiceClientLike,
+} from "@/lib/azure/web-pubsub";
+import { trackEvent } from "@/lib/azure/telemetry";
+
+jest.mock("@/lib/azure/telemetry", () => ({
+  trackEvent: jest.fn().mockResolvedValue(undefined),
+}));
+
+const CONFIGURED_ENV = {
+  AZURE_TENANT_ID: "test-tenant-id",
+  AZURE_CLIENT_ID: "test-client-id",
+  AZURE_CLIENT_SECRET: "test-client-secret",
+  AZURE_KEY_VAULT_NAME: "test-vault",
+};
+
+const APP_CONFIG_CONNECTION_STRING =
+  "Endpoint=https://pawvital-appconfig.azconfig.io;Id=test;Secret=test";
+const WEB_PUBSUB_CONNECTION_STRING =
+  "Endpoint=https://pawvital-webpubsub.webpubsub.azure.com;AccessKey=secret;Version=1.0;";
+
+function makeSecretClient(secrets: Record<string, string>): SecretClientLike {
+  return {
+    getSecret: async (name: string) => ({ value: secrets[name] ?? null }),
+  };
+}
+
+function enabledFlagClient() {
+  return {
+    getConfigurationSetting: async (setting: { key: string }) => {
+      expect(setting.key).toBe(
+        `.appconfig.featureflag/${AZURE_WEB_PUBSUB_FEATURE_FLAG}`,
+      );
+      return { value: JSON.stringify({ enabled: true }) };
+    },
+  };
+}
+
+function disabledFlagClient() {
+  return {
+    getConfigurationSetting: async () => ({
+      value: JSON.stringify({ enabled: false }),
+    }),
+  };
+}
+
+function baseOptions(secrets: Record<string, string> = {}) {
+  return {
+    appConfigurationClientFactory: () => enabledFlagClient(),
+    env: CONFIGURED_ENV,
+    secretClientFactory: () =>
+      makeSecretClient({
+        "appconfig-connection-string": APP_CONFIG_CONNECTION_STRING,
+        "webpubsub-connection-string": WEB_PUBSUB_CONNECTION_STRING,
+        ...secrets,
+      }),
+  };
+}
+
+function makeClient() {
+  return {
+    getClientAccessToken: jest.fn().mockResolvedValue({
+      url: "wss://pawvital-webpubsub.webpubsub.azure.com/client/hubs/pawvital_triage?access_token=client-token",
+    }),
+    sendToUser: jest.fn().mockResolvedValue(undefined),
+  } satisfies WebPubSubServiceClientLike;
+}
+
+describe("Azure Web PubSub helper", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("defaults off when the App Config Web PubSub flag is disabled", async () => {
+    const webPubSubClientFactory = jest.fn();
+
+    await expect(
+      negotiateTriageLiveUpdates(
+        { sessionId: "session-1", userId: "user-1" },
+        {
+          ...baseOptions(),
+          appConfigurationClientFactory: () => disabledFlagClient(),
+          webPubSubClientFactory,
+        },
+      ),
+    ).resolves.toEqual({ enabled: false, reason: "feature_disabled" });
+
+    expect(webPubSubClientFactory).not.toHaveBeenCalled();
+  });
+
+  it("creates a short-lived browser connection URL without exposing the connection string", async () => {
+    const client = makeClient();
+
+    const result = await negotiateTriageLiveUpdates(
+      { sessionId: "session-1", userId: "user-1" },
+      {
+        ...baseOptions(),
+        webPubSubClientFactory: jest.fn().mockReturnValue(client),
+      },
+    );
+
+    expect(result).toEqual({
+      enabled: true,
+      sessionId: "session-1",
+      url: expect.stringContaining("wss://"),
+    });
+    expect(JSON.stringify(result)).not.toContain("AccessKey=secret");
+    expect(client.getClientAccessToken).toHaveBeenCalledWith({
+      expirationTimeInMinutes: 60,
+      userId: "user-1",
+    });
+  });
+
+  it("fails closed when the Web PubSub connection string is absent", async () => {
+    const webPubSubClientFactory = jest.fn();
+
+    await expect(
+      negotiateTriageLiveUpdates(
+        { sessionId: "session-1", userId: "user-1" },
+        {
+          ...baseOptions({ "webpubsub-connection-string": "" }),
+          webPubSubClientFactory,
+        },
+      ),
+    ).resolves.toEqual({ enabled: false, reason: "not_configured" });
+
+    expect(webPubSubClientFactory).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when Azure does not issue a client URL", async () => {
+    const client = {
+      ...makeClient(),
+      getClientAccessToken: jest.fn().mockResolvedValue({}),
+    };
+
+    await expect(
+      negotiateTriageLiveUpdates(
+        { sessionId: "session-1", userId: "user-1" },
+        {
+          ...baseOptions(),
+          webPubSubClientFactory: jest.fn().mockReturnValue(client),
+        },
+      ),
+    ).resolves.toEqual({ enabled: false, reason: "negotiate_failed" });
+  });
+
+  it("publishes metadata-only triage updates to the authenticated user", async () => {
+    const client = makeClient();
+
+    await expect(
+      publishTriageLiveUpdate(
+        {
+          action: "chat",
+          sessionId: "session-1",
+          status: "response_ready",
+          userId: "user-1",
+        },
+        {
+          ...baseOptions(),
+          webPubSubClientFactory: jest.fn().mockReturnValue(client),
+        },
+      ),
+    ).resolves.toEqual({ enabled: true, published: true });
+
+    expect(client.sendToUser).toHaveBeenCalledWith("user-1", {
+      action: "chat",
+      generatedAt: expect.any(String),
+      sessionId: "session-1",
+      status: "response_ready",
+      type: "triage_update",
+    });
+    expect(JSON.stringify(client.sendToUser.mock.calls[0])).not.toContain(
+      "vomit",
+    );
+  });
+
+  it("fails closed when publishing to Web PubSub fails", async () => {
+    const client = {
+      ...makeClient(),
+      sendToUser: jest.fn().mockRejectedValue(new Error("broker offline")),
+    };
+
+    await expect(
+      publishTriageLiveUpdate(
+        {
+          action: "chat",
+          sessionId: "session-1",
+          status: "failed",
+          userId: "user-1",
+        },
+        {
+          ...baseOptions(),
+          webPubSubClientFactory: jest.fn().mockReturnValue(client),
+        },
+      ),
+    ).resolves.toEqual({ enabled: false, reason: "publish_failed" });
+  });
+
+  it("rejects unsafe IDs before negotiating or publishing", async () => {
+    const client = makeClient();
+    const webPubSubClientFactory = jest.fn().mockReturnValue(client);
+
+    await expect(
+      negotiateTriageLiveUpdates(
+        { sessionId: "../session", userId: "user-1" },
+        {
+          ...baseOptions(),
+          webPubSubClientFactory,
+        },
+      ),
+    ).resolves.toEqual({ enabled: false, reason: "invalid_request" });
+
+    await expect(
+      publishTriageLiveUpdate(
+        {
+          action: "chat",
+          sessionId: "session-1",
+          status: "processing",
+          userId: "user 1",
+        },
+        {
+          ...baseOptions(),
+          webPubSubClientFactory,
+        },
+      ),
+    ).resolves.toEqual({ enabled: false, reason: "invalid_request" });
+
+    expect(webPubSubClientFactory).not.toHaveBeenCalled();
+  });
+
+  it("uses the expected default hub name for the service client", async () => {
+    const client = makeClient();
+    const webPubSubClientFactory = jest.fn().mockReturnValue(client);
+
+    await negotiateTriageLiveUpdates(
+      { sessionId: "session-1", userId: "user-1" },
+      {
+        ...baseOptions(),
+        webPubSubClientFactory,
+      },
+    );
+
+    expect(webPubSubClientFactory).toHaveBeenCalledWith(
+      WEB_PUBSUB_CONNECTION_STRING,
+      DEFAULT_WEB_PUBSUB_HUB_NAME,
+    );
+    expect(trackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "azure.service.called",
+      }),
+      expect.any(Object),
+    );
+  });
+});

--- a/tests/azure-web-pubsub.test.ts
+++ b/tests/azure-web-pubsub.test.ts
@@ -23,6 +23,7 @@ const APP_CONFIG_CONNECTION_STRING =
   "Endpoint=https://pawvital-appconfig.azconfig.io;Id=test;Secret=test";
 const WEB_PUBSUB_CONNECTION_STRING =
   "Endpoint=https://pawvital-webpubsub.webpubsub.azure.com;AccessKey=secret;Version=1.0;";
+const LIVE_SESSION_ID = "550e8400-e29b-41d4-a716-446655440000";
 
 function makeSecretClient(secrets: Record<string, string>): SecretClientLike {
   return {
@@ -81,7 +82,7 @@ describe("Azure Web PubSub helper", () => {
 
     await expect(
       negotiateTriageLiveUpdates(
-        { sessionId: "session-1", userId: "user-1" },
+        { sessionId: LIVE_SESSION_ID, userId: "user-1" },
         {
           ...baseOptions(),
           appConfigurationClientFactory: () => disabledFlagClient(),
@@ -97,7 +98,7 @@ describe("Azure Web PubSub helper", () => {
     const client = makeClient();
 
     const result = await negotiateTriageLiveUpdates(
-      { sessionId: "session-1", userId: "user-1" },
+      { sessionId: LIVE_SESSION_ID, userId: "user-1" },
       {
         ...baseOptions(),
         webPubSubClientFactory: jest.fn().mockReturnValue(client),
@@ -106,7 +107,7 @@ describe("Azure Web PubSub helper", () => {
 
     expect(result).toEqual({
       enabled: true,
-      sessionId: "session-1",
+      sessionId: LIVE_SESSION_ID,
       url: expect.stringContaining("wss://"),
     });
     expect(JSON.stringify(result)).not.toContain("AccessKey=secret");
@@ -121,7 +122,7 @@ describe("Azure Web PubSub helper", () => {
 
     await expect(
       negotiateTriageLiveUpdates(
-        { sessionId: "session-1", userId: "user-1" },
+        { sessionId: LIVE_SESSION_ID, userId: "user-1" },
         {
           ...baseOptions({ "webpubsub-connection-string": "" }),
           webPubSubClientFactory,
@@ -140,7 +141,7 @@ describe("Azure Web PubSub helper", () => {
 
     await expect(
       negotiateTriageLiveUpdates(
-        { sessionId: "session-1", userId: "user-1" },
+        { sessionId: LIVE_SESSION_ID, userId: "user-1" },
         {
           ...baseOptions(),
           webPubSubClientFactory: jest.fn().mockReturnValue(client),
@@ -156,7 +157,7 @@ describe("Azure Web PubSub helper", () => {
       publishTriageLiveUpdate(
         {
           action: "chat",
-          sessionId: "session-1",
+          sessionId: LIVE_SESSION_ID,
           status: "response_ready",
           userId: "user-1",
         },
@@ -170,7 +171,7 @@ describe("Azure Web PubSub helper", () => {
     expect(client.sendToUser).toHaveBeenCalledWith("user-1", {
       action: "chat",
       generatedAt: expect.any(String),
-      sessionId: "session-1",
+      sessionId: LIVE_SESSION_ID,
       status: "response_ready",
       type: "triage_update",
     });
@@ -189,7 +190,7 @@ describe("Azure Web PubSub helper", () => {
       publishTriageLiveUpdate(
         {
           action: "chat",
-          sessionId: "session-1",
+          sessionId: LIVE_SESSION_ID,
           status: "failed",
           userId: "user-1",
         },
@@ -219,7 +220,7 @@ describe("Azure Web PubSub helper", () => {
       publishTriageLiveUpdate(
         {
           action: "chat",
-          sessionId: "session-1",
+          sessionId: LIVE_SESSION_ID,
           status: "processing",
           userId: "user 1",
         },
@@ -238,7 +239,7 @@ describe("Azure Web PubSub helper", () => {
     const webPubSubClientFactory = jest.fn().mockReturnValue(client);
 
     await negotiateTriageLiveUpdates(
-      { sessionId: "session-1", userId: "user-1" },
+      { sessionId: LIVE_SESSION_ID, userId: "user-1" },
       {
         ...baseOptions(),
         webPubSubClientFactory,

--- a/tests/azure-webpubsub-negotiate-route.test.ts
+++ b/tests/azure-webpubsub-negotiate-route.test.ts
@@ -19,6 +19,14 @@ jest.mock("@/lib/rate-limit", () => ({
 jest.mock("@/lib/azure/web-pubsub", () => ({
   negotiateTriageLiveUpdates: (...args: unknown[]) =>
     mockNegotiateTriageLiveUpdates(...args),
+  normalizeWebPubSubSafeId: (value: unknown) => {
+    if (typeof value !== "string") {
+      return null;
+    }
+
+    const trimmed = value.trim();
+    return /^[A-Za-z0-9:_@.-]{1,128}$/.test(trimmed) ? trimmed : null;
+  },
 }));
 
 function makeRequest(sessionId = "session-1") {
@@ -129,11 +137,6 @@ describe("azure Web PubSub negotiate route", () => {
   });
 
   it("fails closed for invalid session IDs", async () => {
-    mockNegotiateTriageLiveUpdates.mockResolvedValueOnce({
-      enabled: false,
-      reason: "invalid_request",
-    });
-
     const { GET } = await import(
       "@/app/api/azure/webpubsub/negotiate/route"
     );
@@ -144,6 +147,7 @@ describe("azure Web PubSub negotiate route", () => {
       reason: "invalid_request",
     });
     expect(response.status).toBe(400);
+    expect(mockNegotiateTriageLiveUpdates).not.toHaveBeenCalled();
   });
 
   it("fails closed when Web PubSub is unavailable", async () => {

--- a/tests/azure-webpubsub-negotiate-route.test.ts
+++ b/tests/azure-webpubsub-negotiate-route.test.ts
@@ -4,6 +4,7 @@ const mockRequireAuthenticatedApiUser = jest.fn();
 const mockCheckRateLimit = jest.fn();
 const mockGetRateLimitId = jest.fn();
 const mockNegotiateTriageLiveUpdates = jest.fn();
+const LIVE_SESSION_ID = "550e8400-e29b-41d4-a716-446655440000";
 
 jest.mock("@/lib/api-auth", () => ({
   requireAuthenticatedApiUser: (...args: unknown[]) =>
@@ -19,17 +20,21 @@ jest.mock("@/lib/rate-limit", () => ({
 jest.mock("@/lib/azure/web-pubsub", () => ({
   negotiateTriageLiveUpdates: (...args: unknown[]) =>
     mockNegotiateTriageLiveUpdates(...args),
-  normalizeWebPubSubSafeId: (value: unknown) => {
+  normalizeWebPubSubSessionId: (value: unknown) => {
     if (typeof value !== "string") {
       return null;
     }
 
     const trimmed = value.trim();
-    return /^[A-Za-z0-9:_@.-]{1,128}$/.test(trimmed) ? trimmed : null;
+    return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      trimmed,
+    )
+      ? trimmed.toLowerCase()
+      : null;
   },
 }));
 
-function makeRequest(sessionId = "session-1") {
+function makeRequest(sessionId = LIVE_SESSION_ID) {
   return new Request(
     `http://localhost/api/azure/webpubsub/negotiate?sessionId=${encodeURIComponent(
       sessionId,
@@ -52,7 +57,7 @@ describe("azure Web PubSub negotiate route", () => {
     mockGetRateLimitId.mockReturnValue("user:user-1");
     mockNegotiateTriageLiveUpdates.mockResolvedValue({
       enabled: true,
-      sessionId: "session-1",
+      sessionId: LIVE_SESSION_ID,
       url: "wss://pawvital-webpubsub.webpubsub.azure.com/client/hubs/pawvital_triage?access_token=client-token",
     });
   });
@@ -107,12 +112,12 @@ describe("azure Web PubSub negotiate route", () => {
     expect(response.headers.get("Cache-Control")).toBe("no-store");
     expect(payload).toEqual({
       enabled: true,
-      sessionId: "session-1",
+      sessionId: LIVE_SESSION_ID,
       url: expect.stringContaining("wss://"),
     });
     expect(JSON.stringify(payload)).not.toContain("AccessKey=");
     expect(mockNegotiateTriageLiveUpdates).toHaveBeenCalledWith({
-      sessionId: "session-1",
+      sessionId: LIVE_SESSION_ID,
       userId: "user-1",
     });
   });

--- a/tests/azure-webpubsub-negotiate-route.test.ts
+++ b/tests/azure-webpubsub-negotiate-route.test.ts
@@ -1,0 +1,166 @@
+import { NextResponse } from "next/server";
+
+const mockRequireAuthenticatedApiUser = jest.fn();
+const mockCheckRateLimit = jest.fn();
+const mockGetRateLimitId = jest.fn();
+const mockNegotiateTriageLiveUpdates = jest.fn();
+
+jest.mock("@/lib/api-auth", () => ({
+  requireAuthenticatedApiUser: (...args: unknown[]) =>
+    mockRequireAuthenticatedApiUser(...args),
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  generalApiLimiter: {},
+  checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
+  getRateLimitId: (...args: unknown[]) => mockGetRateLimitId(...args),
+}));
+
+jest.mock("@/lib/azure/web-pubsub", () => ({
+  negotiateTriageLiveUpdates: (...args: unknown[]) =>
+    mockNegotiateTriageLiveUpdates(...args),
+}));
+
+function makeRequest(sessionId = "session-1") {
+  return new Request(
+    `http://localhost/api/azure/webpubsub/negotiate?sessionId=${encodeURIComponent(
+      sessionId,
+    )}`,
+  );
+}
+
+describe("azure Web PubSub negotiate route", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    mockRequireAuthenticatedApiUser.mockResolvedValue({
+      supabase: {},
+      user: { id: "user-1" },
+    });
+    mockCheckRateLimit.mockResolvedValue({
+      reset: Date.now() + 30_000,
+      success: true,
+    });
+    mockGetRateLimitId.mockReturnValue("user:user-1");
+    mockNegotiateTriageLiveUpdates.mockResolvedValue({
+      enabled: true,
+      sessionId: "session-1",
+      url: "wss://pawvital-webpubsub.webpubsub.azure.com/client/hubs/pawvital_triage?access_token=client-token",
+    });
+  });
+
+  it("requires an authenticated user because API routes bypass the proxy", async () => {
+    mockRequireAuthenticatedApiUser.mockResolvedValueOnce({
+      response: NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 },
+      ),
+    });
+
+    const { GET } = await import(
+      "@/app/api/azure/webpubsub/negotiate/route"
+    );
+    const response = await GET(makeRequest());
+    const payload = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(payload.error).toBe("Authentication required");
+    expect(mockNegotiateTriageLiveUpdates).not.toHaveBeenCalled();
+  });
+
+  it("rate limits negotiations by authenticated user id", async () => {
+    mockCheckRateLimit.mockResolvedValueOnce({
+      remaining: 0,
+      reset: Date.now() + 10_000,
+      success: false,
+    });
+
+    const { GET } = await import(
+      "@/app/api/azure/webpubsub/negotiate/route"
+    );
+    const response = await GET(makeRequest());
+    const payload = await response.json();
+
+    expect(response.status).toBe(429);
+    expect(payload.error).toContain("Too many requests");
+    expect(response.headers.get("Retry-After")).toBeTruthy();
+    expect(mockGetRateLimitId).toHaveBeenCalledWith(expect.any(Request), "user-1");
+    expect(mockNegotiateTriageLiveUpdates).not.toHaveBeenCalled();
+  });
+
+  it("returns a no-store browser WebSocket URL without exposing the connection string", async () => {
+    const { GET } = await import(
+      "@/app/api/azure/webpubsub/negotiate/route"
+    );
+    const response = await GET(makeRequest());
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(payload).toEqual({
+      enabled: true,
+      sessionId: "session-1",
+      url: expect.stringContaining("wss://"),
+    });
+    expect(JSON.stringify(payload)).not.toContain("AccessKey=");
+    expect(mockNegotiateTriageLiveUpdates).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      userId: "user-1",
+    });
+  });
+
+  it("returns disabled when the App Config Web PubSub flag is off", async () => {
+    mockNegotiateTriageLiveUpdates.mockResolvedValueOnce({
+      enabled: false,
+      reason: "feature_disabled",
+    });
+
+    const { GET } = await import(
+      "@/app/api/azure/webpubsub/negotiate/route"
+    );
+    const response = await GET(makeRequest());
+
+    await expect(response.json()).resolves.toEqual({
+      enabled: false,
+      reason: "feature_disabled",
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("fails closed for invalid session IDs", async () => {
+    mockNegotiateTriageLiveUpdates.mockResolvedValueOnce({
+      enabled: false,
+      reason: "invalid_request",
+    });
+
+    const { GET } = await import(
+      "@/app/api/azure/webpubsub/negotiate/route"
+    );
+    const response = await GET(makeRequest("../session"));
+
+    await expect(response.json()).resolves.toEqual({
+      enabled: false,
+      reason: "invalid_request",
+    });
+    expect(response.status).toBe(400);
+  });
+
+  it("fails closed when Web PubSub is unavailable", async () => {
+    mockNegotiateTriageLiveUpdates.mockResolvedValueOnce({
+      enabled: false,
+      reason: "not_configured",
+    });
+
+    const { GET } = await import(
+      "@/app/api/azure/webpubsub/negotiate/route"
+    );
+    const response = await GET(makeRequest());
+
+    await expect(response.json()).resolves.toEqual({
+      enabled: false,
+      reason: "webpubsub_unavailable",
+    });
+    expect(response.status).toBe(503);
+  });
+});

--- a/tests/symptom-chat.route.test.ts
+++ b/tests/symptom-chat.route.test.ts
@@ -241,17 +241,23 @@ jest.mock("@/lib/azure/telemetry", () => ({
 }));
 
 jest.mock("@/lib/azure/web-pubsub", () => ({
-  normalizeWebPubSubSafeId: (value: unknown) => {
+  normalizeWebPubSubSessionId: (value: unknown) => {
     if (typeof value !== "string") {
       return null;
     }
 
     const trimmed = value.trim();
-    return /^[A-Za-z0-9:_@.-]{1,128}$/.test(trimmed) ? trimmed : null;
+    return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      trimmed,
+    )
+      ? trimmed.toLowerCase()
+      : null;
   },
   publishTriageLiveUpdate: (...args: unknown[]) =>
     mockPublishTriageLiveUpdate(...args),
 }));
+
+const LIVE_SESSION_ID = "550e8400-e29b-41d4-a716-446655440000";
 
 const PET = {
   name: "Bruno",
@@ -745,7 +751,7 @@ describe("symptom-chat mixed text + image routing", () => {
     const liveRequest = new Request("http://localhost/api/ai/symptom-chat", {
       body: JSON.stringify({
         ...body,
-        liveSessionId: "live-session-1",
+        liveSessionId: LIVE_SESSION_ID,
       }),
       headers: { "Content-Type": "application/json" },
       method: "POST",
@@ -756,13 +762,13 @@ describe("symptom-chat mixed text + image routing", () => {
 
     expect(mockPublishTriageLiveUpdate).toHaveBeenNthCalledWith(1, {
       action: "chat",
-      sessionId: "live-session-1",
+      sessionId: LIVE_SESSION_ID,
       status: "processing",
       userId: "user-1",
     });
     expect(mockPublishTriageLiveUpdate).toHaveBeenNthCalledWith(2, {
       action: "chat",
-      sessionId: "live-session-1",
+      sessionId: LIVE_SESSION_ID,
       status: "response_ready",
       userId: "user-1",
     });
@@ -819,7 +825,7 @@ describe("symptom-chat mixed text + image routing", () => {
     const liveRequest = new Request("http://localhost/api/ai/symptom-chat", {
       body: JSON.stringify({
         ...body,
-        liveSessionId: "live-session-1",
+        liveSessionId: LIVE_SESSION_ID,
       }),
       headers: { "Content-Type": "application/json" },
       method: "POST",
@@ -844,7 +850,7 @@ describe("symptom-chat mixed text + image routing", () => {
     expect(settled).toBe(true);
     expect(mockPublishTriageLiveUpdate).toHaveBeenNthCalledWith(2, {
       action: "chat",
-      sessionId: "live-session-1",
+      sessionId: LIVE_SESSION_ID,
       status: "response_ready",
       userId: "user-1",
     });

--- a/tests/symptom-chat.route.test.ts
+++ b/tests/symptom-chat.route.test.ts
@@ -56,6 +56,7 @@ const mockEmit = jest.fn();
 const mockCalibrateDiagnosticConfidence = jest.fn();
 const mockTrackRouteTelemetry = jest.fn();
 const mockTrackException = jest.fn();
+const mockPublishTriageLiveUpdate = jest.fn();
 const mockEventType = {
   REPORT_READY: "REPORT_READY",
   URGENCY_HIGH: "URGENCY_HIGH",
@@ -237,6 +238,11 @@ jest.mock("@/lib/events/notification-handler", () => ({}));
 jest.mock("@/lib/azure/telemetry", () => ({
   trackRouteTelemetry: (...args: unknown[]) => mockTrackRouteTelemetry(...args),
   trackException: (...args: unknown[]) => mockTrackException(...args),
+}));
+
+jest.mock("@/lib/azure/web-pubsub", () => ({
+  publishTriageLiveUpdate: (...args: unknown[]) =>
+    mockPublishTriageLiveUpdate(...args),
 }));
 
 const PET = {
@@ -661,6 +667,10 @@ describe("symptom-chat mixed text + image routing", () => {
     });
     mockEvaluateImageGate.mockResolvedValue(null);
     mockShouldAnalyzeWoundImage.mockReturnValue(false);
+    mockPublishTriageLiveUpdate.mockResolvedValue({
+      enabled: true,
+      published: true,
+    });
   });
 
   it("records sanitized route telemetry for rate-limited symptom-chat requests", async () => {
@@ -688,6 +698,46 @@ describe("symptom-chat mixed text + image routing", () => {
       "coughing"
     );
     expect(mockTrackException).not.toHaveBeenCalled();
+  });
+
+  it("publishes metadata-only live update statuses for authenticated sessions", async () => {
+    mockCreateServerSupabaseClient.mockResolvedValue(
+      buildBillingSupabase({ userId: "user-1" }),
+    );
+
+    const session = createSession();
+    const request = makeTextOnlyRequest(
+      session,
+      "My dog is limping on the back leg.",
+    );
+    const body = await request.json();
+    const liveRequest = new Request("http://localhost/api/ai/symptom-chat", {
+      body: JSON.stringify({
+        ...body,
+        liveSessionId: "live-session-1",
+      }),
+      headers: { "Content-Type": "application/json" },
+      method: "POST",
+    });
+
+    const { POST } = await import("@/app/api/ai/symptom-chat/route");
+    await POST(liveRequest);
+
+    expect(mockPublishTriageLiveUpdate).toHaveBeenNthCalledWith(1, {
+      action: "chat",
+      sessionId: "live-session-1",
+      status: "processing",
+      userId: "user-1",
+    });
+    expect(mockPublishTriageLiveUpdate).toHaveBeenNthCalledWith(2, {
+      action: "chat",
+      sessionId: "live-session-1",
+      status: "response_ready",
+      userId: "user-1",
+    });
+    expect(JSON.stringify(mockPublishTriageLiveUpdate.mock.calls)).not.toContain(
+      "limping",
+    );
   });
 
   it("fuses a direct leg answer with wound-photo evidence and pivots to wound follow-up", async () => {

--- a/tests/symptom-chat.route.test.ts
+++ b/tests/symptom-chat.route.test.ts
@@ -241,6 +241,14 @@ jest.mock("@/lib/azure/telemetry", () => ({
 }));
 
 jest.mock("@/lib/azure/web-pubsub", () => ({
+  normalizeWebPubSubSafeId: (value: unknown) => {
+    if (typeof value !== "string") {
+      return null;
+    }
+
+    const trimmed = value.trim();
+    return /^[A-Za-z0-9:_@.-]{1,128}$/.test(trimmed) ? trimmed : null;
+  },
   publishTriageLiveUpdate: (...args: unknown[]) =>
     mockPublishTriageLiveUpdate(...args),
 }));
@@ -738,6 +746,32 @@ describe("symptom-chat mixed text + image routing", () => {
     expect(JSON.stringify(mockPublishTriageLiveUpdate.mock.calls)).not.toContain(
       "limping",
     );
+  });
+
+  it("does not schedule live updates for unsafe live session IDs", async () => {
+    mockCreateServerSupabaseClient.mockResolvedValue(
+      buildBillingSupabase({ userId: "user-1" }),
+    );
+
+    const session = createSession();
+    const request = makeTextOnlyRequest(
+      session,
+      "My dog is limping on the back leg.",
+    );
+    const body = await request.json();
+    const liveRequest = new Request("http://localhost/api/ai/symptom-chat", {
+      body: JSON.stringify({
+        ...body,
+        liveSessionId: "../live session",
+      }),
+      headers: { "Content-Type": "application/json" },
+      method: "POST",
+    });
+
+    const { POST } = await import("@/app/api/ai/symptom-chat/route");
+    await POST(liveRequest);
+
+    expect(mockPublishTriageLiveUpdate).not.toHaveBeenCalled();
   });
 
   it("fuses a direct leg answer with wound-photo evidence and pivots to wound follow-up", async () => {

--- a/tests/symptom-chat.route.test.ts
+++ b/tests/symptom-chat.route.test.ts
@@ -856,6 +856,66 @@ describe("symptom-chat mixed text + image routing", () => {
     });
   });
 
+  it("preserves live update order when processing publish is slow", async () => {
+    mockCreateServerSupabaseClient.mockResolvedValue(
+      buildBillingSupabase({ userId: "user-1" }),
+    );
+
+    const processingPublish = createDeferred<{
+      enabled: true;
+      published: true;
+    }>();
+    mockPublishTriageLiveUpdate
+      .mockReturnValueOnce(processingPublish.promise)
+      .mockResolvedValueOnce({ enabled: true, published: true });
+
+    const session = createSession();
+    const request = makeTextOnlyRequest(
+      session,
+      "My dog is limping on the back leg.",
+    );
+    const body = await request.json();
+    const liveRequest = new Request("http://localhost/api/ai/symptom-chat", {
+      body: JSON.stringify({
+        ...body,
+        liveSessionId: LIVE_SESSION_ID,
+      }),
+      headers: { "Content-Type": "application/json" },
+      method: "POST",
+    });
+
+    const { POST } = await import("@/app/api/ai/symptom-chat/route");
+    const responsePromise = POST(liveRequest);
+    await waitForMockCalls(mockPublishTriageLiveUpdate, 1);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockPublishTriageLiveUpdate).toHaveBeenCalledTimes(1);
+
+    let settled = false;
+    void responsePromise.then(() => {
+      settled = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(settled).toBe(false);
+
+    processingPublish.resolve({ enabled: true, published: true });
+    const response = await responsePromise;
+
+    expect(response.status).toBe(200);
+    expect(mockPublishTriageLiveUpdate).toHaveBeenNthCalledWith(1, {
+      action: "chat",
+      sessionId: LIVE_SESSION_ID,
+      status: "processing",
+      userId: "user-1",
+    });
+    expect(mockPublishTriageLiveUpdate).toHaveBeenNthCalledWith(2, {
+      action: "chat",
+      sessionId: LIVE_SESSION_ID,
+      status: "response_ready",
+      userId: "user-1",
+    });
+  });
+
   it("fuses a direct leg answer with wound-photo evidence and pivots to wound follow-up", async () => {
     let session = createSession();
     session = addSymptoms(session, ["limping"]);

--- a/tests/symptom-chat.route.test.ts
+++ b/tests/symptom-chat.route.test.ts
@@ -504,6 +504,29 @@ function buildErrorSidecarResult(
   return { ok: false, category, error, latencyMs, service };
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolver) => {
+    resolve = resolver;
+  });
+
+  return { promise, resolve };
+}
+
+async function waitForMockCalls(
+  mock: { mock: { calls: unknown[][] } },
+  count: number,
+) {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (mock.mock.calls.length >= count) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  throw new Error(`Expected at least ${count} mock calls`);
+}
+
 describe("symptom-chat mixed text + image routing", () => {
   beforeEach(() => {
     jest.resetModules();
@@ -772,6 +795,59 @@ describe("symptom-chat mixed text + image routing", () => {
     await POST(liveRequest);
 
     expect(mockPublishTriageLiveUpdate).not.toHaveBeenCalled();
+  });
+
+  it("awaits the terminal live update before returning", async () => {
+    mockCreateServerSupabaseClient.mockResolvedValue(
+      buildBillingSupabase({ userId: "user-1" }),
+    );
+
+    const terminalPublish = createDeferred<{
+      enabled: true;
+      published: true;
+    }>();
+    mockPublishTriageLiveUpdate
+      .mockResolvedValueOnce({ enabled: true, published: true })
+      .mockReturnValueOnce(terminalPublish.promise);
+
+    const session = createSession();
+    const request = makeTextOnlyRequest(
+      session,
+      "My dog is limping on the back leg.",
+    );
+    const body = await request.json();
+    const liveRequest = new Request("http://localhost/api/ai/symptom-chat", {
+      body: JSON.stringify({
+        ...body,
+        liveSessionId: "live-session-1",
+      }),
+      headers: { "Content-Type": "application/json" },
+      method: "POST",
+    });
+
+    const { POST } = await import("@/app/api/ai/symptom-chat/route");
+    const responsePromise = POST(liveRequest);
+    await waitForMockCalls(mockPublishTriageLiveUpdate, 2);
+
+    let settled = false;
+    void responsePromise.then(() => {
+      settled = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(settled).toBe(false);
+
+    terminalPublish.resolve({ enabled: true, published: true });
+    const response = await responsePromise;
+
+    expect(response.status).toBe(200);
+    expect(settled).toBe(true);
+    expect(mockPublishTriageLiveUpdate).toHaveBeenNthCalledWith(2, {
+      action: "chat",
+      sessionId: "live-session-1",
+      status: "response_ready",
+      userId: "user-1",
+    });
   });
 
   it("fuses a direct leg answer with wound-photo evidence and pivots to wound follow-up", async () => {

--- a/tests/symptom-checker.tester-onboarding.test.ts
+++ b/tests/symptom-checker.tester-onboarding.test.ts
@@ -15,6 +15,10 @@ jest.mock("@/components/symptom-report", () => ({
   FullReport: () => null,
 }));
 
+jest.mock("@/components/symptom-checker/use-webpubsub-live-updates", () => ({
+  useWebPubSubLiveUpdates: jest.fn(),
+}));
+
 const TEST_PET = {
   id: "pet-1",
   user_id: "user-1",

--- a/tests/webpubsub-live-updates.test.ts
+++ b/tests/webpubsub-live-updates.test.ts
@@ -1,0 +1,38 @@
+import { parseTriageLiveUpdate } from "@/components/symptom-checker/use-webpubsub-live-updates";
+
+describe("parseTriageLiveUpdate", () => {
+  it("accepts metadata-only triage update JSON", () => {
+    expect(
+      parseTriageLiveUpdate(
+        JSON.stringify({
+          action: "chat",
+          generatedAt: "2026-05-29T18:00:00.000Z",
+          sessionId: "session-1",
+          status: "response_ready",
+          type: "triage_update",
+        }),
+      ),
+    ).toEqual({
+      action: "chat",
+      generatedAt: "2026-05-29T18:00:00.000Z",
+      sessionId: "session-1",
+      status: "response_ready",
+      type: "triage_update",
+    });
+  });
+
+  it("rejects malformed or non-triage messages", () => {
+    expect(parseTriageLiveUpdate("{")).toBeNull();
+    expect(parseTriageLiveUpdate({ type: "chat_message" })).toBeNull();
+    expect(
+      parseTriageLiveUpdate({
+        action: "chat",
+        generatedAt: "2026-05-29T18:00:00.000Z",
+        rawSymptoms: "vomiting blood",
+        sessionId: "session-1",
+        status: "response_ready",
+        type: "triage_update",
+      }),
+    ).toBeNull();
+  });
+});

--- a/tests/webpubsub-live-updates.test.ts
+++ b/tests/webpubsub-live-updates.test.ts
@@ -1,5 +1,7 @@
 import { parseTriageLiveUpdate } from "@/components/symptom-checker/use-webpubsub-live-updates";
 
+const LIVE_SESSION_ID = "550e8400-e29b-41d4-a716-446655440000";
+
 describe("parseTriageLiveUpdate", () => {
   it("accepts metadata-only triage update JSON", () => {
     expect(
@@ -7,7 +9,7 @@ describe("parseTriageLiveUpdate", () => {
         JSON.stringify({
           action: "chat",
           generatedAt: "2026-05-29T18:00:00.000Z",
-          sessionId: "session-1",
+          sessionId: LIVE_SESSION_ID,
           status: "response_ready",
           type: "triage_update",
         }),
@@ -15,7 +17,7 @@ describe("parseTriageLiveUpdate", () => {
     ).toEqual({
       action: "chat",
       generatedAt: "2026-05-29T18:00:00.000Z",
-      sessionId: "session-1",
+      sessionId: LIVE_SESSION_ID,
       status: "response_ready",
       type: "triage_update",
     });
@@ -28,8 +30,17 @@ describe("parseTriageLiveUpdate", () => {
       parseTriageLiveUpdate({
         action: "chat",
         generatedAt: "2026-05-29T18:00:00.000Z",
+        sessionId: "owner-name-or-free-text",
+        status: "response_ready",
+        type: "triage_update",
+      }),
+    ).toBeNull();
+    expect(
+      parseTriageLiveUpdate({
+        action: "chat",
+        generatedAt: "2026-05-29T18:00:00.000Z",
         rawSymptoms: "vomiting blood",
-        sessionId: "session-1",
+        sessionId: LIVE_SESSION_ID,
         status: "response_ready",
         type: "triage_update",
       }),


### PR DESCRIPTION
## Summary
- Add feature-flagged Azure Web PubSub helper for short-lived browser negotiation and metadata-only triage status publication.
- Add authenticated no-store negotiate route and a browser connector/parser that fails back to the existing fetch flow.
- Pass a live session id from the symptom checker and publish only safe status metadata from symptom-chat.

## Safety / boundaries
- `azure.webpubsub.enabled` defaults off through App Configuration.
- Missing Key Vault secret or Azure failures disable the feature cleanly.
- Web PubSub connection string stays server-side; browser only receives a short-lived client URL.
- Payloads are IDs/status/action/timestamp only; no symptoms, owner text, pet names, coordinates, or secrets.
- Deterministic clinical logic is unchanged; fetch remains canonical.

## Verification
- `npx jest --runInBand --runTestsByPath tests/azure-web-pubsub.test.ts tests/azure-webpubsub-negotiate-route.test.ts tests/webpubsub-live-updates.test.ts` — 16/16 passed
- `npm test -- --runInBand --testPathPatterns=symptom-chat` — 584/584 passed
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- `npm run security:secrets`
- `npm audit --omit=dev`
- `npm run lint` — passed with 42 pre-existing warnings
- `npm run build`
- AutoScientists verify passed for `G:\MY Website\.agents\autoscientists\runs\az-011-web-pubsub-live-session-updates`

## Thermo-review verdict
Pass — blocking findings resolved: no secrets exposed, no WebSocket-only path, metadata-only payload, and protected route change kept to a small scheduling helper.