### PR TITLE
VET-1580C: clarify Cohort 1 allowlist proof

### DIFF
--- a/docs/private-tester-cohort-1-registry-template.csv
+++ b/docs/private-tester-cohort-1-registry-template.csv
@@ -1,2 +1,2 @@
-tester_alias,email,dog_name,dog_age,dog_breed_size,device_browser,invite_status,consent_status,first_login_timestamp,first_symptom_check_timestamp,feedback_submitted,deletion_requested,access_disabled,notes
-example-tester,tester@example.com,Buddy,4 years,Golden Retriever medium-large,iPhone Safari,invited,manual-verify,,,,,,
+tester_alias,email,dog_name,dog_age,dog_breed_size,device_browser,allowlist_status,invitation_sent_proof,consent_status,first_login_timestamp,first_symptom_check_timestamp,feedback_submitted,deletion_requested,access_disabled,notes
+example-tester,tester@example.com,Buddy,4 years,Golden Retriever medium-large,iPhone Safari,allowlisted,manual-verify,manual-verify,,,,,,

--- a/docs/private-tester-cohort-1-report-template.md
+++ b/docs/private-tester-cohort-1-report-template.md
@@ -12,7 +12,8 @@ Use this after the first 48 hours of Cohort 1.
 
 ## Core metrics
 
-- Testers invited:
+- Testers allowlisted:
+- Invitations sent (attach manual proof):
 - Testers signed in:
 - Symptom checks started:
 - Symptom checks completed:

--- a/docs/private-tester-cohort-1-report-template.md
+++ b/docs/private-tester-cohort-1-report-template.md
@@ -7,7 +7,7 @@ Use this after the first 48 hours of Cohort 1.
 - Date window:
 - Release branch / commit:
 - Founder reviewer:
-- Invite count:
+- Allowlisted tester count:
 - Active tester count:
 
 ## Core metrics

