### PR TITLE
VET-1581C: harden candidate approval validation

### DIFF
--- a/scripts/build-model-candidate-selection-packet.mjs
+++ b/scripts/build-model-candidate-selection-packet.mjs
@@ -65,6 +65,50 @@ function hasText(value) {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+function isSha256Hex(value) {
+  return hasText(value) && /^[a-f0-9]{64}$/i.test(value.trim());
+}
+
+function isIsoUtcTimestamp(value) {
+  if (!hasText(value)) {
+    return false;
+  }
+
+  const timestamp = value.trim();
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(timestamp)) {
+    return false;
+  }
+
+  const parsed = new Date(timestamp);
+  if (Number.isNaN(parsed.getTime())) {
+    return false;
+  }
+
+  const normalized = timestamp.includes(".")
+    ? timestamp
+    : timestamp.replace("Z", ".000Z");
+  return parsed.toISOString() === normalized;
+}
+
+function isEvidenceReference(value) {
+  if (!hasText(value)) {
+    return false;
+  }
+
+  const reference = value.trim();
+  if (reference.includes("<") || reference.includes(">")) {
+    return false;
+  }
+
+  return (
+    /^https?:\/\/\S+$/i.test(reference) ||
+    /^(docs|plans|artifacts)\/\S+$/i.test(reference) ||
+    /^#\d+/.test(reference) ||
+    /^(issue|pr)\s+#?\d+/i.test(reference) ||
+    /^VET-\d+[A-Z]?(?:\b|[-_\s])/i.test(reference)
+  );
+}
+
 const allowedArtifactTypes = new Set([
   "provider-model-id",
   "adapter",
@@ -77,14 +121,32 @@ function validArtifactType(value) {
   return hasText(value) && allowedArtifactTypes.has(value);
 }
 
-function approvedValidationCapture(captureApproval) {
-  return (
-    captureApproval?.scope === "validation-output-capture-only" &&
-    captureApproval?.promotionApproval === false &&
-    hasText(captureApproval?.approvedBy) &&
+function validationCaptureBlockers(captureApproval) {
+  return [
+    captureApproval?.scope === "validation-output-capture-only"
+      ? null
+      : "candidate validation-output-capture approval scope must be validation-output-capture-only",
+    captureApproval?.promotionApproval === false
+      ? null
+      : "candidate validation-output-capture approval must not grant promotion",
+    hasText(captureApproval?.approvedBy)
+      ? null
+      : "candidate validation-output-capture approver missing",
+    hasText(captureApproval?.approvedAt)
+      ? null
+      : "candidate validation-output-capture approval timestamp missing",
     hasText(captureApproval?.approvedAt) &&
+    !isIsoUtcTimestamp(captureApproval?.approvedAt)
+      ? "candidate validation-output-capture approval timestamp must be an ISO-8601 UTC timestamp"
+      : null,
     hasText(captureApproval?.approvalRecord)
-  );
+      ? null
+      : "candidate validation-output-capture approval record reference missing",
+    hasText(captureApproval?.approvalRecord) &&
+    !isEvidenceReference(captureApproval?.approvalRecord)
+      ? "candidate validation-output-capture approval record reference must be a URL, issue/PR/ticket reference, or repo artifact path"
+      : null,
+  ].filter(Boolean);
 }
 
 function approvalBlockers(candidateApprovalRecord) {
@@ -115,14 +177,22 @@ function approvalBlockers(candidateApprovalRecord) {
     hasText(candidate.artifactSha256)
       ? null
       : "candidate artifact hash missing",
+    hasText(candidate.artifactSha256) && !isSha256Hex(candidate.artifactSha256)
+      ? "candidate artifact hash must be a 64-character SHA-256 hex digest"
+      : null,
     hasText(candidate.approvedBy) ? null : "candidate approval approver missing",
     hasText(candidate.approvedAt) ? null : "candidate approval timestamp missing",
+    hasText(candidate.approvedAt) && !isIsoUtcTimestamp(candidate.approvedAt)
+      ? "candidate approval timestamp must be an ISO-8601 UTC timestamp"
+      : null,
     hasText(candidate.approvalRecord)
       ? null
       : "candidate approval record reference missing",
-    approvedValidationCapture(captureApproval)
-      ? null
-      : "candidate validation-output-capture approval record missing",
+    hasText(candidate.approvalRecord) &&
+    !isEvidenceReference(candidate.approvalRecord)
+      ? "candidate approval record reference must be a URL, issue/PR/ticket reference, or repo artifact path"
+      : null,
+    ...validationCaptureBlockers(captureApproval),
     hasText(candidate.offlineTrainingEvalManifest)
       ? null
       : "offline training/eval artifact is not populated",

--- a/tests/vet1560-model-evidence.test.ts
+++ b/tests/vet1560-model-evidence.test.ts
@@ -556,6 +556,67 @@ describe("VET-1560 model evidence readouts", () => {
     }
   });
 
+  it("keeps candidate selection blocked for malformed approval evidence fields", () => {
+    const approvalRecordPath = path.join(
+      repoRoot,
+      "plans",
+      "VET-1563-extraction-candidate-approval-record.json",
+    );
+    writeFileSync(
+      approvalRecordPath,
+      `${JSON.stringify(
+        {
+          ticket: "VET-1563",
+          role: "extraction",
+          mode: "candidate-approval-record",
+          candidate: {
+            modelOrAdapterId: "nvidia/example-extraction-candidate",
+            provider: "nvidia-nim",
+            artifactType: "provider-model-id",
+            artifactSha256: "not-a-sha256",
+            offlineTrainingEvalManifest:
+              "provider-model-id proof: no local weight artifact",
+            approvedBy: "owner@example.com",
+            approvedAt: "June 4, 2026",
+            approvalRecord: "approved verbally",
+            captureApproval: {
+              scope: "validation-output-capture-only",
+              approvedBy: "owner@example.com",
+              approvedAt: "2026-99-99T00:00:00.000Z",
+              approvalRecord: "capture ok",
+              promotionApproval: false,
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    try {
+      const packet = runJson<CandidateSelectionPacket>([
+        "scripts/build-model-candidate-selection-packet.mjs",
+        "--role=extraction",
+      ]);
+
+      expect(packet.status).toBe("blocked");
+      expect(packet.candidateIdentityResolved).toBe(false);
+      expect(packet.blockers).toEqual(
+        expect.arrayContaining([
+          "candidate artifact hash must be a 64-character SHA-256 hex digest",
+          "candidate approval timestamp must be an ISO-8601 UTC timestamp",
+          "candidate approval record reference must be a URL, issue/PR/ticket reference, or repo artifact path",
+          "candidate validation-output-capture approval timestamp must be an ISO-8601 UTC timestamp",
+          "candidate validation-output-capture approval record reference must be a URL, issue/PR/ticket reference, or repo artifact path",
+        ]),
+      );
+    } finally {
+      if (existsSync(approvalRecordPath)) {
+        unlinkSync(approvalRecordPath);
+      }
+    }
+  });
+
   it("can consume a future candidate approval record without inferring identity from manifests", () => {
     const approvalRecordPath = path.join(
       repoRoot,


### PR DESCRIPTION
## VET-1581C candidate approval validation hardening

This is a review-only VET-1563 harness hardening change. It prevents malformed candidate approval evidence from resolving candidate identity or unlocking output-capture readiness.

### What changed

- Require candidate artifact hashes to be 64-character SHA-256 hex digests.
- Require candidate and validation-capture approval timestamps to be ISO-8601 UTC timestamps.
- Require candidate and validation-capture approval references to be reviewable URLs, issue/PR/ticket references, or repo artifact paths.
- Add a regression test proving malformed approval evidence keeps candidate selection blocked.

### Verification

- Direct malformed temporary approval record: blocked with explicit malformed-field blockers.
- Direct valid future temporary approval record: still resolves to `ready-for-output-capture`.
- `npx jest --runInBand --runTestsByPath tests/vet1560-model-evidence.test.ts --testNamePattern "malformed approval evidence"`
- `npx jest --runInBand --runTestsByPath tests/vet1560-model-evidence.test.ts --testNamePattern "unsupported approval artifact type|malformed approval evidence|future candidate approval record"`
- `npm test -- --runTestsByPath tests/vet1560-model-evidence.test.ts` passed 15/15.
- `npx eslint scripts/build-model-candidate-selection-packet.mjs tests/vet1560-model-evidence.test.ts`
- `npm run vet1560:regenerate-all`
- `git diff --check`
- AutoScientists verifier: ok=true.

### Scope guardrails

No provider calls, runtime routing, Vercel env, Supabase schema, model flags, package/dependency/deployment-image changes, protected clinical edits, committed candidate approval record, or frozen output writes.

### Gate status

Candidate approval validation harness: GO.
Candidate approval record: still absent.
Provider capture: HOLD.
Model/NIM promotion: HOLD.
Public-beta model lane: HOLD.