### PR TITLE
docs(plans): add improve advisor execution plans (top 10)

### DIFF
--- a/plans/improve/00-index.md
+++ b/plans/improve/00-index.md
@@ -1,0 +1,109 @@
+# plans/improve — Index
+
+Executable improvement plans derived from the advisor audit + vetting pass. Each plan is self-contained, written for a small executor model with no session context, and stamped against the commit below.
+
+## Git commit stamp
+
+All plans written against HEAD:
+
+```
+19d15ac2fb919996212747653c1638aac08f90f1
+```
+
+Working tree was dirty at authoring time. Relevant dirty files (executors must read current file state, not assume the stamp):
+
+- `README.md` (Plan 08 edits its checklist; Plan 10 edits several sections)
+- `src/app/api/ai/outcome-feedback/route.ts` and `tests/outcome-feedback.route.test.ts` (Plan 09 reads these as-is; STOP if shape diverged)
+- Various landing/auth/marketing pages and `src/components/ui/button.tsx`, `src/app/globals.css`, etc. (unrelated; no plan touches them)
+- Untracked: `.claude/skills/`, `tmp/` (unrelated)
+
+## The plans
+
+| # | File | Title | Effort | Risk |
+|---|------|-------|--------|------|
+| 01 | `01-server-session-integrity-symptom-chat.md` | Server-side session integrity for `generate_report` + red-flag escalation | M | Highest-care plan; STOP on any ambiguity |
+| 02 | `02-body-size-cap-symptom-chat.md` | 10 MB capped JSON reader for symptom-chat (413) | S | Low |
+| 03 | `03-rate-limit-fail-closed-production.md` | In-process fallback limiter when Redis unset in production | S | Low-medium |
+| 04 | `04-auth-ratelimit-nearest-vets.md` | Auth + rate limit on `/api/azure/maps/nearest-vets` | S | Low (has a pre-flight STOP check) |
+| 05 | `05-server-bind-image-gate-override.md` | HMAC-bound `gateOverride` token | M | Medium |
+| 06 | `06-usage-gate-fail-closed.md` | Usage gate returns 503 on DB errors instead of granting | S | Low |
+| 07 | `07-batch-translator-calls.md` | Batch/parallelize 3 per-turn translator calls | S | Low |
+| 08 | `08-typecheck-script-and-build-gate.md` | `typecheck` script + attempt removing `ignoreBuildErrors` | S | Low (built-in fallback) |
+| 09 | `09-owner-outcome-feedback-loop.md` | Owner "did this match?" UI wired to existing outcome API | M | Low-medium (dirty-file caution) |
+| 10 | `10-docs-sync-readme-agents.md` | README/AGENTS factual drift corrections | S | Minimal (doc-only) |
+
+## Priority order
+
+Recommended execution order (security/cost exposure first, then quality-of-life, then docs):
+
+1. **01** server-session-integrity (clinical trust boundary)
+2. **02** body-size-cap (DoS on the main route)
+3. **05** image-gate override binding (gate bypass)
+4. **03** rate-limit fail-closed (prod cost exposure)
+5. **04** nearest-vets auth (metered API exposure)
+6. **06** usage-gate fail-closed (billing exposure)
+7. **08** typecheck script + build gate (independent, can run any time)
+8. **09** owner outcome feedback loop (product value)
+9. **07** translator batching (latency)
+10. **10** docs sync (do last so docs reflect any landed changes; Plan 08 also touches README — see dependencies)
+
+## Dependency graph
+
+```
+01 ─┐
+02 ─┼─ all edit src/app/api/ai/symptom-chat/route.ts → MUST run serially,
+05 ─┘  in any order, and EACH must re-run its drift check + re-locate its
+       anchor code before editing (line numbers shift after each lands)
+
+08 ── independent (package.json, next.config.ts, README checklist)
+03 ── independent (src/lib/rate-limit.ts)
+04 ── independent (nearest-vets route + its test)
+06 ── independent (usage-limit-gate.ts) — but shares the route's test suite
+       gate with 01/02/05; safe to run in parallel, serialize test runs
+07 ── independent (symptom-checker page UI + translator client)
+09 ── independent (report UI components + outcome-feedback test)
+       NOTE: 07 and 09 both may touch src/app/(dashboard)/symptom-checker/page.tsx
+       (07 edits it; 09 only reads it) — no conflict, but run 07's drift check after 09 if reordered
+
+08 → 10 : both edit README.md. Land 08 before 10 (10's greps then run
+          against the post-08 README). If 10 runs first, 08 must re-locate
+          the checklist by content (its plan already says to).
+01..09 → 10 : soft dependency — 10 documents current reality; running it
+          last avoids documenting state that plans 01–09 are about to change
+          (none of 10's items overlap the other plans' claims, so this is
+          ordering hygiene, not a hard block).
+```
+
+Hard rules:
+
+- **Plans 01, 02, 05 are serial** (same file: `src/app/api/ai/symptom-chat/route.ts`). After each lands, the next must re-verify drift: `git -C "G:\MY Website\pawvital-ai" diff --stat 19d15ac2fb919996212747653c1638aac08f90f1 -- src/app/api/ai/symptom-chat/route.ts` will be non-empty — that is expected; the executor must instead confirm its plan's quoted anchor code still exists (each plan names its search anchor) and that the previously-landed plans' diffs account for all changes.
+- **Plan 08 before Plan 10** (both edit README.md).
+- Every plan touching `src/app/api/ai/symptom-chat/route.ts` must pass `npm test -- --testPathPattern=symptom-chat` as a gate and restrict edits to the request-handling/validation layer.
+- Global boundary for ALL plans: `src/lib/triage-engine.ts`, `src/lib/clinical-matrix.ts`, `src/lib/symptom-memory.ts` contain deterministic clinical logic and must not be modified; no plan may alter clinical decision behavior.
+
+## Authoring corrections
+
+Discrepancies found while verifying the audit's citations against the real tree (plans were written to reality):
+
+1. **`uncertainty-routing.ts` path** — audit cited `src/lib/uncertainty-routing.ts`; the real path is `src/lib/clinical/uncertainty-routing.ts` (lines 174–204 confirmed). Plan 01 uses the correct path.
+2. **Red-flag escalation nuance (Plan 01)** — the route does re-derive flags from the *last* user message via `extractDeterministicEmergencyRedFlags` (route.ts:1841–1852) before escalating; the vulnerability is that it *merges* with and escalates on client-supplied `session.red_flags_triggered` regardless. Plan 01 describes the real merge-then-escalate code.
+3. **`DEVELOPMENT_ROADMAP.md` path** — audit cited repo-root `DEVELOPMENT_ROADMAP.md`; the real path is `plans/DEVELOPMENT_ROADMAP.md` (line 19 "NEEDS RECONCILIATION" confirmed). Plan 10 cites the correct path.
+4. **Lint reality (Plan 10, item F)** — re-verified live at authoring time: `npx eslint .` → `✖ 50 problems (0 errors, 50 warnings)`, dominated by `@typescript-eslint/no-unused-vars`. The audit's exact 46/4 breakdown was not re-counted; Plan 10 instructs the executor to re-run eslint and write the observed counts.
+5. **`symptom-check` cap constant location** — `MAX_REQUEST_BYTES = 32 * 1024` is at `symptom-check/route.ts:14` (not inside the 42–132 range); `readJsonBody` spans lines 54–132. Plan 02 quotes both accurately.
+6. **Azure maps route test exists** — `tests/azure-maps-route.test.ts` exists and already tests `POST /api/azure/maps/nearest-vets` (one auditor was right). Plan 04 extends it rather than creating a new file.
+7. **next.config comment staleness confirmed** — `rg "^export " src/app/api/ai/symptom-chat/route.ts` returns only `export async function POST` at line 1214, confirming the `ignoreBuildErrors` justification comment is stale (Plan 08).
+8. **README "Seven tables" claim** — the schema list correction (Plan 10 item D) also requires fixing the "Seven tables" count to whatever `supabase-schema.sql` actually contains; the audit didn't mention the count.
+
+## Files in this directory
+
+- `00-index.md` (this file)
+- `01-server-session-integrity-symptom-chat.md`
+- `02-body-size-cap-symptom-chat.md`
+- `03-rate-limit-fail-closed-production.md`
+- `04-auth-ratelimit-nearest-vets.md`
+- `05-server-bind-image-gate-override.md`
+- `06-usage-gate-fail-closed.md`
+- `07-batch-translator-calls.md`
+- `08-typecheck-script-and-build-gate.md`
+- `09-owner-outcome-feedback-loop.md`
+- `10-docs-sync-readme-agents.md`