--- a/src/app/(dashboard)/admin/cohort-launch/page.tsx
+++ b/src/app/(dashboard)/admin/cohort-launch/page.tsx
@@ -289,7 +289,7 @@ export default async function AdminCohortLaunchPage() {
           <div className="mt-4 space-y-3">
             {commandCenter.filters.failedSignInOrAccessSessions.length === 0 ? (
               <p className="text-sm text-slate-500">
-                No blocked or not-invited tester accounts are currently surfaced.
+                No blocked or not-allowlisted tester accounts are currently surfaced.
               </p>
             ) : (
               commandCenter.filters.failedSignInOrAccessSessions.map((entry) => (
@@ -301,7 +301,8 @@ export default async function AdminCohortLaunchPage() {
                     {entry.email || entry.testerId}
                   </p>
                   <p className="mt-1 text-xs uppercase tracking-wide text-slate-500">
-                    {entry.blocked ? "blocked" : "needs invite follow-up"} • {entry.accessReason}
+                    {entry.blocked ? "blocked" : "needs access follow-up"} •{" "}
+                    {entry.accessReason}
                   </p>
                   <p className="mt-2 text-sm text-slate-700">
                     Symptom checks: {entry.symptomChecks} • Negative feedback:{" "}

--- a/src/app/(dashboard)/admin/cohort-launch/page.tsx
+++ b/src/app/(dashboard)/admin/cohort-launch/page.tsx
@@ -84,7 +84,7 @@ export default async function AdminCohortLaunchPage() {
   });
 
   const summaryCards = [
-    ["Testers invited", commandCenter.summary.testersInvited],
+    ["Allowlisted testers", commandCenter.summary.allowlistedTesters],
     ["Signed-in testers", commandCenter.summary.signedInTesters],
     ["Completed symptom checks", commandCenter.summary.completedSymptomChecks],
     ["Report-linked cases", commandCenter.summary.reportsOpened],

--- a/src/lib/private-tester-cohort.ts
+++ b/src/lib/private-tester-cohort.ts
@@ -315,16 +315,21 @@ export function buildPrivateTesterRegistryTemplateRows(
 ) {
   return testers.map((tester) => ({
     access_disabled: tester.access.blocked ? "yes" : "no",
+    allowlist_status: tester.access.allowed
+      ? "allowlisted"
+      : tester.access.blocked
+        ? "blocked"
+        : "not_allowlisted",
     consent_status: "manual-verify",
     deletion_requested: "manual-verify",
-    device_browser: "capture-during-invite",
-    dog_age: "capture-during-invite",
-    dog_breed_size: "capture-during-invite",
+    device_browser: "capture-during-onboarding",
+    dog_age: "capture-during-onboarding",
+    dog_breed_size: "capture-during-onboarding",
     email: tester.user.email ?? "",
     feedback_submitted: tester.counts.outcomeFeedbackEntries > 0 ? "yes" : "no",
     first_login_timestamp: "capture-during-launch",
     first_symptom_check_timestamp: tester.recentCases.at(-1)?.createdAt ?? "",
-    invite_status: tester.access.allowed ? "invited" : tester.access.blocked ? "blocked" : "not-invited",
+    invitation_sent_proof: "manual-verify",
     tester_alias: tester.user.fullName ?? tester.user.id,
   }));
 }

--- a/src/lib/private-tester-cohort.ts
+++ b/src/lib/private-tester-cohort.ts
@@ -53,7 +53,7 @@ export interface PrivateTesterCohortCommandCenter {
     signInFailures: number;
     signedInTesters: number;
     testerAccessDisabled: number;
-    testersInvited: number;
+    allowlistedTesters: number;
   };
   triage: Record<PrivateTesterTriageSeverity, PrivateTesterTriageCase[]>;
 }
@@ -207,6 +207,7 @@ function buildNotes(
   const notes = [
     "Sign-in failures and deletion-request counts remain zero until a dedicated auth/admin incident log is wired into production storage.",
     "Reports opened is derived from report-linked case rows in the founder review ledger, not browser-level analytics.",
+    "Allowlisted tester count comes from private-tester configuration; sent invitation delivery must be verified separately.",
     "The current command center is cohort-aware only when private-tester cases are present in the stored feedback ledger.",
   ];
 
@@ -298,7 +299,7 @@ export function buildPrivateTesterCohortCommandCenter(input: {
       signInFailures: 0,
       signedInTesters: input.privateTesterDashboard.testers.length,
       testerAccessDisabled: input.privateTesterDashboard.summary.authAccessDisabled,
-      testersInvited: input.privateTesterDashboard.config.allowedEmailCount,
+      allowlistedTesters: input.privateTesterDashboard.config.allowedEmailCount,
     },
     triage: {
       P0: triageEntries.filter((entry) => entry.severity === "P0"),

--- a/tests/admin-cohort-launch.page.test.ts
+++ b/tests/admin-cohort-launch.page.test.ts
@@ -189,6 +189,8 @@ describe("AdminCohortLaunchPage", () => {
     expect(html).toContain("Founder triage queue");
     expect(html).toContain("Allowlisted testers");
     expect(html).not.toContain("Testers invited");
+    expect(html).not.toContain("not-invited");
+    expect(html).not.toContain("needs invite follow-up");
     expect(html).toContain("Question-flow flags");
     expect(html).toContain("question_flow_issue");
     expect(html).not.toContain("Repeated-question flags");

--- a/tests/admin-cohort-launch.page.test.ts
+++ b/tests/admin-cohort-launch.page.test.ts
@@ -90,6 +90,7 @@ function buildCommandCenterFixture() {
       dataDeletionRequests: 0,
       emergencyResults: 1,
       feedbackSubmitted: 1,
+      allowlistedTesters: 1,
       negativeFeedback: 1,
       questionFlowIssueFlags: 1,
       repeatedQuestionFlags: 1,
@@ -98,7 +99,6 @@ function buildCommandCenterFixture() {
       signInFailures: 0,
       signedInTesters: 1,
       testerAccessDisabled: 0,
-      testersInvited: 1,
     },
     triage: {
       P0: [
@@ -187,6 +187,8 @@ describe("AdminCohortLaunchPage", () => {
 
     expect(html).toContain("Private Tester Cohort 1 Command Center");
     expect(html).toContain("Founder triage queue");
+    expect(html).toContain("Allowlisted testers");
+    expect(html).not.toContain("Testers invited");
     expect(html).toContain("Question-flow flags");
     expect(html).toContain("question_flow_issue");
     expect(html).not.toContain("Repeated-question flags");

--- a/tests/admin-cohort-launch.production.test.ts
+++ b/tests/admin-cohort-launch.production.test.ts
@@ -85,6 +85,7 @@ function buildCommandCenterFixture() {
       dataDeletionRequests: 0,
       emergencyResults: 0,
       feedbackSubmitted: 0,
+      allowlistedTesters: 1,
       negativeFeedback: 0,
       questionFlowIssueFlags: 0,
       repeatedQuestionFlags: 0,
@@ -93,7 +94,6 @@ function buildCommandCenterFixture() {
       signInFailures: 0,
       signedInTesters: 1,
       testerAccessDisabled: 0,
-      testersInvited: 1,
     },
     triage: {
       P0: [],

--- a/tests/private-tester-cohort.test.ts
+++ b/tests/private-tester-cohort.test.ts
@@ -248,6 +248,7 @@ describe("private tester cohort command center helpers", () => {
       dataDeletionRequests: 1,
       emergencyResults: 1,
       feedbackSubmitted: 3,
+      allowlistedTesters: 5,
       negativeFeedback: 2,
       questionFlowIssueFlags: 1,
       repeatedQuestionFlags: 1,
@@ -255,8 +256,11 @@ describe("private tester cohort command center helpers", () => {
       reportsOpened: 3,
       signedInTesters: 2,
       testerAccessDisabled: 1,
-      testersInvited: 5,
     });
+    expect(dashboard.summary).not.toHaveProperty("testersInvited");
+    expect(dashboard.notes).toContain(
+      "Allowlisted tester count comes from private-tester configuration; sent invitation delivery must be verified separately."
+    );
     expect(dashboard.filters.failedSignInOrAccessSessions).toEqual([
       expect.objectContaining({
         accessDisabled: true,

--- a/tests/private-tester-cohort.test.ts
+++ b/tests/private-tester-cohort.test.ts
@@ -1,4 +1,7 @@
-import { buildPrivateTesterCohortCommandCenter } from "@/lib/private-tester-cohort";
+import {
+  buildPrivateTesterCohortCommandCenter,
+  buildPrivateTesterRegistryTemplateRows,
+} from "@/lib/private-tester-cohort";
 import type { AdminFeedbackLedgerDashboardData } from "@/lib/admin-feedback-ledger";
 import type { PrivateTesterDashboardData } from "@/lib/private-tester-admin";
 
@@ -285,6 +288,23 @@ describe("private tester cohort command center helpers", () => {
     expect(dashboard.triage.P0).toHaveLength(1);
     expect(dashboard.triage.P1).toHaveLength(1);
     expect(dashboard.triage.P3).toHaveLength(1);
+  });
+
+  it("keeps allowlist status separate from invitation-send proof in registry rows", () => {
+    const rows = buildPrivateTesterRegistryTemplateRows(
+      buildPrivateTesterDashboard().testers
+    );
+
+    expect(rows[0]).toMatchObject({
+      allowlist_status: "allowlisted",
+      invitation_sent_proof: "manual-verify",
+    });
+    expect(rows[0]).not.toHaveProperty("invite_status");
+    expect(rows[1]).toMatchObject({
+      access_disabled: "yes",
+      allowlist_status: "blocked",
+      invitation_sent_proof: "manual-verify",
+    });
   });
 
   it("does not propagate unexpected telemetry or secret fields from feedback cases", () => {


### PR DESCRIPTION
## Summary
- Renames the Cohort 1 command-center summary from invite proof to allowlist proof: `testersInvited` -> `allowlistedTesters`.
- Changes the admin command-center card from `Testers invited` to `Allowlisted testers`.
- Separates allowlist/access state from invitation-send proof in registry exports, the registry CSV template, the report template, and admin copy.

## Why
VET-1574C still lacks invitation-send proof. The previous command-center and registry language could make `PRIVATE_TESTER_ALLOWED_EMAILS` look like sent-invitation evidence. This PR keeps allowlist configuration visible while requiring invitation delivery to be verified separately.

## Verification
- `npm test -- --runTestsByPath tests/private-tester-cohort.test.ts tests/admin-cohort-launch.page.test.ts tests/admin-cohort-launch.production.test.ts --runInBand` passed: 3 suites / 8 tests.
- `npx tsc --noEmit --pretty false` passed.
- Targeted ESLint on changed files passed.
- `npm run lint` passed with existing warnings.
- `npm run build` passed with known Next workspace-root / metadata warnings.
- `git diff --check` and `git diff --cached --check` passed; the working-tree diff-check emitted only a non-blocking CSV LF-to-CRLF normalization warning before staging.
- Prohibited-surface scan was empty for runtime routing, env/schema/model/provider/package/deployment/protected clinical files.
- AutoScientists verifier passed: `G:\MY Website\.agents\autoscientists\runs\vet-1580c-cohort-command-center-invite-proof-label`.
- TecjLead final review: `GO_REVIEW_ONLY`, no Blocking/Should/Nit findings.

## Safety / gates
- No runtime routing changes.
- No provider calls.
- No Vercel env mutation.
- No Supabase schema mutation.
- No model flag changes.
- No protected clinical logic changes.
- Bumblebee: not applicable; no dependency or deployment-image files changed.

## GO / HOLD
- Command-center / registry semantics fix: GO_REVIEW_ONLY.
- Cohort 1 launch execution: HOLD until invitation-send proof and full tester-flow evidence exist.
- Public beta: HOLD.
- Model/NIM promotion: HOLD.
- PR merge: HOLD until required checks attach/pass and branch protection resolves cleanly.
