### PR TITLE
VET-1577C: recover threshold gate for Codex PR pushes

### DIFF
--- a/.github/workflows/threshold-review-gate.yml
+++ b/.github/workflows/threshold-review-gate.yml
@@ -6,6 +6,10 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
   pull_request_review:
     types: [submitted, dismissed, edited]
+  push:
+    branches:
+      - "codex/**"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -16,6 +20,8 @@ jobs:
     name: Threshold Review Gate
     runs-on: ubuntu-latest
     if: >
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.base.ref == 'master'
     env:
       THRESHOLD_ENGINEERING_REVIEWER: ${{ vars.THRESHOLD_ENGINEERING_REVIEWER || 'kandamukeshkumar4-cmyk' }}
@@ -25,13 +31,42 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const pr = context.payload.pull_request;
+            let pr = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+
             if (!pr) {
-              core.info("No pull request payload found; skipping.");
+              const branch = context.ref.replace(/^refs\/heads\//, "");
+              const matchingPulls = await github.paginate(github.rest.pulls.list, {
+                owner,
+                repo,
+                state: "open",
+                base: "master",
+                head: `${owner}:${branch}`,
+                per_page: 100,
+              });
+
+              if (matchingPulls.length === 0) {
+                await core.summary
+                  .addHeading("Threshold Review Gate", 2)
+                  .addRaw(`No open pull request to \`master\` found for branch \`${branch}\`. Gate skipped.`)
+                  .addEOL()
+                  .write();
+                return;
+              }
+
+              pr = matchingPulls[0];
+              core.info(`Resolved PR #${pr.number} from branch ${branch}.`);
+            }
+
+            if (pr.base.ref !== "master") {
+              await core.summary
+                .addHeading("Threshold Review Gate", 2)
+                .addRaw(`PR #${pr.number} targets \`${pr.base.ref}\`, not \`master\`. Gate skipped.`)
+                .addEOL()
+                .write();
               return;
             }
 
-            const { owner, repo } = context.repo;
             const protectedMatchers = [
               /^src\/lib\/threshold-proposals\.ts$/,
               /^src\/lib\/admin-threshold-proposals\.ts$/,


### PR DESCRIPTION
## Summary
- Adds a narrow recovery path to the required `Threshold Review Gate` workflow for Codex branch pushes and manual dispatches.
- Resolves the open PR targeting `master` from the branch before running the existing protected threshold-file approval logic.
- Skips cleanly when a branch push has no open PR to `master`.

## Verification
- Static workflow marker check passed: push/manual trigger and PR-resolution markers are present.
- `git diff --check` and `git diff --cached --check` passed.
- Staged diff contained only `.github/workflows/threshold-review-gate.yml`.
- Prohibited-surface diff was empty for runtime, package, deployment, env, schema, model, provider, plans, tests, and protected clinical surfaces.

## Current blocker
- PR #596 opened at `745a1173db546805afdedfe788677081cec2a93b`, but `statusCheckRollup=[]`.
- `gh run list --branch codex/vet-1579c-threshold-gate-recovery` returned no runs.
- Manual dispatch failed with `HTTP 422: Actions has been disabled for this user`.

## Safety
- No runtime routing changes.
- No provider calls.
- No Vercel env mutation.
- No Supabase schema mutation.
- No model flag changes.
- No protected clinical logic changes.
- This PR only proposes a GitHub Actions required-check harness recovery; it does not make public beta, product-intelligence production readiness, or model promotion GO.

## Status
- Workflow recovery branch: `GO_REVIEW_ONLY`.
- Merge: `HOLD` until Actions scheduling is restored and required checks attach/pass.
- Downstream PRs #591-#595: still `HOLD`, because required `Threshold Review Gate` context is absent.