--- a/plans/improve/01-server-session-integrity-symptom-chat.md
+++ b/plans/improve/01-server-session-integrity-symptom-chat.md
@@ -1,0 +1,262 @@
+# Plan 01 — Server-Side Session Integrity for symptom-chat `generate_report` and Red-Flag Escalation
+
+## Goal
+
+The `POST /api/ai/symptom-chat` route trusts the client-supplied `TriageSession` object. With `action: "generate_report"` a forged session can produce a full veterinary report without ever satisfying the deterministic readiness rule (`isReadyForDiagnosis`), and a forged `session.red_flags_triggered` array escalates the conversation to an emergency response without any supporting message content. This plan adds **server-side validation in the route's request-handling layer only**: before honoring `generate_report`, re-verify readiness by calling the existing deterministic function; before escalating on red flags, validate that client-supplied flags are supported by deterministic detection over the actual message history. No clinical logic is changed — the plan only *calls* existing deterministic functions, it does not reimplement or alter them.
+
+## Why
+
+This is a trust-boundary bug: the server's deterministic clinical gates can be bypassed entirely by a client that edits the session JSON. A malicious or buggy client can (a) generate authoritative-looking medical reports from empty interviews, and (b) trigger emergency escalation UI/telemetry at will. Both undermine the project's core invariant that "deterministic clinical logic remains the source of truth."
+
+## Git stamp
+
+Written against commit: `19d15ac2fb919996212747653c1638aac08f90f1`
+
+Drift check (run before starting):
+
+```bash
+git -C "G:\MY Website\pawvital-ai" diff --stat 19d15ac2fb919996212747653c1638aac08f90f1 -- src/app/api/ai/symptom-chat/route.ts src/lib/triage-engine.ts src/lib/clinical/uncertainty-routing.ts tests/symptom-chat.route.test.ts
+```
+
+If the output is non-empty for files this plan edits beyond what the plan describes, **STOP and report**.
+
+## Current state (real code, verified at the stamp commit)
+
+### 1. The route destructures and trusts the client session
+
+`src/app/api/ai/symptom-chat/route.ts` lines 1258–1270:
+
+```typescript
+    const body: RequestBody = await request.json();
+    const {
+      messages,
+      pet,
+      action,
+      session: clientSession,
+      liveSessionId,
+      image,
+      imageMeta,
+      gateOverride,
+    } = body;
+
+    let session = clientSession || createSession();
+```
+
+### 2. The `generate_report` path gates only on blocking-critical-info, never readiness
+
+`src/app/api/ai/symptom-chat/route.ts` lines 1318–1341:
+
+```typescript
+    if (action === "generate_report") {
+      const reportBlockingCriticalInfo = findReportBlockingCriticalInfo(session);
+      if (reportBlockingCriticalInfo) {
+        return await generateTerminalOutcomeReport({
+          session,
+          pet: effectivePet,
+          terminalOutcome: buildCannotAssessOutcome({
+            petName: pet.name || "your dog",
+            questionId: reportBlockingCriticalInfo.questionId,
+            questionText: reportBlockingCriticalInfo.questionText,
+          }),
+          verifiedUserId,
+        });
+      }
+
+      return await generateReport({
+        session,
+        pet: effectivePet,
+        messages,
+        image,
+        requestOrigin: new URL(request.url).origin,
+        verifiedUserId,
+      });
+    }
+```
+
+`findReportBlockingCriticalInfo` lives in `src/lib/clinical/uncertainty-routing.ts` lines 174–204 (NOTE: directory is `src/lib/clinical/`, not `src/lib/`):
+
+```typescript
+export function findReportBlockingCriticalInfo(
+  session: TriageSession
+): ReportBlockingCriticalInfoFinding | null {
+  for (const questionId of EMERGENCY_GRADE_CRITICAL_QUESTIONS) {
+    if (!isQuestionRelevantToCurrentSession(session, questionId)) {
+      continue;
+    }
+    ...
+  }
+
+  return null;
+}
+```
+
+### 3. The readiness rule exists but runs only on the chat path
+
+`src/app/api/ai/symptom-chat/route.ts` line 2691 (chat path only):
+
+```typescript
+    const ready = isReadyForDiagnosis(session);
+```
+
+The rule itself, `src/lib/triage-engine.ts` lines 927–951 (DO NOT MODIFY this file):
+
+```typescript
+export function isReadyForDiagnosis(session: TriageSession): boolean {
+  // Always ready if red flags are triggered
+  if (
+    session.red_flags_triggered.length > 0 ||
+    getCompositeEmergencyRedFlags(session).length > 0
+  ) {
+    return true;
+  }
+
+  // NEVER ready if no symptoms identified yet
+  if (session.known_symptoms.length === 0) return false;
+
+  // NEVER ready if fewer than 3 questions have been answered
+  // A real vet always asks at least a few follow-up questions
+  if (session.answered_questions.length < 3) return false;
+
+  // Check if all critical questions are answered
+  const missing = getMissingQuestions(session);
+  const criticalMissing = missing.filter((qId) => {
+    const qDef = FOLLOW_UP_QUESTIONS[qId];
+    return qDef?.critical;
+  });
+
+  return criticalMissing.length === 0;
+}
+```
+
+Note the first clause: `red_flags_triggered.length > 0` makes the session "ready" — so a forged red flag also forges readiness. Validation of red flags (step 2 below) must therefore happen **before** the readiness check.
+
+### 4. Red-flag escalation merges client-supplied flags and escalates on them
+
+`src/app/api/ai/symptom-chat/route.ts` lines 1841–1868. The route does re-derive flags from the **last** user message (`extractDeterministicEmergencyRedFlags`) but then escalates on the union including whatever the client already put in `session.red_flags_triggered`:
+
+```typescript
+    const directEmergencyFlags = extractDeterministicEmergencyRedFlags(
+      lastUserMessage.content,
+      session.known_symptoms
+    );
+    if (directEmergencyFlags.length > 0) {
+      session = {
+        ...session,
+        red_flags_triggered: Array.from(
+          new Set([...session.red_flags_triggered, ...directEmergencyFlags])
+        ),
+      };
+    }
+
+    if (session.red_flags_triggered.length > 0) {
+      session = transitionToEscalation({
+        session,
+        redFlags: session.red_flags_triggered,
+        reason: "deterministic_emergency_first_turn",
+      });
+
+      return NextResponse.json(
+        buildRedFlagEmergencyResponse({
+          petName: pet.name,
+          redFlags: session.red_flags_triggered,
+          session,
+        })
+      );
+    }
+```
+
+## Steps
+
+> Every edit in this plan lives in `src/app/api/ai/symptom-chat/route.ts` (request-handling/validation layer) and `tests/`. Calling existing exported functions from `src/lib/triage-engine.ts` is allowed; editing that file is FORBIDDEN.
+
+1. **Baseline.** Run the existing route tests to confirm a green start.
+   - Gate: `npm test -- --testPathPattern=symptom-chat` → all tests pass, exit 0. If any fail before you change anything, STOP and report.
+
+2. **Validate client-supplied red flags against the message history.** In `route.ts`, immediately after `let session = clientSession || createSession();` (line 1270), add a validation helper (defined near the other route-local helpers in the same file, NOT exported — the route must keep exporting only `POST`). The helper re-derives the set of red flags supported by the actual conversation: run `extractDeterministicEmergencyRedFlags(message.content, session.known_symptoms)` over every `role === "user"` message in `messages` (the same function the route already imports and uses at line 1841), union the results, and intersect `session.red_flags_triggered` with that derived set, e.g.:
+
+   ```typescript
+   function validateClientRedFlags(
+     session: TriageSession,
+     messages: { role: "user" | "assistant"; content: string }[]
+   ): TriageSession {
+     if (session.red_flags_triggered.length === 0) return session;
+     const derived = new Set<string>();
+     for (const m of messages) {
+       if (m.role !== "user") continue;
+       for (const flag of extractDeterministicEmergencyRedFlags(
+         m.content,
+         session.known_symptoms
+       )) {
+         derived.add(flag);
+       }
+     }
+     const validated = session.red_flags_triggered.filter((f) => derived.has(f));
+     if (validated.length === session.red_flags_triggered.length) return session;
+     console.warn(
+       `[session-integrity] Dropping ${session.red_flags_triggered.length - validated.length} client red flag(s) not supported by message history`
+     );
+     return { ...session, red_flags_triggered: validated };
+   }
+   ```
+
+   **AMBIGUITY CHECK before writing this:** inspect how `getCompositeEmergencyRedFlags(session)` (used by `isReadyForDiagnosis`) and any composite-flag writers populate `red_flags_triggered`. If you find code paths that legitimately add flags to `red_flags_triggered` that `extractDeterministicEmergencyRedFlags` over user messages can NOT reproduce (e.g. composite flags derived from `extracted_answers`, vision-derived flags), the simple intersection above would wrongly drop legitimate flags mid-conversation. In that case you MUST also accept flags reproducible from those deterministic sources (call the same deterministic functions over the session's answers), or — if you cannot enumerate the legitimate sources with certainty — **STOP and report the ambiguity instead of guessing**.
+   - Gate: `npx tsc --noEmit` → exit 0, no output.
+
+3. **Apply the validation before both consumers.** Call `session = validateClientRedFlags(session, messages);` once, after line 1270 (after `let session = ...`) and before the `action === "generate_report"` branch at line 1318, so both the report path and the chat escalation path (line 1854) see only validated flags.
+   - Gate: `npm test -- --testPathPattern=symptom-chat` → all existing tests still pass. If a previously passing test now fails, your validation dropped a legitimate flag — STOP, revert step 3, and report which test and which flag.
+
+4. **Enforce readiness on `generate_report`.** Inside the `if (action === "generate_report")` block, after the existing `findReportBlockingCriticalInfo` check (keep it — it must stay first so terminal "cannot assess" outcomes are unchanged), and before `return await generateReport(...)`, add:
+
+   ```typescript
+   if (!isReadyForDiagnosis(session)) {
+     statusCode = 409;
+     return NextResponse.json(
+       {
+         error: "Session is not ready for report generation",
+         code: "SESSION_NOT_READY",
+         ready_for_report: false,
+       },
+       { status: 409 }
+     );
+   }
+   ```
+
+   `isReadyForDiagnosis` is already imported by the route (it is used at line 2691) — verify the import exists; if not, add it to the existing `@/lib/triage-engine` import.
+
+   **AMBIGUITY CHECK:** Before adding this, search the client (`src/app/(dashboard)/symptom-checker/page.tsx`) for how `generate_report` is invoked. The legitimate client only calls `generate_report` after receiving `ready_for_report: true` from the chat path (which implies `isReadyForDiagnosis` returned true server-side) or after an emergency/terminal response. If you find a legitimate client flow that calls `generate_report` on a session where `isReadyForDiagnosis(session)` is false AND `findReportBlockingCriticalInfo(session)` is null (e.g. emergency summaries on first turn — note `isReadyForDiagnosis` returns true when red flags are present, so genuine emergencies pass), **STOP and report** — do not weaken the check to make it fit.
+   - Gate: `npx tsc --noEmit` → exit 0, no output.
+   - Gate: `npm test -- --testPathPattern=symptom-chat` → all existing tests pass. If an existing test legitimately generates a report from a not-ready session, that is exactly the ambiguity above — STOP and report it; do not edit the test to pass.
+
+5. **Add regression tests.** Extend `tests/symptom-chat.route.test.ts` (the existing route test file — follow its mocking and request-building patterns) with at least:
+   - *Forged-session report rejected*: POST with `action: "generate_report"` and a session with `known_symptoms: []`, `answered_questions: []`, `red_flags_triggered: []` → expect HTTP 409 and `code: "SESSION_NOT_READY"`, and assert the report-generation model call was NOT made.
+   - *Injected red flags do not escalate*: POST with `action: "chat"`, a benign message history (e.g. single user message "my dog seems a little tired"), and a session whose `red_flags_triggered` contains a real flag id copied from `extractDeterministicEmergencyRedFlags`'s source — expect the response NOT to be the emergency type, and the returned session's `red_flags_triggered` not to contain the injected flag.
+   - *Genuine red flag still escalates* (no regression): a user message that deterministically triggers a red flag (copy an input already used by an existing emergency test in this file or in `tests/clinical-intelligence/emergency-sentinel.test.ts`) → emergency response still returned.
+   - Gate: `npm test -- --runTestsByPath tests/symptom-chat.route.test.ts` → all pass.
+
+6. **Full gate.**
+   - Gate: `npm test -- --testPathPattern=symptom-chat` → all pass.
+   - Gate: `npx tsc --noEmit` → exit 0, no output.
+   - Gate: `npx eslint src/app/api/ai/symptom-chat/route.ts tests/symptom-chat.route.test.ts` → 0 errors (warnings allowed; repo baseline has 50 warnings / 0 errors).
+
+## Repo conventions
+
+- Package manager: npm. Tests: Jest 30 via ts-jest (CJS, `useESM: false`), `@/` maps to `./src/`, test environment `node`.
+- ESLint 9 flat config; run `npx eslint <file>`.
+- Route test exemplar: `tests/symptom-chat.route.test.ts` (mocks module dependencies with `jest.mock`, builds `Request` objects directly, dynamic-imports the route).
+- The route file must keep exporting only `POST` (verified: the only `export` in route.ts is `export async function POST` at line 1214). Adding another export breaks Next.js route-export validation (see comment in `next.config.ts:54-56`).
+
+## Out of scope
+
+- ANY edit to `src/lib/triage-engine.ts`, `src/lib/clinical-matrix.ts`, `src/lib/symptom-memory.ts`, `src/lib/clinical/uncertainty-routing.ts` — deterministic clinical logic is the source of truth and must not change.
+- Changing what `findReportBlockingCriticalInfo` blocks, changing question criticality, changing red-flag definitions.
+- Server-side session persistence / signing (a larger architectural fix; not this plan).
+- Body-size caps (Plan 02) and gate-override binding (Plan 05) — same file; coordinate via the index's serialization order.
+
+## STOP conditions
+
+- The quoted code is not found at (or near) the stated lines in `route.ts`, `triage-engine.ts`, or `uncertainty-routing.ts`.
+- The drift check shows changes to `route.ts` you did not make.
+- Any existing symptom-chat test fails for a reason you cannot trace directly to your added validation.
+- You discover legitimate red-flag sources that user-message re-derivation cannot reproduce and cannot enumerate them with certainty (step 2 ambiguity check).
+- You discover a legitimate client flow that calls `generate_report` on a not-ready session (step 4 ambiguity check).
+- The fix would require modifying any clinical file. **Any behavior ambiguity at all = STOP and report; do not guess.**

--- a/plans/improve/02-body-size-cap-symptom-chat.md
+++ b/plans/improve/02-body-size-cap-symptom-chat.md
@@ -1,0 +1,211 @@
+# Plan 02 — Request Body Size Cap for symptom-chat
+
+## Goal
+
+`POST /api/ai/symptom-chat` reads its body with a bare `await request.json()` and its payload includes an optional base64 `image` field, so an attacker (or a buggy client) can post arbitrarily large bodies that are buffered and parsed before any size check. Sibling routes already solve this: `symptom-check` has a streaming capped JSON reader (32 KB cap) and `async-review` caps at 10 MB because it also carries base64 images. This plan introduces a capped JSON reader for symptom-chat with a 10 MB limit (sized for legitimate image payloads, matching async-review), returning HTTP 413 consistent with the siblings.
+
+## Why
+
+Unbounded body parsing is a memory-exhaustion / DoS vector on the busiest AI route in the app. The fix is mechanical and the pattern already exists twice in the codebase.
+
+## Git stamp
+
+Written against commit: `19d15ac2fb919996212747653c1638aac08f90f1`
+
+Drift check (run before starting):
+
+```bash
+git -C "G:\MY Website\pawvital-ai" diff --stat 19d15ac2fb919996212747653c1638aac08f90f1 -- src/app/api/ai/symptom-chat/route.ts src/app/api/ai/symptom-check/route.ts src/app/api/ai/async-review/route.ts tests/symptom-chat.route.test.ts
+```
+
+If the output is non-empty for files this plan edits beyond what the plan describes, **STOP and report**. (Note: if Plan 01 or Plan 05 already landed, `route.ts` will show their diffs — read the current file and confirm line 1258's bare `await request.json()` is still present before proceeding.)
+
+## Current state (real code, verified at the stamp commit)
+
+### 1. symptom-chat parses without a cap
+
+`src/app/api/ai/symptom-chat/route.ts` line 1258:
+
+```typescript
+    const body: RequestBody = await request.json();
+```
+
+The payload can carry a base64 image — `route.ts` lines 196–205:
+
+```typescript
+interface RequestBody {
+  messages: { role: "user" | "assistant"; content: string }[];
+  pet: PetProfile;
+  action: "chat" | "generate_report";
+  session?: TriageSession;
+  liveSessionId?: string;
+  image?: string; // base64 image data (with or without data URL prefix)
+  imageMeta?: ImageMeta;
+  gateOverride?: boolean;
+}
+```
+
+### 2. Exemplar: symptom-check's capped streaming reader
+
+`src/app/api/ai/symptom-check/route.ts` line 14:
+
+```typescript
+const MAX_REQUEST_BYTES = 32 * 1024;
+```
+
+And lines 54–105 (the core of the pattern to copy; full function spans 54–132):
+
+```typescript
+async function readJsonBody<T>(
+  request: Request,
+  maxBytes: number
+): Promise<BodyParseResult<T>> {
+  const declaredLength = Number(request.headers.get("content-length") ?? "");
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    return {
+      ok: false,
+      response: jsonError(
+        "Request body too large",
+        413,
+        "PAYLOAD_TOO_LARGE"
+      ),
+    };
+  }
+
+  const reader = request.body?.getReader();
+  if (!reader) {
+    return {
+      ok: false,
+      response: jsonError("Request body is required", 400, "INVALID_JSON"),
+    };
+  }
+
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (!value) {
+        continue;
+      }
+
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBytes) {
+        try {
+          await reader.cancel();
+        } catch {}
+
+        return {
+          ok: false,
+          response: jsonError(
+            "Request body too large",
+            413,
+            "PAYLOAD_TOO_LARGE"
+          ),
+        };
+      }
+
+      chunks.push(value);
+    }
+  } catch { ... }
+  ...
+}
+```
+
+It is used at `symptom-check/route.ts` line 160:
+
+```typescript
+  const parsedBody = await readJsonBody<unknown>(request, MAX_REQUEST_BYTES);
+```
+
+### 3. Exemplar limit for image-bearing routes: async-review
+
+`src/app/api/ai/async-review/route.ts` lines 14–15:
+
+```typescript
+const MAX_CONTENT_LENGTH_BYTES = 10 * 1024 * 1024;
+const MAX_IMAGE_PAYLOAD_LENGTH = 8 * 1024 * 1024;
+```
+
+And lines 54–57:
+
+```typescript
+function hasOversizedContentLength(request: Request): boolean {
+  const contentLength = Number(request.headers.get("content-length") || "");
+  return Number.isFinite(contentLength) && contentLength > MAX_CONTENT_LENGTH_BYTES;
+}
+```
+
+**Limit justification:** async-review accepts the same kind of base64 image (`MAX_IMAGE_PAYLOAD_LENGTH = 8 MB` of base64 ≈ 6 MB raw image) plus a session and report, inside a 10 MB total body. symptom-chat carries an image plus messages, pet, and session — the same envelope. Use **10 MB** (`10 * 1024 * 1024`).
+
+### 4. The triplicated helper (stretch goal context)
+
+`readJsonBody` is duplicated in three routes (verified by grep): `src/app/api/ai/health-score/route.ts`, `src/app/api/ai/supplements/route.ts`, `src/app/api/ai/symptom-check/route.ts`.
+
+## Steps
+
+1. **Baseline.**
+   - Gate: `npm test -- --testPathPattern=symptom-chat` → all pass, exit 0.
+
+2. **Add the capped reader to symptom-chat.** In `src/app/api/ai/symptom-chat/route.ts`, add a module-level constant `const MAX_REQUEST_BYTES = 10 * 1024 * 1024;` and copy the `readJsonBody`/`decodeUtf8`/`BodyParseResult`/`jsonError` pattern from `src/app/api/ai/symptom-check/route.ts:38-132` as route-local (non-exported) helpers. Do NOT add new exports to this file (the route must keep exporting only `POST`, see `next.config.ts:54-56` comment).
+   - Gate: `npx tsc --noEmit` → exit 0, no output.
+
+3. **Replace the bare parse.** Replace line 1258:
+
+   ```typescript
+   const body: RequestBody = await request.json();
+   ```
+
+   with:
+
+   ```typescript
+   const parsedBody = await readJsonBody<RequestBody>(request, MAX_REQUEST_BYTES);
+   if (!parsedBody.ok) {
+     statusCode = parsedBody.response.status;
+     return parsedBody.response;
+   }
+   const body = parsedBody.value;
+   ```
+
+   (The route tracks `statusCode` for telemetry — keep that assignment; see line 1223 `let statusCode = 200;`.)
+   - Gate: `npx tsc --noEmit` → exit 0, no output.
+   - Gate: `npm test -- --testPathPattern=symptom-chat` → all existing tests pass. If existing tests post bodies without a readable stream and now fail with 400, check how `tests/symptom-chat.route.test.ts` builds requests (`new Request(url, { body: JSON.stringify(...) })` produces a readable body — this works with the streaming reader; `tests/azure-maps-route.test.ts` uses the same construction against a streaming parse). If failures persist for unrelated reasons, STOP and report.
+
+4. **Add oversize regression tests** to `tests/symptom-chat.route.test.ts`:
+   - POST with header `content-length` greater than 10 MB → expect 413 and `code: "PAYLOAD_TOO_LARGE"` (mirror the request-building style of the existing tests in that file).
+   - POST with an actual body string larger than 10 MB (e.g. `JSON.stringify({ image: "a".repeat(10 * 1024 * 1024 + 1), ... })`) without a content-length header → expect 413.
+   - A normal small chat request still succeeds (reuse an existing happy-path test as proof — no new test needed if one exists).
+   - Gate: `npm test -- --runTestsByPath tests/symptom-chat.route.test.ts` → all pass.
+
+5. **(OPTIONAL stretch goal — skip if anything is unclear.)** Extract the shared reader into `src/lib/http-body.ts` exporting `readJsonBody` + `MAX`-agnostic types, and update the three duplicates (`health-score`, `supplements`, `symptom-check`) plus symptom-chat to import it. Only do this if all three duplicates are byte-for-byte the same logic; if they have diverged, skip this step entirely and note that in your handoff.
+   - Gate (only if done): `npm test` → full suite passes; `npx tsc --noEmit` → exit 0.
+
+6. **Full gate.**
+   - Gate: `npm test -- --testPathPattern=symptom-chat` → all pass.
+   - Gate: `npx tsc --noEmit` → exit 0, no output.
+   - Gate: `npx eslint src/app/api/ai/symptom-chat/route.ts` → 0 errors.
+
+## Repo conventions
+
+- npm; Jest 30 via ts-jest CJS; `@/` → `./src/`; node test environment; ESLint 9 flat config.
+- Capped body parsing exemplar: `src/app/api/ai/symptom-check/route.ts:42-132`.
+- Image-payload limit exemplar: `src/app/api/ai/async-review/route.ts:14-15, 54-60`.
+- Route test exemplar: `tests/symptom-chat.route.test.ts`.
+
+## Out of scope
+
+- `src/lib/triage-engine.ts`, `src/lib/clinical-matrix.ts`, `src/lib/symptom-memory.ts` — no clinical changes. This plan touches only the body-parsing lines at the very top of the request-handling layer.
+- Changing the 32 KB cap of symptom-check or the 10 MB cap of async-review.
+- Per-field image size validation (async-review's `MAX_IMAGE_PAYLOAD_LENGTH` analog) — acceptable follow-up, not required here.
+- Plans 01 and 05 edit the same file — execute serially per the index.
+
+## STOP conditions
+
+- Line 1258 no longer contains the bare `await request.json()` (someone fixed or moved it) — re-assess and report.
+- The drift check shows unexplained changes to files this plan edits.
+- Any symptom-chat test fails for a reason unrelated to body parsing.
+- The change would require touching clinical files or altering response shapes beyond the new 413/400 parse errors.

--- a/plans/improve/03-rate-limit-fail-closed-production.md
+++ b/plans/improve/03-rate-limit-fail-closed-production.md
@@ -1,0 +1,156 @@
+# Plan 03 — Rate Limiting Must Not Fail Open in Production
+
+## Goal
+
+`checkRateLimit` in `src/lib/rate-limit.ts` returns unconditional success when a limiter is `null`, and every limiter is `null` whenever the Upstash env vars are unset — including in production. The library already contains a working in-process fallback limiter (`runLocalFallbackLimiter`) with per-scope configs registered via `registerFallbackConfig`, but today that fallback only engages when Redis is configured *and* errors at call time. This plan makes the production-with-no-Redis case use the in-process fallback limiter instead of granting unlimited requests, while keeping dev/demo (non-production) behavior exactly as permissive as today.
+
+## Why
+
+A production deployment that forgets (or loses) `UPSTASH_REDIS_REST_URL`/`UPSTASH_REDIS_REST_TOKEN` silently runs with **zero** rate limiting on every AI route — cost exposure and abuse exposure with no signal. The fix reuses code that already exists and is already tested.
+
+## Git stamp
+
+Written against commit: `19d15ac2fb919996212747653c1638aac08f90f1`
+
+Drift check (run before starting):
+
+```bash
+git -C "G:\MY Website\pawvital-ai" diff --stat 19d15ac2fb919996212747653c1638aac08f90f1 -- src/lib/rate-limit.ts tests/rate-limit.test.ts tests/rate-limit-failover-harness.test.ts
+```
+
+If the output is non-empty for files this plan edits beyond what the plan describes, **STOP and report**.
+
+## Current state (real code, verified at the stamp commit)
+
+### 1. Limiters are null when Upstash env is unset
+
+`src/lib/rate-limit.ts` lines 10–23:
+
+```typescript
+const redisUrl = process.env.UPSTASH_REDIS_REST_URL?.trim();
+const redisToken = process.env.UPSTASH_REDIS_REST_TOKEN?.trim();
+
+const isConfigured =
+  !!redisUrl &&
+  !!redisToken &&
+  redisUrl.startsWith("https://");
+
+const redis = isConfigured
+  ? new Redis({
+      url: redisUrl!,
+      token: redisToken!,
+    })
+  : null;
+```
+
+Each limiter passes `null` through when `redis` is null — e.g. lines 64–79:
+
+```typescript
+/** Symptom chat: 30 requests per minute per user */
+export const symptomChatLimiter = registerFallbackConfig(
+  redis
+    ? new Ratelimit({
+        redis,
+        limiter: Ratelimit.slidingWindow(30, "1 m"),
+        prefix: "rl:symptom-chat",
+        analytics: true,
+      })
+    : null,
+  {
+    limit: 30,
+    scope: "symptom-chat",
+    windowMs: DEFAULT_FALLBACK_WINDOW_MS,
+  }
+);
+```
+
+Note: `registerFallbackConfig` (lines 44–52) only records the config when the limiter object exists:
+
+```typescript
+function registerFallbackConfig<T extends object>(
+  limiter: T | null,
+  config: RateLimitFallbackConfig
+): T | null {
+  if (limiter) {
+    limiterFallbackConfigs.set(limiter, config);
+  }
+  return limiter;
+}
+```
+
+(`limiterFallbackConfigs` is a `WeakMap<object, ...>` — line 41 — so it cannot key on `null`. The unconfigured path therefore cannot reuse the WeakMap as-is; see step 2.)
+
+### 2. The fail-open line
+
+`src/lib/rate-limit.ts` lines 202–206:
+
+```typescript
+export async function checkRateLimit(
+  limiter: Ratelimit | null,
+  identifier: string
+): Promise<RateLimitResult> {
+  if (!limiter) return { success: true }; // No-op in dev/demo
+```
+
+### 3. The existing in-process fallback (already engaged on Redis call-time errors)
+
+`src/lib/rate-limit.ts` lines 162–200 (`runLocalFallbackLimiter`) — counts per `scope:identifier` in a module-level `Map`, enforces `config.limit` per `config.windowMs`, returns `{ success: false, reset, remaining: 0 }` when exceeded and `{ success: true, degraded: true, reason: "redis_unavailable" }` otherwise.
+
+### 4. Existing tests that must keep passing
+
+- `tests/rate-limit.test.ts`
+- `tests/rate-limit-failover-harness.test.ts`
+
+There is also a harness script: `npm run verify:rate-limit:failover` (package.json: `"verify:rate-limit:failover": "node scripts/run-rate-limit-failover-harness.cjs"`).
+
+## Steps
+
+1. **Baseline.**
+   - Gate: `npm test -- --runTestsByPath tests/rate-limit.test.ts tests/rate-limit-failover-harness.test.ts` → all pass, exit 0.
+
+2. **Make the unconfigured-production path use the local fallback.** Because limiters are `null` when unconfigured, the per-scope config must be reachable without a limiter object. The smallest change consistent with the existing structure:
+   - Change `registerFallbackConfig` callers' data flow so that the scope config is recoverable for null limiters. Recommended approach: keep the existing API but additionally key configs by **scope name** in a plain `Map<string, RateLimitFallbackConfig>` populated inside `registerFallbackConfig` regardless of whether `limiter` is null, and change `checkRateLimit`'s signature usage so the null-limiter path can find a config. Since `checkRateLimit(limiter, identifier)` receives only the (null) limiter, the cleanest mechanical option is to have `registerFallbackConfig` return a sentinel: when `limiter` is null **and** `process.env.NODE_ENV === "production"`, you cannot decide at module load time in a testable way — so instead implement the decision inside `checkRateLimit`:
+
+   ```typescript
+   if (!limiter) {
+     if (process.env.NODE_ENV === "production") {
+       logRateLimitNotConfiguredOnce(); // one-time console.warn, copy the throttle pattern of logRateLimitFailure (lines 138-152)
+       return runLocalFallbackLimiterForScope(identifier);
+     }
+     return { success: true }; // No-op in dev/demo
+   }
+   ```
+
+   where `runLocalFallbackLimiterForScope` reuses the body of `runLocalFallbackLimiter` with a default config (`DEFAULT_FALLBACK_LIMIT = 30`, `DEFAULT_FALLBACK_WINDOW_MS = 60_000`, scope `"default"` — these constants already exist at lines 26–27). Per-scope precision for null limiters is a nice-to-have; if wiring per-scope configs through requires changing every route's call signature, use the default config and note it. Do NOT change `checkRateLimit`'s public signature — 15+ routes call it.
+   - Gate: `npx tsc --noEmit` → exit 0, no output.
+
+3. **Add tests for the prod-unset path** in `tests/rate-limit.test.ts` (follow its existing patterns for module isolation — it likely uses `jest.isolateModules`/`jest.resetModules` with env manipulation; read the file first and copy its approach):
+   - With `NODE_ENV=production` and Upstash env unset: calling `checkRateLimit(null-limiter, "user-1")` more than the default limit (30) times within the window → the 31st call returns `success: false`.
+   - With `NODE_ENV=test` (or anything non-production) and Upstash unset: unlimited calls still return `success: true` (preserves dev/demo behavior).
+   - Gate: `npm test -- --runTestsByPath tests/rate-limit.test.ts` → all pass.
+
+4. **Regression gates.**
+   - Gate: `npm test -- --runTestsByPath tests/rate-limit.test.ts tests/rate-limit-failover-harness.test.ts` → all pass.
+   - Gate: `npm test -- --testPathPattern=symptom-chat` → all pass (the chat route calls `checkRateLimit` first; Jest runs with `NODE_ENV=test`, so behavior there must be unchanged).
+   - Gate: `npx tsc --noEmit` → exit 0, no output.
+   - Gate: `npx eslint src/lib/rate-limit.ts tests/rate-limit.test.ts` → 0 errors.
+
+## Repo conventions
+
+- npm; Jest 30 via ts-jest CJS; `@/` → `./src/`; node test environment; ESLint 9 flat config.
+- Exemplar for env-sensitive module testing: read `tests/rate-limit.test.ts` and `tests/rate-limit-failover-harness.test.ts` first and mirror their setup (they already exercise the fallback path).
+- One-time-warn throttle exemplar: `logRateLimitFailure`, `src/lib/rate-limit.ts:138-152`.
+
+## Out of scope
+
+- Changing limiter quotas (30/10/60/20 per minute) or Upstash configuration.
+- Fail-closed hard 429 when unconfigured (the chosen design is the in-process fallback, which is strictly safer than today and doesn't brick a misconfigured prod deploy).
+- The usage/billing gate (Plan 06) — different module.
+- Clinical files — untouched.
+
+## STOP conditions
+
+- The quoted code is not found at the stated lines in `src/lib/rate-limit.ts`.
+- Existing rate-limit tests fail before any change, or fail after the change for reasons you cannot trace to the new prod-unset branch.
+- The change cannot be made without altering `checkRateLimit`'s signature (would force edits across many routes) — report instead.
+- Jest in this repo turns out to run with `NODE_ENV=production` somewhere (would silently activate the fallback in unrelated tests) — verify, and if so STOP and report.

--- a/plans/improve/04-auth-ratelimit-nearest-vets.md
+++ b/plans/improve/04-auth-ratelimit-nearest-vets.md
@@ -1,0 +1,207 @@
+# Plan 04 — Add Auth + Rate Limit to /api/azure/maps/nearest-vets
+
+## Goal
+
+`POST /api/azure/maps/nearest-vets` is the only Azure-backed route with neither authentication nor rate limiting — any anonymous caller can burn Azure Maps quota. Sibling Azure routes use `requireAuthenticatedApiUser` plus a per-user rate limit (exemplar: `speech-token`). This plan applies the identical pattern to nearest-vets, after verifying the only client (`NearestVetFinder`, rendered on emergency reports) sends authenticated same-origin requests so no client change is needed.
+
+## Why
+
+Unauthenticated, unthrottled access to a metered third-party API (Azure Maps) is direct cost exposure and a free proxy for vet-clinic lookups.
+
+## Git stamp
+
+Written against commit: `19d15ac2fb919996212747653c1638aac08f90f1`
+
+Drift check (run before starting):
+
+```bash
+git -C "G:\MY Website\pawvital-ai" diff --stat 19d15ac2fb919996212747653c1638aac08f90f1 -- src/app/api/azure/maps/nearest-vets/route.ts src/components/symptom-report/nearest-vet-finder.tsx src/components/symptom-report/full-report.tsx tests/azure-maps-route.test.ts
+```
+
+If the output is non-empty for files this plan edits beyond what the plan describes, **STOP and report**. (`full-report.tsx` is read-only context here; note it may be dirty from unrelated landing-page work in the working tree — only its `NearestVetFinder` usage matters.)
+
+## Current state (real code, verified at the stamp commit)
+
+### 1. The unprotected route (full handler)
+
+`src/app/api/azure/maps/nearest-vets/route.ts` lines 17–42:
+
+```typescript
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonNoStore(
+      { clinics: [], enabled: false, reason: "invalid_location" },
+      400
+    );
+  }
+
+  const record = body && typeof body === "object" ? body : {};
+  const location = record as { latitude?: unknown; longitude?: unknown };
+  const latitude = asNumber(location.latitude);
+  const longitude = asNumber(location.longitude);
+  if (latitude === null || longitude === null) {
+    return jsonNoStore(
+      { clinics: [], enabled: false, reason: "invalid_location" },
+      400
+    );
+  }
+
+  const result = await findNearestEmergencyVets({ latitude, longitude });
+  const status = !result.enabled && result.reason === "invalid_location" ? 400 : 200;
+  return jsonNoStore(result, status);
+}
+```
+
+### 2. The exemplar pattern to copy: speech-token
+
+`src/app/api/azure/speech-token/route.ts` lines 39–63:
+
+```typescript
+export async function GET(request: Request) {
+  const auth = await requireAuthenticatedApiUser({
+    demoMessage: "Speech input is unavailable in demo mode",
+  });
+  if ("response" in auth) {
+    return auth.response;
+  }
+
+  const rateLimitResult = await checkRateLimit(
+    generalApiLimiter,
+    getRateLimitId(request, auth.user.id)
+  );
+  if (!rateLimitResult.success) {
+    return jsonNoStore(
+      { error: "Too many requests. Please slow down." },
+      {
+        headers: {
+          "Retry-After": String(
+            Math.max(1, Math.ceil((rateLimitResult.reset - Date.now()) / 1000))
+          ),
+        },
+        status: 429,
+      }
+    );
+  }
+```
+
+The auth helper, `src/lib/api-auth.ts` lines 17–20:
+
+```typescript
+export async function requireAuthenticatedApiUser(input?: {
+  demoMessage?: string;
+  unauthenticatedMessage?: string;
+}): Promise<AuthenticatedApiContext> {
+```
+
+It returns `{ response }` (503 `DEMO_MODE` when Supabase is unconfigured, 401 when unauthenticated, 500 on client-creation error) or `{ supabase, user }`.
+
+### 3. The only client — sends plain same-origin fetch (cookies included by default)
+
+`src/components/symptom-report/nearest-vet-finder.tsx` lines 52–63:
+
+```typescript
+  const lookupClinics = async (coords: GeolocationCoordinates) => {
+    setState("loading");
+    setMessage(null);
+    try {
+      const response = await fetch("/api/azure/maps/nearest-vets", {
+        body: JSON.stringify({
+          latitude: coords.latitude,
+          longitude: coords.longitude,
+        }),
+        headers: { "Content-Type": "application/json" },
+        method: "POST",
+      });
+```
+
+And the component gracefully hides itself when the API reports unavailability — lines 42–44 and 65–69:
+
+```typescript
+function shouldHideUnavailable(reason: MapsUnavailableReason): boolean {
+  return reason === "feature_disabled" || reason === "not_configured";
+}
+...
+      if (!data.enabled) {
+        if (shouldHideUnavailable(data.reason)) {
+          setHidden(true);
+          return;
+        }
+```
+
+### 4. Where the component renders (auth-context check)
+
+`src/components/symptom-report/full-report.tsx` line 243:
+
+```tsx
+          report.severity === "emergency") && <NearestVetFinder />}
+```
+
+`FullReport` is rendered in three places (verified by grep): the dashboard symptom-checker page, the dashboard history page, and any **shared report** surface. The shared-report surface is the risk: it may render for unauthenticated viewers. `FullReport` has a `readOnlyShared` prop (`full-report.tsx:43-44`: `/** Public shared view: hide owner-only UI */`). **You must check whether `<NearestVetFinder />` at line 243 is inside a `readOnlyShared` guard.** If the shared/public report view can render `NearestVetFinder` for an unauthenticated viewer, adding 401 to the route changes user-visible behavior — STOP and report (see STOP conditions).
+
+### 5. Existing tests to extend (do not duplicate)
+
+`tests/azure-maps-route.test.ts` exists and tests this exact route — lines 12–37:
+
+```typescript
+describe("POST /api/azure/maps/nearest-vets", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("returns no-store invalid_location for malformed JSON", async () => {
+    const { POST } = await import(
+      "@/app/api/azure/maps/nearest-vets/route"
+    );
+    ...
+```
+
+There is also `tests/azure-maps.test.ts` (the `findNearestEmergencyVets` lib — not touched) and `tests/nearest-vet-finder.test.ts` (the component — not touched unless behavior changes). An auth+rate-limit route-test exemplar exists at `tests/azure-speech-token.route.test.ts`.
+
+## Steps
+
+1. **Verify the unauthenticated-context question.** Open `src/components/symptom-report/full-report.tsx`, locate line 243 and determine whether `<NearestVetFinder />` renders when `readOnlyShared` is true; also grep for any shared/public page rendering `FullReport` (e.g. `rg "FullReport" src/app --glob "*.tsx"` and check any `share` route). If `NearestVetFinder` can render for an unauthenticated viewer, **STOP and report** — do not proceed to gate the API.
+   - Gate: write down the verdict (file + line proving it) in your handoff notes.
+
+2. **Baseline.**
+   - Gate: `npm test -- --runTestsByPath tests/azure-maps-route.test.ts tests/azure-speech-token.route.test.ts tests/nearest-vet-finder.test.ts` → all pass, exit 0.
+
+3. **Apply the pattern.** Edit `src/app/api/azure/maps/nearest-vets/route.ts`: at the top of `POST`, before body parsing, add the auth block and rate-limit block copied from `speech-token/route.ts:39-63`, adapted:
+   - `requireAuthenticatedApiUser({ demoMessage: "Nearby vet lookup is unavailable in demo mode" })` — but note this route's contract returns `{ clinics: [], enabled: false, reason }` envelopes that the client uses to hide itself. To preserve graceful client behavior in demo mode, map the DEMO_MODE case to the route's own envelope: when auth returns the 503 demo response, instead return `jsonNoStore({ clinics: [], enabled: false, reason: "not_configured" }, 200)` so `shouldHideUnavailable` hides the widget (this matches the component contract quoted above). For the plain unauthenticated case, return the helper's 401 response as-is.
+   - Rate limit with `generalApiLimiter` and `getRateLimitId(request, auth.user.id)` (imports from `@/lib/rate-limit` mirroring speech-token's import block).
+   - Gate: `npx tsc --noEmit` → exit 0, no output.
+
+4. **Extend `tests/azure-maps-route.test.ts`** (extend — do not create a duplicate file). Following the mock style of `tests/azure-speech-token.route.test.ts` (read it first), add:
+   - Unauthenticated request → 401, and `findNearestEmergencyVets` NOT called.
+   - Demo mode (Supabase unconfigured / `DEMO_MODE` thrown) → 200 with `{ clinics: [], enabled: false, reason: "not_configured" }`, helper NOT called.
+   - Rate-limited request (mock `checkRateLimit` failure) → 429 with `Retry-After` header.
+   - Existing happy-path tests updated to mock an authenticated user + passing rate limit so they still pass.
+   - Gate: `npm test -- --runTestsByPath tests/azure-maps-route.test.ts` → all pass.
+
+5. **Full gate.**
+   - Gate: `npm test -- --runTestsByPath tests/azure-maps-route.test.ts tests/nearest-vet-finder.test.ts tests/azure-speech-token.route.test.ts` → all pass.
+   - Gate: `npx tsc --noEmit` → exit 0, no output.
+   - Gate: `npx eslint src/app/api/azure/maps/nearest-vets/route.ts tests/azure-maps-route.test.ts` → 0 errors.
+
+## Repo conventions
+
+- npm; Jest 30 via ts-jest CJS; `@/` → `./src/`; node test environment; ESLint 9 flat config.
+- Authenticated Azure route exemplar: `src/app/api/azure/speech-token/route.ts`.
+- Auth helper: `src/lib/api-auth.ts:17-20` (`requireAuthenticatedApiUser`).
+- Route test exemplars: `tests/azure-maps-route.test.ts` (this route, extend it), `tests/azure-speech-token.route.test.ts` (auth/rate-limit mocking pattern).
+
+## Out of scope
+
+- `src/lib/azure/maps.ts` (`findNearestEmergencyVets`) — unchanged.
+- Client changes to `nearest-vet-finder.tsx` — same-origin fetch carries Supabase auth cookies automatically; only change it if step 1 reveals a problem (which is a STOP, not a workaround).
+- Clinical files — untouched.
+- Other unauthenticated routes — one route per plan.
+
+## STOP conditions
+
+- Step 1 finds `NearestVetFinder` rendered in any unauthenticated context (shared report page, public view) — report the file/line and stop.
+- The quoted route code is not found at the stated lines.
+- The drift check shows unexplained changes to the route or test file.
+- Existing azure-maps tests fail for reasons unrelated to the added auth/rate-limit blocks.

--- a/plans/improve/05-server-bind-image-gate-override.md
+++ b/plans/improve/05-server-bind-image-gate-override.md
@@ -1,0 +1,174 @@
+# Plan 05 — Server-Bind the Image Gate Override (gateOverride)
+
+## Goal
+
+The symptom-chat image quality gate is skipped whenever the client sends `gateOverride: true` — the server never verifies that it actually issued a gate warning for *this* image. This plan makes the override server-verifiable: when the server returns an `image_gate` response it includes a short-lived signed token (HMAC over the image hash), and an override is honored only when the client echoes a valid token for the same image. UX stays identical — the existing "Analyze anyway" button just passes back a token it received.
+
+## Why
+
+Today any client can set `gateOverride: true` on the first request and bypass the gate entirely for any image, defeating the quality/safety gate's purpose. Binding the override to a server-issued token restores the invariant that the server decides which images were gated.
+
+## Git stamp
+
+Written against commit: `19d15ac2fb919996212747653c1638aac08f90f1`
+
+Drift check (run before starting):
+
+```bash
+git -C "G:\MY Website\pawvital-ai" diff --stat 19d15ac2fb919996212747653c1638aac08f90f1 -- src/app/api/ai/symptom-chat/route.ts "src/app/(dashboard)/symptom-checker/page.tsx" tests/symptom-chat.route.test.ts
+```
+
+If the output is non-empty for files this plan edits beyond what the plan describes, **STOP and report**. (If Plans 01/02 already landed, `route.ts` will show their diffs — re-locate the gate block by searching for `gateOverride !== true` before proceeding.)
+
+## Current state (real code, verified at the stamp commit)
+
+### 1. The gate block and the unconditional override
+
+`src/app/api/ai/symptom-chat/route.ts` lines 1525–1548:
+
+```typescript
+    if (image && shouldRunWoundVision && gateOverride !== true) {
+      const gateCacheKey = buildGateCacheKey(imageHash || "", imageMeta);
+      const gateWarning =
+        session.gate_cache_key === gateCacheKey
+          ? readCachedGateWarning(session)
+          : await evaluateAndCacheGate(session, gateCacheKey, image, imageMeta);
+      if (gateWarning) {
+        console.log(
+          `[Image Gate] warning=${gateWarning.reason}, label=${gateWarning.topLabel || "n/a"}`
+        );
+        return NextResponse.json({
+          type: "image_gate",
+          message: buildImageGateMessage(pet.name, gateWarning),
+          session,
+          gate: gateWarning,
+          ready_for_report: false,
+        });
+      }
+    }
+
+    if (image && shouldRunWoundVision) {
+      if (gateOverride === true) {
+        console.log("[Image Gate] Override accepted, continuing to vision pipeline");
+      }
+```
+
+`gateOverride` arrives straight from the request body (`route.ts:1267` in the destructuring; declared in `RequestBody` at line 204: `gateOverride?: boolean;`). The image hash already exists: `route.ts:1284`:
+
+```typescript
+    const imageHash = image ? hashImage(image) : null;
+```
+
+### 2. The UI sends the override from "Analyze anyway"
+
+`src/app/(dashboard)/symptom-checker/page.tsx` lines 829–838:
+
+```typescript
+  const handleAnalyzeAnyway = () => {
+    if (!pendingGateImage || loading) return;
+
+    void sendMessage(undefined, {
+      imageOverride: pendingGateImage,
+      imageMetaOverride: pendingGateImageMeta,
+      gateOverride: true,
+      appendUserMessage: false,
+    });
+  };
+```
+
+## Steps
+
+1. **Baseline.**
+   - Gate: `npm test -- --testPathPattern=symptom-chat` → all pass, exit 0.
+
+2. **Add a small HMAC token helper.** Create `src/lib/symptom-chat/gate-override-token.ts` (new file in the existing `src/lib/symptom-chat/` directory — NOT a clinical file) exporting two functions:
+
+   ```typescript
+   import { createHmac, timingSafeEqual } from "crypto";
+
+   const TOKEN_TTL_MS = 15 * 60 * 1000; // 15 minutes
+
+   function getSecret(): string {
+     return (
+       process.env.IMAGE_GATE_OVERRIDE_SECRET?.trim() ||
+       process.env.ASYNC_REVIEW_WEBHOOK_SECRET?.trim() ||
+       "dev-only-gate-override-secret"
+     );
+   }
+
+   export function issueGateOverrideToken(imageHash: string, now = Date.now()): string {
+     const expiresAt = now + TOKEN_TTL_MS;
+     const payload = `${imageHash}.${expiresAt}`;
+     const sig = createHmac("sha256", getSecret()).update(payload).digest("hex");
+     return `${expiresAt}.${sig}`;
+   }
+
+   export function verifyGateOverrideToken(
+     token: string | undefined,
+     imageHash: string,
+     now = Date.now()
+   ): boolean {
+     if (!token) return false;
+     const dot = token.indexOf(".");
+     if (dot <= 0) return false;
+     const expiresAt = Number(token.slice(0, dot));
+     if (!Number.isFinite(expiresAt) || now > expiresAt) return false;
+     const expected = createHmac("sha256", getSecret())
+       .update(`${imageHash}.${expiresAt}`)
+       .digest("hex");
+     const given = token.slice(dot + 1);
+     if (given.length !== expected.length) return false;
+     return timingSafeEqual(Buffer.from(given, "hex"), Buffer.from(expected, "hex"));
+   }
+   ```
+
+   Decision note for the executor: the dev fallback secret keeps demo mode working with zero env config (matching the repo's demo-mode philosophy, see `AGENTS.md` "Demo mode"). Stateless HMAC avoids any storage.
+   - Gate: `npx tsc --noEmit` → exit 0, no output.
+
+3. **Issue the token with the `image_gate` response.** In `route.ts`, in the gate block quoted above, add to the returned JSON one field: `gate_override_token: issueGateOverrideToken(imageHash || "")`. Do not change any other field of the response.
+   - Gate: `npx tsc --noEmit` → exit 0, no output.
+
+4. **Verify the token on override.** Add `gateOverrideToken?: string;` to `RequestBody` (line 196–205) and to the destructuring at line 1259. Change the gate conditions:
+   - Compute once, near the gate block: `const gateOverrideAccepted = gateOverride === true && verifyGateOverrideToken(gateOverrideToken, imageHash || "");`
+   - Line 1525: `if (image && shouldRunWoundVision && gateOverride !== true)` → `if (image && shouldRunWoundVision && !gateOverrideAccepted)`. NOTE this also changes behavior for `gateOverride: true` **without** a valid token: the gate now runs and, if it warns, returns `image_gate` (with a fresh token) instead of being bypassed. That is the intended fix.
+   - Line 1546: `if (gateOverride === true)` → `if (gateOverrideAccepted)` (the log line).
+   - Gate: `npm test -- --testPathPattern=symptom-chat` → all existing tests pass. If an existing test sends `gateOverride: true` and expects a bypass, it is exercising the vulnerability — update that test to first obtain a token from an `image_gate` response (or use `issueGateOverrideToken` directly) and note this in the handoff. Any other failure: STOP and report.
+
+5. **Echo the token from the UI.** In `src/app/(dashboard)/symptom-checker/page.tsx`:
+   - Where the `image_gate` response is handled (search the file for `"image_gate"`), store `data.gate_override_token` in state alongside the existing `pendingGateImage` (mirror how `pendingGateImage`/`pendingGateImageMeta` are stored and cleared — search for `setPendingGateImage` and `clearPendingGateImage`).
+   - In `handleAnalyzeAnyway` (lines 829–838 quoted above), pass the stored token through `sendMessage`'s options (add `gateOverrideTokenOverride` plumbing analogous to `imageOverride`) so the POST body includes `gateOverrideToken`.
+   - Clear the stored token wherever `clearPendingGateImage()` is called.
+   - Gate: `npx tsc --noEmit` → exit 0, no output.
+   - Gate: `npx eslint "src/app/(dashboard)/symptom-checker/page.tsx"` → 0 errors.
+
+6. **Add regression tests** to `tests/symptom-chat.route.test.ts`:
+   - *Override without token rejected*: request with image + `gateOverride: true`, no `gateOverrideToken`, mocked gate evaluation returning a warning → response `type: "image_gate"` (gate NOT bypassed) and response contains a non-empty `gate_override_token`.
+   - *Override with valid token accepted*: same request but with `gateOverrideToken: issueGateOverrideToken(<hash of the test image>)` — compute the hash the same way the route does (`hashImage`; if not exported, derive the token by first capturing `gate_override_token` from a prior `image_gate` response within the test) → gate is bypassed (no `image_gate` response; vision path proceeds per existing test mocks).
+   - *Expired/garbage token rejected*: `gateOverrideToken: "123.deadbeef"` → `image_gate` returned.
+   - Gate: `npm test -- --runTestsByPath tests/symptom-chat.route.test.ts` → all pass.
+
+7. **Full gate.**
+   - Gate: `npm test -- --testPathPattern=symptom-chat` → all pass.
+   - Gate: `npx tsc --noEmit` → exit 0, no output.
+   - Gate: `npx eslint src/app/api/ai/symptom-chat/route.ts src/lib/symptom-chat/gate-override-token.ts` → 0 errors.
+
+## Repo conventions
+
+- npm; Jest 30 via ts-jest CJS; `@/` → `./src/`; node test environment; ESLint 9 flat config.
+- Route-adjacent helper module exemplar: `src/lib/symptom-chat/usage-limit-gate.ts` (same directory, same import style from the route).
+- Secret-handling exemplar: `src/app/api/ai/async-review/route.ts:24-26` (`getAsyncReviewWebhookSecret`).
+- Route test exemplar: `tests/symptom-chat.route.test.ts`.
+
+## Out of scope
+
+- The gate evaluation logic itself (`evaluateAndCacheGate`, `buildGateCacheKey`, `readCachedGateWarning`) — unchanged.
+- `src/lib/triage-engine.ts`, `src/lib/clinical-matrix.ts`, `src/lib/symptom-memory.ts` — untouched; edits in `route.ts` are restricted to the gate block, the `RequestBody` type, the destructuring line, and the new helper import.
+- Vision pipeline behavior after a valid override — identical to today.
+- Plans 01 and 02 edit the same route file — execute serially per the index.
+
+## STOP conditions
+
+- The gate block is not found at/near lines 1525–1548 (search `gateOverride !== true`; if absent, the gate was restructured — report).
+- The `image_gate` handling in `page.tsx` cannot be located by searching `"image_gate"`, or `pendingGateImage` state plumbing differs materially from the description — report rather than improvise a new UI flow.
+- Any existing test failure not attributable to the now-closed bypass.
+- The change would require touching clinical files.

--- a/plans/improve/06-usage-gate-fail-closed.md
+++ b/plans/improve/06-usage-gate-fail-closed.md
@@ -1,0 +1,183 @@
+# Plan 06 — Usage Limit Gate: Fail Closed on Database Errors
+
+## Goal
+
+The free-tier usage gate for new symptom-chat conversations (`maybeBuildUsageLimitResponse` in `src/lib/symptom-chat/usage-limit-gate.ts`) swallows **every** error in a catch-all and returns `null`, which means "gate passes". A Supabase outage therefore silently grants unlimited free new chats. This plan distinguishes error types: real database/lookup failures on a new-chat start return a 503-style "try again shortly" response instead of silently granting, while the deliberate permissive paths (demo mode, unauthenticated user, conversation already in progress, emergency bypass) keep returning `null` exactly as today.
+
+## Why
+
+Billing enforcement that fails open under infrastructure errors converts every outage into a free-usage window, and does so invisibly (one `console.error` only). Failing closed for *new* chat starts is safe because in-progress conversations and emergencies are already exempted before the try block.
+
+## Git stamp
+
+Written against commit: `19d15ac2fb919996212747653c1638aac08f90f1`
+
+Drift check (run before starting):
+
+```bash
+git -C "G:\MY Website\pawvital-ai" diff --stat 19d15ac2fb919996212747653c1638aac08f90f1 -- src/lib/symptom-chat/usage-limit-gate.ts tests/
+```
+
+If the output is non-empty for files this plan edits beyond what the plan describes, **STOP and report**.
+
+## Current state (real code, verified at the stamp commit)
+
+### 1. The deliberate permissive pre-checks (DO NOT CHANGE)
+
+`src/lib/symptom-chat/usage-limit-gate.ts` lines 149–158 (inside `maybeBuildUsageLimitResponse`, which begins at line 144):
+
+```typescript
+  if (input.action !== "chat") {
+    return null;
+  }
+  ...
+  if (
+    hasConversationStarted(input.session) ||
+    hasEmergencyUsageGateBypassSignal(input.session, input.messages)
+  ) {
+    return null;
+  }
+```
+
+And the by-design unauthenticated pass, lines 160–169:
+
+```typescript
+  try {
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return null;
+    }
+```
+
+### 2. The fail-open catch (THE BUG)
+
+Lines 193–197:
+
+```typescript
+  } catch (error) {
+    console.error("[Billing] Usage gate failed open:", error);
+    return null;
+  }
+}
+```
+
+Note: `createServerSupabaseClient()` throws `Error("DEMO_MODE")` when Supabase is unconfigured (see `src/lib/api-auth.ts:25`: `if (error instanceof Error && error.message === "DEMO_MODE")`). That demo-mode throw currently lands in this same catch and correctly passes — the fix must preserve that.
+
+Also note the lookup helper already throws typed-ish errors — lines 110–112:
+
+```typescript
+  if (checksError) {
+    throw new Error(`USAGE_COUNT_FAILED:${checksError.message}`);
+  }
+```
+
+### 3. The existing blocked-response builder (shape exemplar for the new 503)
+
+Lines 117–142 build the 402 response:
+
+```typescript
+function buildUsageLimitResponse(
+  session: TriageSession,
+  usageGate: Pick<
+    SymptomCheckUsageGateResult,
+    "limit" | "reason" | "remaining" | "requiresUpgrade"
+  >
+) {
+  return NextResponse.json(
+    {
+      type: "usage_limit",
+      code: "FREE_TIER_LIMIT_REACHED",
+      error: "Monthly free-tier limit reached",
+      ...
+      ready_for_report: false,
+      conversationState: "idle",
+      session: sanitizeSessionForClient(session),
+    },
+    { status: 402 }
+  );
+}
+```
+
+### 4. How the route consumes the result
+
+`src/app/api/ai/symptom-chat/route.ts` lines 1271–1279: any non-null return is sent to the client as-is:
+
+```typescript
+    const usageLimitResponse = await maybeBuildUsageLimitResponse({
+      action,
+      messages,
+      session,
+    });
+    if (usageLimitResponse) {
+      statusCode = usageLimitResponse.status;
+      return usageLimitResponse;
+    }
+```
+
+## Steps
+
+1. **Baseline.** Find existing tests for this module: `rg -l "usage-limit-gate|maybeBuildUsageLimitResponse" tests/`. Run whatever matches (plus the route suite).
+   - Gate: `npm test -- --testPathPattern=symptom-chat` → all pass, exit 0.
+
+2. **Split the catch.** In `usage-limit-gate.ts`, replace the catch block (lines 193–196) with logic that:
+   - Re-returns `null` for demo mode: `if (error instanceof Error && error.message === "DEMO_MODE") return null;`
+   - For everything else (including `USAGE_COUNT_FAILED:*` and subscription-lookup failures), logs `console.error("[Billing] Usage gate unavailable, failing closed for new chat:", error);` and returns a new 503 response built by a sibling helper:
+
+   ```typescript
+   function buildUsageGateUnavailableResponse(session: TriageSession) {
+     return NextResponse.json(
+       {
+         type: "usage_limit",
+         code: "USAGE_GATE_UNAVAILABLE",
+         error: "We couldn't verify your plan usage",
+         message:
+           "We couldn't verify your plan usage just now. Please try starting your symptom check again in a moment.",
+         requires_upgrade: false,
+         ready_for_report: false,
+         conversationState: "idle",
+         session: sanitizeSessionForClient(session),
+       },
+       { status: 503 }
+     );
+   }
+   ```
+
+   Keep the response `type: "usage_limit"` so existing client handling of the gate envelope degrades gracefully; the distinct `code` lets the UI show a retry message later. Do not change anything before the `try` block.
+   - Gate: `npx tsc --noEmit` → exit 0, no output.
+
+3. **Unit tests for the error path.** Locate the existing test file for this gate (step 1 grep). If none exists, create `tests/usage-limit-gate.test.ts` following the mocking style of `tests/symptom-chat.route.test.ts` (mock `@/lib/supabase-server`). Cases:
+   - `createServerSupabaseClient` throws `Error("DEMO_MODE")` → returns `null` (unchanged behavior).
+   - `supabase.auth.getUser()` resolves `{ data: { user: null }, error: null }` → returns `null` (unauthenticated by design — unchanged).
+   - Authenticated user, but the monthly count query yields an error (so `USAGE_COUNT_FAILED:` is thrown) → returns a response with status 503 and `code: "USAGE_GATE_UNAVAILABLE"`.
+   - Authenticated user, `createServerSupabaseClient` throws a generic network error → 503 response.
+   - Sanity: `action: "generate_report"` → `null` without any Supabase call.
+   - Gate: `npm test -- --runTestsByPath tests/usage-limit-gate.test.ts` (or the located existing file) → all pass.
+
+4. **Full gate.**
+   - Gate: `npm test -- --testPathPattern=symptom-chat` → all pass (the route consumes this module; in test/demo conditions the pre-checks return `null` before any Supabase call, so existing route tests must be unaffected — if one fails, STOP and report).
+   - Gate: `npx tsc --noEmit` → exit 0, no output.
+   - Gate: `npx eslint src/lib/symptom-chat/usage-limit-gate.ts` → 0 errors.
+
+## Repo conventions
+
+- npm; Jest 30 via ts-jest CJS; `@/` → `./src/`; node test environment; ESLint 9 flat config.
+- Response-envelope exemplar: `buildUsageLimitResponse` in the same file (lines 117–142, quoted above).
+- DEMO_MODE sentinel handling exemplar: `src/lib/api-auth.ts:25`.
+
+## Out of scope
+
+- Plan quotas, `evaluateSymptomCheckUsageGate` logic, private-tester bypass (`shouldBypassUsageLimitForPrivateTester`) — unchanged.
+- The unauthenticated permissive path at lines 167–169 — explicitly preserved by design; DO NOT make unauthenticated users hit the gate.
+- UI handling of the new `USAGE_GATE_UNAVAILABLE` code (optional follow-up; the generic usage_limit envelope renders acceptably today).
+- Clinical files and `route.ts` — untouched (this plan edits only `usage-limit-gate.ts` and tests).
+
+## STOP conditions
+
+- The quoted catch block is not found at/near lines 193–196.
+- You cannot determine with certainty how the symptom-checker UI reacts to a `type: "usage_limit"` envelope with an unknown `code` (read `src/app/(dashboard)/symptom-checker/page.tsx`'s `usage_limit` handling first; if it would hard-crash on the new code, STOP and report).
+- Any existing test fails for reasons unrelated to the catch-block change.

--- a/plans/improve/07-batch-translator-calls.md
+++ b/plans/improve/07-batch-translator-calls.md
@@ -1,0 +1,145 @@
+# Plan 07 — Batch the Per-Turn Translator Calls in the Symptom Checker UI
+
+## Goal
+
+After every chat turn, `src/app/(dashboard)/symptom-checker/page.tsx` makes three **sequential** `await localizeAssistantText(...)` calls (assistant message, terminal owner message, terminal next-step). Each call can hit `POST /api/azure/translator`. The translator client already supports batching (`requestTranslations` takes `texts: string[]`, batch size 25). This plan collapses the three sequential awaits into one parallel/batched localization step. Client-side only; zero clinical logic.
+
+## Why
+
+Three serial network round-trips per turn add latency to every assistant reply for non-English users, and consume 3× the translator rate-limit budget (20/min per user) for no reason.
+
+## Git stamp
+
+Written against commit: `19d15ac2fb919996212747653c1638aac08f90f1`
+
+Drift check (run before starting):
+
+```bash
+git -C "G:\MY Website\pawvital-ai" diff --stat 19d15ac2fb919996212747653c1638aac08f90f1 -- "src/app/(dashboard)/symptom-checker/page.tsx" src/lib/azure/translator-client.ts
+```
+
+If the output is non-empty for files this plan edits beyond what the plan describes, **STOP and report**.
+
+## Current state (real code, verified at the stamp commit)
+
+### 1. The three sequential awaits
+
+`src/app/(dashboard)/symptom-checker/page.tsx` lines 615–626:
+
+```typescript
+      const assistantText =
+        typeof data.message === "string"
+          ? await localizeAssistantText(data.message)
+          : null;
+      const terminalOwnerText =
+        typeof data.owner_message === "string"
+          ? await localizeAssistantText(data.owner_message)
+          : null;
+      const terminalNextStepText =
+        typeof data.recommended_next_step === "string"
+          ? await localizeAssistantText(data.recommended_next_step)
+          : null;
+```
+
+### 2. The translator client already batches
+
+`src/lib/azure/translator-client.ts` line 40:
+
+```typescript
+const TRANSLATOR_ROUTE_BATCH_SIZE = 25;
+```
+
+`requestTranslations` (lines 58–87) accepts `texts: string[]` in one POST:
+
+```typescript
+async function requestTranslations(
+  input: {
+    sourceLanguage?: string | null;
+    targetLanguage: string;
+    texts: string[];
+  },
+  options: TranslateClientOptions = {},
+): Promise<TranslatorRouteResult | null> {
+  if (input.texts.length === 0) {
+    return null;
+  }
+  ...
+```
+
+And the batch helper (lines 89–118):
+
+```typescript
+async function requestTranslationBatches(
+  input: {
+    sourceLanguage?: string | null;
+    targetLanguage: string;
+    texts: string[];
+  },
+  options: TranslateClientOptions = {},
+): Promise<string[] | null> {
+  const translations: string[] = [];
+
+  for (
+    let start = 0;
+    start < input.texts.length;
+    start += TRANSLATOR_ROUTE_BATCH_SIZE
+  ) {
+    ...
+```
+
+### 3. What `localizeAssistantText` is
+
+Before editing, locate the definition of `localizeAssistantText` in `page.tsx` (search the file). It returns an object with at least `content` and optional `apiContent` (see usage at lines 633–634: `content: assistantText?.content ?? data.message, apiContent: assistantText?.apiContent,`). Read its body to determine whether it already delegates to a function in `translator-client.ts` that could accept multiple texts.
+
+## Steps
+
+1. **Baseline.** Find the translator tests: `rg -l "translator" tests/` and run them.
+   - Gate: `npm test -- --testPathPattern=translator` → all pass, exit 0 (if no test file matches, note that and rely on the later gates).
+
+2. **Implement batching.** Two acceptable designs — pick the first that fits what you find in step 3-reading of `localizeAssistantText`:
+   - **Preferred (single batched call):** add a `localizeAssistantTexts(texts: (string | null)[])` helper next to `localizeAssistantText` in `page.tsx` (or, if `localizeAssistantText` wraps an exported translator-client function, add the plural variant in `src/lib/azure/translator-client.ts` reusing `requestTranslationBatches`). It collects the non-null strings, sends them in ONE `requestTranslations` call, and maps results back positionally so each input gets `{ content, apiContent }` or `null` exactly as the singular version would produce.
+   - **Minimum acceptable (parallel):** replace the three sequential awaits with:
+
+   ```typescript
+   const [assistantText, terminalOwnerText, terminalNextStepText] =
+     await Promise.all([
+       typeof data.message === "string"
+         ? localizeAssistantText(data.message)
+         : Promise.resolve(null),
+       typeof data.owner_message === "string"
+         ? localizeAssistantText(data.owner_message)
+         : Promise.resolve(null),
+       typeof data.recommended_next_step === "string"
+         ? localizeAssistantText(data.recommended_next_step)
+         : Promise.resolve(null),
+     ]);
+   ```
+
+   The downstream variables keep the same names and types, so no other lines change.
+   - Gate: `npx tsc --noEmit` → exit 0, no output.
+
+3. **Behavior parity check.** Confirm the three result variables are used identically afterwards (lines 628+ use `assistantText?.content ?? data.message` etc.). No fallback behavior may change: when translation is disabled/fails, each variable must still be `null` and the raw English string must render.
+   - Gate: `npm test -- --testPathPattern=translator` → all pass.
+   - Gate: `npm test -- --runTestsByPath tests/symptom-checker-state-ui.test.ts tests/conversation-state-ui.test.ts` → all pass (these exercise the page's state handling; both files verified to exist in `tests/`).
+
+4. **Full gate.**
+   - Gate: `npx tsc --noEmit` → exit 0, no output.
+   - Gate: `npx eslint "src/app/(dashboard)/symptom-checker/page.tsx" src/lib/azure/translator-client.ts` → 0 errors.
+
+## Repo conventions
+
+- npm; Jest 30 via ts-jest CJS; `@/` → `./src/`; node test environment; ESLint 9 flat config.
+- Batch-call exemplar: `requestTranslationBatches`, `src/lib/azure/translator-client.ts:89-118`.
+- Parallelization rule reference: workspace React best practices §1.5 (Promise.all for independent operations).
+
+## Out of scope
+
+- The translator API route (`/api/azure/translator`) and its rate limiter — unchanged.
+- Report-localization paths elsewhere in `translator-client.ts` (`normalizeOwnerTextForClinical`, report string assignment) — unchanged.
+- Clinical files — untouched. This is UI-layer latency work only.
+
+## STOP conditions
+
+- The three sequential awaits are not found at/near lines 615–626 of `page.tsx`.
+- `localizeAssistantText`'s return shape differs from `{ content, apiContent }` as inferred above — re-read and adapt, or report if ambiguous.
+- Any translator or UI-state test fails for reasons unrelated to call ordering.

--- a/plans/improve/08-typecheck-script-and-build-gate.md
+++ b/plans/improve/08-typecheck-script-and-build-gate.md
@@ -1,0 +1,136 @@
+# Plan 08 — Add a typecheck Script and Attempt Re-enabling Build-Time Type Errors
+
+## Goal
+
+`package.json` has no `typecheck` script even though CI runs `npx tsc --noEmit` and the README's pre-push checklist omits typechecking. Separately, `next.config.ts` sets `typescript.ignoreBuildErrors: true` with a comment that is now stale (it claims `symptom-chat/route.ts` exports a helper that breaks route-export validation; verified at the stamp commit the file's only export is `POST` at line 1214). This plan (a) adds `"typecheck": "tsc --noEmit"`, (b) attempts to remove `ignoreBuildErrors` and keeps the removal only if `npm run build` passes, and (c) updates the README pre-push checklist. Low risk; fully reversible.
+
+## Why
+
+A named script makes the CI gate reproducible locally with one command, and `ignoreBuildErrors: true` is a standing safety hole — if its original justification is gone, builds should fail on type errors again.
+
+## Git stamp
+
+Written against commit: `19d15ac2fb919996212747653c1638aac08f90f1`
+
+Drift check (run before starting):
+
+```bash
+git -C "G:\MY Website\pawvital-ai" diff --stat 19d15ac2fb919996212747653c1638aac08f90f1 -- package.json next.config.ts README.md
+```
+
+If the output is non-empty for files this plan edits beyond what the plan describes, **STOP and report**. KNOWN EXCEPTION: `README.md` is dirty in the working tree at authoring time (unrelated landing-page edits). Read the CURRENT README, find the pre-push checklist by content (the ```bash block containing `npm run lint`), and edit what is actually there.
+
+## Current state (real code, verified at the stamp commit)
+
+### 1. No typecheck script
+
+`package.json` scripts begin (lines 5–11):
+
+```json
+  "scripts": {
+    "dev": "next dev",
+    "build": "node scripts/build.js",
+    "start": "next start",
+    "lint": "eslint",
+    "test": "jest --verbose",
+    "test:watch": "jest --watch",
+```
+
+No `typecheck` entry exists anywhere in the scripts block (verified by reading the full file). Note `build` runs `node scripts/build.js`, not `next build` directly.
+
+### 2. The ignore flag and stale comment
+
+`next.config.ts` lines 51–59:
+
+```typescript
+const nextConfig: NextConfig = {
+  // Exclude Node.js-only packages from bundling
+  serverExternalPackages: ["pg", "pg-native", "pg-pool", "pg-protocol"],
+  // Skip type-checking during build — handled separately by CI `tsc --noEmit`.
+  // Needed because symptom-chat/route.ts exports a helper that triggers
+  // Next.js route-export validation (we must not modify clinical files).
+  typescript: {
+    ignoreBuildErrors: true,
+  },
+```
+
+Staleness verified: `rg "^export " src/app/api/ai/symptom-chat/route.ts` returns exactly one line — `1214:export async function POST(request: Request) {`.
+
+### 3. CI already typechecks
+
+`.github/workflows/ci.yml` line 100:
+
+```yaml
+      - run: npx tsc --noEmit
+```
+
+### 4. README pre-push checklist
+
+`README.md` lines 240–246 (at the stamp commit; the file is dirty — re-locate by content):
+
+```bash
+# Validate before pushing
+npm run lint
+npm run build
+npm test
+npm run security:secrets
+```
+
+### 5. Baseline typecheck status
+
+`npx tsc --noEmit` passes clean at the stamp commit (verified by the auditing pass; re-verify in step 1).
+
+## Steps
+
+1. **Baseline.**
+   - Gate: `npx tsc --noEmit` → exit 0, no output. If it fails, STOP and report (the premise is gone).
+
+2. **Add the script.** In `package.json`, add to scripts (after `"lint"`):
+
+   ```json
+   "typecheck": "tsc --noEmit",
+   ```
+
+   - Gate: `npm run typecheck` → exit 0, no output.
+
+3. **Attempt removing `ignoreBuildErrors`.** In `next.config.ts`, delete the `typescript: { ignoreBuildErrors: true },` block AND its two stale comment lines (the `// Skip type-checking...` through `// ...clinical files).` lines quoted above). Then run the build.
+   - Gate: `npm run build` → exit 0.
+   - **If the build FAILS:** restore `next.config.ts` exactly to its prior content, record the exact build error text in your handoff report, and keep only the step-2 script addition + step-4 README edit. This is a defined fallback, not a STOP.
+   - **If the build PASSES:** keep the removal. No replacement comment is needed.
+
+4. **Update the README checklist.** In the current `README.md`, find the validate-before-pushing bash block (content quoted above; line numbers may have drifted) and add `npm run typecheck` after `npm run lint`:
+
+   ```bash
+   # Validate before pushing
+   npm run lint
+   npm run typecheck
+   npm run build
+   npm test
+   npm run security:secrets
+   ```
+
+   - Gate: `rg -n "npm run typecheck" README.md` → exactly one match inside the checklist block.
+
+5. **Full gate.**
+   - Gate: `npm run typecheck` → exit 0, no output.
+   - Gate: `npm run build` → exit 0 (with whichever next.config.ts state survived step 3).
+   - Gate: `npx eslint next.config.ts` → 0 errors.
+
+## Repo conventions
+
+- npm; CI typecheck command: `npx tsc --noEmit` (`.github/workflows/ci.yml:100`) — the new script mirrors it exactly.
+- Build is wrapped: `npm run build` → `node scripts/build.js`. Do not modify `scripts/build.js`.
+
+## Out of scope
+
+- Fixing any type errors `npm run build` might reveal — if removal fails, revert it and report; do not chase errors into source files.
+- `src/app/api/ai/symptom-chat/route.ts` and all clinical files — read-only for the staleness verification.
+- CI workflow changes (CI already typechecks).
+- The dirty landing-page/auth-page edits in the working tree — do not touch.
+
+## STOP conditions
+
+- `npx tsc --noEmit` fails at baseline (step 1).
+- `package.json` already has a `typecheck` script (someone landed it) — report, and continue only with the remaining steps that still apply.
+- The README checklist block cannot be found by content in the current dirty file.
+- `npm run build` fails even WITH `ignoreBuildErrors: true` restored — environment problem; stop and report.

--- a/plans/improve/09-owner-outcome-feedback-loop.md
+++ b/plans/improve/09-owner-outcome-feedback-loop.md
@@ -1,0 +1,207 @@
+# Plan 09 — Wire the Owner Outcome-Feedback Loop in the Report UI
+
+## Goal
+
+The backend already accepts full outcome payloads (`matchedExpectation` / `confirmedDiagnosis` / `vetOutcome` / `ownerNotes`) at `POST /api/ai/outcome-feedback`, persists them, and auto-drafts threshold-review proposals that surface in an existing admin panel. But no UI ever sends that payload: `FullReport` accepts an `onOutcomeFeedback` prop that no caller passes, and the rendered feedback section only collects tester *helpfulness* feedback. This plan adds an owner-facing "Did this match what happened?" follow-up in the report and history views that POSTs the existing schema and surfaces the `proposalCreated` response. UI work only; no thresholds logic changes.
+
+## Why
+
+The calibration feedback loop (owner outcome → threshold proposal → admin review) is fully built server-side and admin-side but dead-ended at the owner UI. Wiring it closes the only missing link in an already-shipped learning loop.
+
+## Git stamp
+
+Written against commit: `19d15ac2fb919996212747653c1638aac08f90f1`
+
+**CAUTION:** `src/app/api/ai/outcome-feedback/route.ts` and `tests/outcome-feedback.route.test.ts` have **uncommitted working-tree edits** at authoring time. The excerpts below were read from the working tree as-is. You MUST re-read the current files first; if the schema or handler shape no longer matches the excerpts, **STOP and report**.
+
+Drift check (run before starting):
+
+```bash
+git -C "G:\MY Website\pawvital-ai" diff --stat 19d15ac2fb919996212747653c1638aac08f90f1 -- src/components/symptom-report/full-report.tsx src/components/symptom-report/outcome-feedback.tsx "src/app/(dashboard)/symptom-checker/page.tsx" "src/app/(dashboard)/history/page.tsx" src/app/api/ai/outcome-feedback/route.ts tests/outcome-feedback.route.test.ts
+```
+
+Expect non-empty output for `outcome-feedback/route.ts` and `tests/outcome-feedback.route.test.ts` (known dirty) and possibly the landing-related files; for the files this plan EDITS, any diff beyond what this plan describes = **STOP and report**.
+
+## Current state (real code; route/test read from dirty working tree)
+
+### 1. The API accepts full outcome payloads
+
+`src/app/api/ai/outcome-feedback/route.ts` lines 34–40 (working tree):
+
+```typescript
+const OutcomeFeedbackRequestBodySchema = z.object({
+  symptomCheckId: z.string().uuid(),
+  matchedExpectation: z.enum(["yes", "partly", "no"]),
+  confirmedDiagnosis: z.string().trim().max(2000).optional(),
+  vetOutcome: z.string().trim().max(2000).optional(),
+  ownerNotes: z.string().trim().max(4000).optional(),
+});
+```
+
+The route discriminates payload kinds — lines 57–61:
+
+```typescript
+function isOutcomeFeedbackPayload(
+  value: unknown
+): value is Record<string, unknown> {
+  return isRecord(value) && "matchedExpectation" in value;
+}
+```
+
+Read the rest of the route's POST handler yourself to confirm the response shape for the outcome branch (look for `proposalCreated` in the response JSON; the proposal draft is built in `src/lib/report-storage.ts` — line 354 `const proposal = buildThresholdProposalDraft({` and line 363 `.from("threshold_proposals")`).
+
+### 2. Proposals are auto-drafted for non-"yes" outcomes
+
+`src/lib/threshold-proposals.ts` lines 22–25:
+
+```typescript
+}): ThresholdProposalDraft | null {
+  if (input.feedback.matchedExpectation === "yes") {
+    return null;
+  }
+```
+
+An admin review panel already exists: `src/components/admin/threshold-proposal-panel.tsx` (verified to exist; not edited by this plan).
+
+### 3. FullReport accepts the prop but nobody passes it
+
+`src/components/symptom-report/full-report.tsx` lines 34–45:
+
+```typescript
+interface FullReportProps {
+  report: SymptomReport;
+  onOutcomeFeedback?: (data: {
+    symptomCheckId: string;
+    matchedExpectation: "yes" | "partly" | "no";
+    confirmedDiagnosis: string;
+    vetOutcome: string;
+    ownerNotes: string;
+  }) => void | Promise<void>;
+  /** Public shared view: hide owner-only UI */
+  readOnlyShared?: boolean;
+}
+```
+
+And the feedback section renders WITHOUT it — lines 405–409:
+
+```tsx
+      {!readOnlyShared ? (
+        <div ref={feedbackRef}>
+          {feedbackEnabled ? (
+            <OutcomeFeedbackSection report={report} />
+          ) : (
+```
+
+### 4. OutcomeFeedbackSection only renders the tester-helpfulness widget
+
+`src/components/symptom-report/outcome-feedback.tsx` lines 10–25 (the entire component):
+
+```typescript
+export function OutcomeFeedbackSection({
+  report,
+}: OutcomeFeedbackSectionProps) {
+  if (!report.report_storage_id) {
+    return null;
+  }
+
+  return (
+    <TesterFeedbackWidget
+      symptomCheckId={report.report_storage_id}
+      reportTitle={report.title}
+      urgencyLabel={report.recommendation}
+      surface="result_page"
+    />
+  );
+}
+```
+
+The widget posts only tester fields — `src/components/tester-feedback/widget.tsx` lines 120–132:
+
+```typescript
+      const response = await fetch("/api/ai/outcome-feedback", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          symptomCheckId,
+          helpfulness,
+          confusingAreas,
+          trustLevel,
+          notes,
+          surface,
+        }),
+      });
+```
+
+### 5. Callers pass no feedback prop
+
+`src/app/(dashboard)/symptom-checker/page.tsx` line 1263:
+
+```tsx
+              <FullReport report={report} />
+```
+
+`src/app/(dashboard)/history/page.tsx` lines 432–436:
+
+```tsx
+                      <FullReport
+                        report={{
+                          ...report,
+                          report_storage_id:
+                            report.report_storage_id ?? row.id,
+```
+
+## Steps
+
+1. **Re-read the dirty route + test.** Read the full current `src/app/api/ai/outcome-feedback/route.ts` and `tests/outcome-feedback.route.test.ts`. Confirm: (a) the zod schema above still exists, (b) the outcome branch still saves via `saveOutcomeFeedbackToDB` and returns a JSON body — record the exact response shape, especially the field indicating proposal creation (search for `proposalCreated`; if the field has a different name, use the real name everywhere below). If the schema/handler no longer matches, **STOP and report**.
+   - Gate: `npm test -- --runTestsByPath tests/outcome-feedback.route.test.ts` → all pass (baseline on the dirty tree; if it fails before your changes, STOP and report).
+
+2. **Build the owner outcome form.** Create `src/components/symptom-report/owner-outcome-form.tsx` — a `"use client"` component styled after the existing widget (read `src/components/tester-feedback/widget.tsx` for the save-state pattern: `saveState`, `errorMessage`, fetch + `response.ok` check). Contents:
+   - Heading: "Did this match what happened?"
+   - A three-way choice mapping to `matchedExpectation: "yes" | "partly" | "no"`.
+   - Optional text inputs: confirmed diagnosis (max 2000 chars), vet outcome (max 2000), notes (max 4000) — mirror the zod limits.
+   - On submit: POST to `/api/ai/outcome-feedback` with `{ symptomCheckId, matchedExpectation, confirmedDiagnosis, vetOutcome, ownerNotes }` (omit empty optional fields).
+   - On success: show a thank-you state; if the response indicates a proposal was created (the field confirmed in step 1), show an additional line such as "Your report was flagged for clinical review — thank you."
+   - Props: `{ symptomCheckId: string }` plus anything needed for display. No clinical imports.
+   - Gate: `npx tsc --noEmit` → exit 0, no output.
+
+3. **Render it from `OutcomeFeedbackSection`.** Edit `src/components/symptom-report/outcome-feedback.tsx` to render the new `OwnerOutcomeForm` (with `symptomCheckId={report.report_storage_id}`) alongside the existing `TesterFeedbackWidget` (keep the tester widget — both feedback kinds are valid; the API discriminates by payload shape per `isOutcomeFeedbackPayload`). Keep the `report_storage_id` null-guard.
+
+   Design note: routing through `OutcomeFeedbackSection` automatically covers BOTH callers (symptom-checker page line 1263 and history page line 432) with no caller edits, because both render `FullReport`, which renders `OutcomeFeedbackSection` when not `readOnlyShared`. Do not add the `onOutcomeFeedback` prop plumbing to callers — leave the existing optional prop as-is.
+   - Gate: `npx tsc --noEmit` → exit 0, no output.
+   - Gate: `npx eslint src/components/symptom-report/outcome-feedback.tsx src/components/symptom-report/owner-outcome-form.tsx` → 0 errors.
+
+4. **Component test (if feasible).** The default Jest environment is `node`, but `jest-environment-jsdom` and `@testing-library/react` are installed (see package.json devDependencies) and `tests/nearest-vet-finder.test.ts` exists as a component-test exemplar — read it to copy the `@jest-environment jsdom` docblock pattern. Add `tests/owner-outcome-form.test.tsx`:
+   - Renders the three choices; submitting "no" with a diagnosis fires a fetch to `/api/ai/outcome-feedback` whose body parses to `{ symptomCheckId, matchedExpectation: "no", confirmedDiagnosis: "..." }`.
+   - Success response with proposal-created field set → review-flagged message appears.
+   - If the exemplar pattern does not transfer cleanly, skip this test, keep step 5's route-level test, and record the skip reason in the handoff.
+   - Gate (if written): `npm test -- --runTestsByPath tests/owner-outcome-form.test.tsx` → all pass.
+
+5. **Route-level regression (extend, don't duplicate).** In `tests/outcome-feedback.route.test.ts`, confirm there is a test posting a full outcome payload and asserting proposal-creation behavior; if missing, add one following the file's existing mock style. Do NOT modify `src/lib/threshold-proposals.ts` or `src/lib/report-storage.ts` to make tests pass.
+   - Gate: `npm test -- --runTestsByPath tests/outcome-feedback.route.test.ts` → all pass.
+
+6. **Full gate.**
+   - Gate: `npm test -- --testPathPattern="outcome-feedback|tester-feedback"` → all pass.
+   - Gate: `npx tsc --noEmit` → exit 0, no output.
+   - Gate: `npx eslint src/components/symptom-report/ tests/outcome-feedback.route.test.ts` → 0 errors.
+
+## Repo conventions
+
+- npm; Jest 30 via ts-jest CJS; `@/` → `./src/`; default test env `node` (component tests opt into jsdom via docblock — exemplar: `tests/nearest-vet-finder.test.ts`); ESLint 9 flat config.
+- Feedback-widget UX/fetch exemplar: `src/components/tester-feedback/widget.tsx:111-143`.
+- Route test exemplar: `tests/outcome-feedback.route.test.ts` (currently dirty — read as-is).
+
+## Out of scope
+
+- `src/lib/threshold-proposals.ts`, `src/lib/report-storage.ts`, the admin panel — read-only.
+- The route handler itself — read-only (it already accepts the payload). If you find it does NOT actually work end-to-end, STOP and report; do not fix the route in this plan.
+- The shared/public report view (`readOnlyShared`) — the section is already hidden there; keep it that way.
+- Clinical files — untouched.
+
+## STOP conditions
+
+- Step 1 finds the dirty route's schema/handler diverged from the excerpts.
+- `tests/outcome-feedback.route.test.ts` fails at baseline.
+- The proposal-created response field cannot be located in the route — report rather than invent a field name.
+- `OutcomeFeedbackSection` or `FullReport`'s feedback block has been restructured beyond the quoted shape.

--- a/plans/improve/10-docs-sync-readme-agents.md
+++ b/plans/improve/10-docs-sync-readme-agents.md
@@ -1,0 +1,172 @@
+# Plan 10 — Documentation Sync: README.md and AGENTS.md vs. Reality
+
+## Goal
+
+README.md and AGENTS.md contain verified factual drift: a Postgres `usage_log` rate limiter that does not exist, database tables absent from the schema file, two nonexistent API endpoints, a wrong Next.js version, a wrong description of current lint findings, and a sidecar section that omits the GPU-host deployment path. This plan makes doc-only edits correcting each item to the verified reality. Each item below quotes the current wrong text and gives the replacement.
+
+## Why
+
+These docs are read by every agent at session start (workspace rules mandate it); wrong infrastructure claims (e.g. "Postgres usage_log rate limiting") actively mislead security and billing work.
+
+## Git stamp
+
+Written against commit: `19d15ac2fb919996212747653c1638aac08f90f1`
+
+**CAUTION:** `README.md` is **dirty in the working tree** (unrelated landing/marketing edits). Read the CURRENT file first and locate each item by its quoted text, not by line number. If a quoted wrong string no longer exists, treat that item as already fixed and skip it (note the skip in the handoff).
+
+Drift check (run before starting):
+
+```bash
+git -C "G:\MY Website\pawvital-ai" diff --stat 19d15ac2fb919996212747653c1638aac08f90f1 -- README.md AGENTS.md
+```
+
+Expect README.md to appear (known dirty). For AGENTS.md, any diff = re-read before editing.
+
+## Current state and replacements (every "wrong" quote verified at authoring time)
+
+### Item A — nonexistent endpoints (README.md lines 105–106 at the stamp)
+
+Wrong (current):
+
+```
+    ├── POST /api/pets/[id]            → pet profile management
+    ├── POST /api/reports              → report generation + sharing
+    └── POST /api/triage               → triage session persistence
+```
+
+Verified reality: `src/app/api/reports/` contains only `pdf/` and `share/`; `src/app/api/triage/` contains only `next/`. Replacement for the two wrong lines:
+
+```
+    ├── POST /api/reports/pdf          → report PDF rendering
+    ├── POST /api/reports/share        → shareable report links
+    └── POST /api/triage/next          → deterministic next-question step
+```
+
+(Before writing, confirm each route directory's HTTP method by opening its `route.ts` — adjust `POST`/`GET` labels to the real exports.)
+
+### Item B — "usage_log rate limiting" in the architecture diagram (README.md line 109)
+
+Wrong (current):
+
+```
+        ├── Upstash Redis    — usage_log rate limiting (per user, per day)
+```
+
+Verified reality: rate limiting is Upstash sliding-window per minute with an in-process fallback (`src/lib/rate-limit.ts`; e.g. line 69 `limiter: Ratelimit.slidingWindow(30, "1 m"),`). No `usage_log` table exists in `supabase-schema.sql`. Replacement:
+
+```
+        ├── Upstash Redis    — sliding-window rate limiting (per user, per minute; in-process fallback)
+```
+
+### Item C — "Rate limiting via Postgres" key decision (README.md line 120)
+
+Wrong (current):
+
+```
+- **Rate limiting via Postgres.** A `usage_log` table with an indexed `(user_id, created_at)` compound key counts daily requests without an external counter. Falls back gracefully if Redis is unavailable.
+```
+
+Replacement:
+
+```
+- **Rate limiting via Upstash Redis.** Sliding-window limiters per scope (symptom-chat, image analysis, general API, translator) defined in `src/lib/rate-limit.ts`. When Redis errors at call time, an in-process fallback limiter enforces the same per-scope limits.
+```
+
+### Item D — phantom tables in the schema list (README.md lines 197–203)
+
+Wrong (current — the three phantom bullets within the seven-table list):
+
+```
+- **`triage_sessions`** — one row per symptom-checker session; stores structured state (`answered_questions`, `extracted_answers`, `urgency_level`)
+- **`chat_messages`** — per-turn message log for every triage session; used for report generation and async review
+...
+- **`usage_log`** — per-user daily AI request counter; `(user_id, created_at)` compound index; rate-limit fallback if Redis is unavailable
+```
+
+Verified reality: `supabase-schema.sql` has no `triage_sessions`, `chat_messages`, or `usage_log`. The real session-data table is `symptom_checks` — `supabase-schema.sql` lines 68–77:
+
+```sql
+-- Symptom checks
+CREATE TABLE symptom_checks (
+  id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+  pet_id UUID REFERENCES pets(id) ON DELETE CASCADE NOT NULL,
+  symptoms TEXT NOT NULL,
+  ai_response TEXT,
+  severity TEXT CHECK (severity IN ('low', 'medium', 'high', 'emergency')),
+  recommendation TEXT CHECK (recommendation IN ('monitor', 'vet_48h', 'vet_24h', 'emergency_vet')),
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+```
+
+Fix: open `supabase-schema.sql`, list every `CREATE TABLE` it actually contains, and rewrite the README's table list to exactly that set (with one-line accurate descriptions; for `symptom_checks` use: "one row per symptom check; stores symptoms text, AI response, severity, and recommendation"). Update the "Seven tables" count to the real number. Also verify whether `outcome_feedback` exists in any schema file (`rg "outcome_feedback" *.sql supabase*.sql` — there may be additional schema files like `supabase-audio-schema.sql`); describe only tables that exist in committed SQL.
+
+### Item E — Next.js version (AGENTS.md line 12)
+
+Wrong (current):
+
+```
+PawVital AI is a single Next.js 16.2.1 app (React 19, Tailwind 4, TypeScript 5) with optional Python sidecar microservices under `services/`. Package manager is **npm** (lockfile: `package-lock.json`).
+```
+
+Verified reality: `package.json` line 129: `"next": "16.2.6",`. Replacement: same sentence with `Next.js 16.2.6`. (If `package.json` shows a newer version when you run, use THAT version — or, more durably, replace the pinned number with "Next.js 16.x (see `package.json` for the exact pin)".)
+
+### Item F — lint claims (AGENTS.md line 69)
+
+Wrong (current):
+
+```
+- The ESLint config uses `eslint/config` with `defineConfig` and `globalIgnores` (ESLint 9 flat config). Pre-existing lint errors exist in test files (`@typescript-eslint/no-explicit-any`) and one `prefer-const` in `symptom-chat/route.ts`.
+```
+
+Verified reality (ran `npx eslint .` at authoring time): final summary line was `✖ 50 problems (0 errors, 50 warnings)`; observed warnings are `@typescript-eslint/no-unused-vars` (plus a small number of `@next/next/no-img-element`). Replacement:
+
+```
+- The ESLint config uses `eslint/config` with `defineConfig` and `globalIgnores` (ESLint 9 flat config). The repo currently lints with 0 errors and ~50 pre-existing warnings (mostly `@typescript-eslint/no-unused-vars`, a few `no-img-element`); do not introduce new errors.
+```
+
+Re-run `npx eslint .` yourself before writing and adjust the counts to what you observe.
+
+### Item G — sidecar hosting omits the GPU-host path (README.md lines 207–219)
+
+Current README sidecar intro:
+
+```
+Five optional microservices under `services/`. Run locally via `docker-compose.sidecars.yml` or deploy to HuggingFace Spaces / RunPod.
+```
+
+Verified reality — `plans/SIDECAR_DEPLOYMENT_RUNBOOK.md` lines 18–23: `vision-preprocess-service` is validated as a standalone Vercel FastAPI deployment; the four heavy sidecars exceed Vercel's Lambda size limits and use a Docker-native GPU-host bundle at `deploy/sidecars-gpu-host/README.md`. Add after the intro sentence (keep the service table unchanged):
+
+```
+Hosting note: `vision-preprocess-service` also runs as a standalone Vercel FastAPI deployment. The four heavier model-backed sidecars exceed Vercel's Lambda size limits and deploy via the Docker GPU-host bundle in `deploy/sidecars-gpu-host/` (see `plans/SIDECAR_DEPLOYMENT_RUNBOOK.md`).
+```
+
+## Steps
+
+1. **Read current files.** Open the current (dirty) `README.md` and `AGENTS.md`; locate each item by its quoted wrong text. Skip (and log) any item whose wrong text is already gone.
+2. **Apply items A–D and G to README.md**, and E–F to AGENTS.md, exactly as specified above (with the live re-verification noted in D, E, F).
+3. **Verification gates** (all must pass):
+   - `rg -n "usage_log" README.md` → no matches.
+   - `rg -n "triage_sessions|chat_messages" README.md` → no matches.
+   - `rg -n "POST /api/reports " README.md` and `rg -n "POST /api/triage " README.md` → no matches (note the trailing space pins the bare paths).
+   - `rg -n "16.2.1" AGENTS.md` → no matches.
+   - `rg -n "prefer-const" AGENTS.md` → no matches.
+   - `rg -n "sidecars-gpu-host" README.md` → at least one match.
+   - `npx eslint .` → unchanged result vs. baseline (doc edits cannot affect lint; this proves no stray file was touched): final line reports 0 errors.
+   - `git -C "G:\MY Website\pawvital-ai" status --short` → no NEW modified files beyond README.md and AGENTS.md (compare against the pre-existing dirty list).
+
+## Repo conventions
+
+- Doc-only change; no build/test gates needed beyond the greps and the no-op lint check above.
+- npm; ESLint 9 flat config (`npx eslint .`).
+
+## Out of scope
+
+- **Deferred (explicitly): the marketing-overclaim rewrite.** `plans/DEVELOPMENT_ROADMAP.md` line 19 records: `| Validated product scope | NEEDS RECONCILIATION | Public claims overstated species support, disease counts, breed counts, and multimodal scope |`. Reconciling public marketing claims is judgment-heavy and is NOT part of this plan — note it as deferred in your handoff.
+- Any source-code, schema-SQL, or config change. If a doc statement turns out to be true and the CODE is wrong, do not change code — report.
+- The dirty landing-page/auth edits in README's working tree — preserve them; edit only the sections in items A–D, G.
+
+## STOP conditions
+
+- A quoted "wrong" string is absent AND no corrected equivalent exists (the section was deleted entirely) — report instead of re-adding sections.
+- `supabase-schema.sql` cannot be reconciled into a simple table list (e.g. multiple conflicting schema files describe the same table) — report the conflict.
+- Any verification grep still matches after your edit (you missed an occurrence — fix or report).


### PR DESCRIPTION
## Summary

The PawVital **improve advisor** workflow audited the repo (baseline commit 19d15ac2) and wrote **documentation only** under plans/improve/: one index plus **10 prioritized, executable improvement plans**. No application source code is changed in this PR.

## Files (11)

- plans/improve/00-index.md
- plans/improve/01-server-session-integrity-symptom-chat.md
- plans/improve/02-body-size-cap-symptom-chat.md
- plans/improve/03-rate-limit-fail-closed-production.md
- plans/improve/04-auth-ratelimit-nearest-vets.md
- plans/improve/05-server-bind-image-gate-override.md
- plans/improve/06-usage-gate-fail-closed.md
- plans/improve/07-batch-translator-calls.md
- plans/improve/08-typecheck-script-and-build-gate.md
- plans/improve/09-owner-outcome-feedback-loop.md
- plans/improve/10-docs-sync-readme-agents.md

## Note for Cursor / Codex agents

- **Entry point:** plans/improve/00-index.md — priority order, dependency graph, and how to pick the next plan.
- **Execution:** use an **isolated worktree** and one ticket/branch per plan; follow project gates (thermo-review, tests, clinical rules).
- **Out of scope unless a plan explicitly authorizes it:** protected clinical logic files (	riage-engine, clinical-matrix, symptom-chat/route, symptom-memory).

## Test plan

- [ ] N/A — docs-only PR