### PR TITLE
[codex] Land signup and checker local fixes

### DIFF
--- a/docs/security-header-allowances.md
+++ b/docs/security-header-allowances.md
@@ -16,4 +16,5 @@ VET-1362 keeps the browser hardening policy centralized in `next.config.ts` so t
 
 - `frame-ancestors 'none'` and `X-Frame-Options: DENY` both block framing/clickjacking attempts.
 - `Strict-Transport-Security` is production-only so local HTTP development stays usable while deployed environments enforce long-lived HTTPS.
-- `Referrer-Policy`, `Permissions-Policy`, and `X-Content-Type-Options` remain explicit and app-wide.
+- `Permissions-Policy` keeps camera and geolocation disabled, while allowing same-origin microphone access for the symptom-checker speech input. Cross-origin frames still cannot request microphone access.
+- `Referrer-Policy` and `X-Content-Type-Options` remain explicit and app-wide.

--- a/next.config.ts
+++ b/next.config.ts
@@ -32,7 +32,7 @@ export function buildSecurityHeaders(
     { key: "X-Frame-Options", value: "DENY" },
     {
       key: "Permissions-Policy",
-      value: "camera=(), geolocation=(), microphone=()",
+      value: "camera=(), geolocation=(), microphone=(self)",
     },
     { key: "Cross-Origin-Opener-Policy", value: "same-origin" },
     { key: "Cross-Origin-Resource-Policy", value: "same-site" },

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -8,13 +8,18 @@ import Button from "@/components/ui/button";
 import Input from "@/components/ui/input";
 import {
   appendRedirectParam,
-  buildBrowserCallbackUrl,
+  buildSignupCallbackUrl,
   getAuthFeedbackMessage,
   getAuthActionErrorMessage,
   resolvePostAuthRedirect,
 } from "@/lib/auth-routing";
 import { replaceWithBrowser } from "@/lib/browser-navigation";
 import { createClient, isSupabaseConfigured } from "@/lib/supabase";
+
+const EXPIRED_CONFIRMATION_ERRORS = new Set([
+  "otp_expired",
+  "confirm_link_expired",
+]);
 
 const benefits = [
   "7-day free trial, no credit card required",
@@ -29,9 +34,16 @@ export default function SignupPage() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
+  const [resendLoading, setResendLoading] = useState(false);
+  const [verifyLoading, setVerifyLoading] = useState(false);
+  const [confirmationCode, setConfirmationCode] = useState("");
   const [error, setError] = useState("");
   const [successMessage, setSuccessMessage] = useState("");
   const redirectTarget = resolvePostAuthRedirect(searchParams.get("redirect"));
+  const urlError = searchParams.get("error");
+  const hasExpiredLinkError =
+    urlError !== null && EXPIRED_CONFIRMATION_ERRORS.has(urlError);
+  const showResendButton = hasExpiredLinkError || Boolean(successMessage);
   const authFeedback = getAuthFeedbackMessage(
     searchParams.get("reason"),
     searchParams.get("error")
@@ -53,24 +65,39 @@ export default function SignupPage() {
         replaceWithBrowser(redirectTarget);
         return;
       }
-      const supabase = createClient();
-      const { data, error: authError } = await supabase.auth.signUp({
-        email,
-        password,
-        options: {
-          data: { full_name: name },
-          emailRedirectTo: buildBrowserCallbackUrl(window.location.origin, redirectTarget),
-        },
+      const signupResponse = await fetch("/api/auth/signup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: email.trim(),
+          password,
+          name,
+          next: redirectTarget,
+        }),
       });
+      const signupPayload = (await signupResponse.json()) as {
+        ok?: boolean;
+        redirect?: string;
+        requiresConfirmation?: boolean;
+        message?: string;
+      };
 
-      if (authError) throw authError;
+      if (!signupResponse.ok) {
+        throw new Error(
+          signupPayload.message ||
+            "We couldn't create your account right now. Please try again."
+        );
+      }
 
-      if (data.session) {
-        replaceWithBrowser(redirectTarget);
+      if (signupPayload.requiresConfirmation) {
+        setSuccessMessage(
+          signupPayload.message ||
+            "Check your email to confirm your account and continue."
+        );
         return;
       }
 
-      setSuccessMessage("Check your email to confirm your account and continue.");
+      replaceWithBrowser(signupPayload.redirect || redirectTarget);
     } catch (err: unknown) {
       console.error("Failed to create account", err);
       const message = getAuthActionErrorMessage(
@@ -81,6 +108,112 @@ export default function SignupPage() {
       setError(message);
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleVerifyConfirmationCode = async () => {
+    const trimmedEmail = email.trim();
+    const trimmedCode = confirmationCode.trim();
+
+    if (!trimmedEmail) {
+      setError("Enter your email above to confirm your account.");
+      return;
+    }
+
+    if (!trimmedCode) {
+      setError("Enter the 6-digit confirmation code from your email.");
+      return;
+    }
+
+    setVerifyLoading(true);
+    setError("");
+
+    try {
+      if (!isSupabaseConfigured) {
+        replaceWithBrowser(redirectTarget);
+        return;
+      }
+
+      const verifyResponse = await fetch("/api/auth/verify-signup-code", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: trimmedEmail,
+          token: trimmedCode,
+          next: redirectTarget,
+        }),
+      });
+      const verifyPayload = (await verifyResponse.json()) as {
+        ok?: boolean;
+        redirect?: string;
+        message?: string;
+      };
+
+      if (!verifyResponse.ok) {
+        throw new Error(
+          verifyPayload.message ||
+            "That confirmation code is invalid or has expired. Please resend the email and try again."
+        );
+      }
+
+      replaceWithBrowser(verifyPayload.redirect || redirectTarget);
+    } catch (err: unknown) {
+      console.error("Failed to verify signup confirmation code", err);
+      const message = getAuthActionErrorMessage(
+        err,
+        "signup",
+        "That confirmation code is invalid or has expired. Please resend the email and try again."
+      );
+      setError(message);
+    } finally {
+      setVerifyLoading(false);
+    }
+  };
+
+  const handleResendConfirmation = async () => {
+    const trimmedEmail = email.trim();
+    if (!trimmedEmail) {
+      setError("Enter your email above to resend the confirmation link.");
+      return;
+    }
+
+    setResendLoading(true);
+    setError("");
+
+    try {
+      if (!isSupabaseConfigured) {
+        setSuccessMessage(
+          "Check your email to confirm your account and continue."
+        );
+        return;
+      }
+
+      const supabase = createClient();
+      const emailRedirectTo = buildSignupCallbackUrl(
+        window.location.origin,
+        redirectTarget
+      );
+      const { error: resendError } = await supabase.auth.resend({
+        type: "signup",
+        email: trimmedEmail,
+        options: { emailRedirectTo },
+      });
+
+      if (resendError) throw resendError;
+
+      setSuccessMessage(
+        "We sent another confirmation email. Enter the 6-digit code from that email below."
+      );
+    } catch (err: unknown) {
+      console.error("Failed to resend confirmation email", err);
+      const message = getAuthActionErrorMessage(
+        err,
+        "signup",
+        "We couldn't resend the confirmation email right now. Please try again."
+      );
+      setError(message);
+    } finally {
+      setResendLoading(false);
     }
   };
 
@@ -177,6 +310,45 @@ export default function SignupPage() {
               <Button type="submit" loading={loading} className="w-full" size="lg">
                 Start Free Trial
               </Button>
+
+              {showResendButton && (
+                <>
+                  <p className="text-xs text-gray-500 text-center">
+                    Email links can expire if opened by security scanners.
+                    Resend the confirmation email, then enter the 6-digit code
+                    from the new email. Do not click the link.
+                  </p>
+                  <Input
+                    label="Confirmation code"
+                    value={confirmationCode}
+                    onChange={(e) => setConfirmationCode(e.target.value)}
+                    placeholder="6-digit code"
+                    icon={<Mail className="w-5 h-5" />}
+                    inputMode="numeric"
+                    autoComplete="one-time-code"
+                    maxLength={6}
+                  />
+                  <Button
+                    type="button"
+                    loading={verifyLoading}
+                    className="w-full"
+                    size="lg"
+                    onClick={() => void handleVerifyConfirmationCode()}
+                  >
+                    Confirm with code
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    loading={resendLoading}
+                    className="w-full"
+                    size="lg"
+                    onClick={() => void handleResendConfirmation()}
+                  >
+                    Resend confirmation email
+                  </Button>
+                </>
+              )}
 
               <p className="text-xs text-gray-500 text-center">
                 By signing up, you agree to our Terms of Service and Privacy Policy.

--- a/src/app/(dashboard)/symptom-checker/page.tsx
+++ b/src/app/(dashboard)/symptom-checker/page.tsx
@@ -48,6 +48,8 @@ import type {
   TriageLiveUpdateStatus,
 } from "@/lib/azure/web-pubsub";
 import { SYMPTOM_CHAT_REQUEST_TIMEOUT_MS } from "@/lib/symptom-chat/request-timeout";
+import { computeConversationProgress } from "@/lib/symptom-checker/session-progress";
+import type { TriageSession } from "@/lib/triage-engine";
 import { useSymptomTranslator } from "@/hooks/useSymptomTranslator";
 
 // --- Types ---
@@ -481,23 +483,11 @@ export default function SymptomCheckerPage() {
       return;
     }
 
-    const {
-      answered_questions: answeredQuestions,
-      unresolved_question_ids: unresolvedQuestionIds,
-    } = session as {
-      answered_questions?: Record<string, unknown>;
-      unresolved_question_ids?: unknown[];
-    };
-
-    const answered = answeredQuestions
-      ? Object.keys(answeredQuestions).length
-      : 0;
-    const unresolved = Array.isArray(unresolvedQuestionIds)
-      ? unresolvedQuestionIds.length
-      : 0;
-
+    const { answered, total } = computeConversationProgress(
+      session as TriageSession
+    );
     setAnsweredCount(answered);
-    setTotalQuestions(answered + unresolved);
+    setTotalQuestions(total);
   };
 
   // --- Send message to hybrid /api/ai/symptom-chat ---

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -5,6 +5,7 @@ import {
   buildBrowserCallbackUrl,
   buildLoginPath,
   buildRecoveryRedirectPath,
+  buildSignupPath,
   DEFAULT_AUTH_REDIRECT,
   RESET_PASSWORD_PATH,
   resolvePostAuthRedirect,
@@ -22,16 +23,15 @@ const OTP_TYPES = new Set<EmailOtpType>([
 function buildFailureRedirect(
   request: NextRequest,
   redirectTarget: string,
-  errorCode = "auth_callback_failed"
+  errorCode = "auth_callback_failed",
+  destination: "login" | "signup" = "login"
 ) {
-  return NextResponse.redirect(
-    new URL(
-      buildLoginPath(redirectTarget, {
-        error: errorCode,
-      }),
-      request.url
-  )
-  );
+  const failurePath =
+    destination === "signup"
+      ? buildSignupPath(redirectTarget, { error: errorCode })
+      : buildLoginPath(redirectTarget, { error: errorCode });
+
+  return NextResponse.redirect(new URL(failurePath, request.url));
 }
 
 function createRouteHandlerSupabaseClient(
@@ -66,6 +66,7 @@ export async function GET(request: NextRequest) {
   const rawType = searchParams.get("type");
   const rawFlow = searchParams.get("flow");
   const rawNext = searchParams.get("next");
+  const rawErrorCode = searchParams.get("error_code") || searchParams.get("error");
   const nextTarget = resolvePostAuthRedirect(rawNext, {
     allowedOrigin: origin,
     fallback: DEFAULT_AUTH_REDIRECT,
@@ -77,11 +78,27 @@ export async function GET(request: NextRequest) {
   });
 
   try {
+    if (rawErrorCode) {
+      const isSignupFlow = rawType === "signup";
+      const errorCode =
+        isSignupFlow && rawErrorCode === "otp_expired"
+          ? "confirm_link_expired"
+          : "auth_callback_failed";
+
+      return buildFailureRedirect(
+        request,
+        nextTarget,
+        errorCode,
+        isSignupFlow ? "signup" : "login"
+      );
+    }
+
     if (code) {
       const isRecoveryFlow =
         rawFlow === "recovery" ||
         rawType === "recovery" ||
         Boolean(rawNext?.includes(RESET_PASSWORD_PATH));
+      const isSignupFlow = rawType === "signup";
       const redirectTarget = isRecoveryFlow
         ? recoveryTarget.startsWith(RESET_PASSWORD_PATH)
           ? recoveryTarget
@@ -105,7 +122,12 @@ export async function GET(request: NextRequest) {
 
       const { error } = await supabase.auth.exchangeCodeForSession(code);
       if (error) {
-        return buildFailureRedirect(request, nextTarget);
+        return buildFailureRedirect(
+          request,
+          nextTarget,
+          "auth_callback_failed",
+          isSignupFlow ? "signup" : "login"
+        );
       }
       return response;
     }
@@ -129,9 +151,20 @@ export async function GET(request: NextRequest) {
       });
 
       if (error) {
-        const errorCode =
-          type === "recovery" ? "invalid_reset_link" : "auth_callback_failed";
-        return buildFailureRedirect(request, nextTarget, errorCode);
+        const isSignupFlow = type === "signup";
+        let errorCode = "auth_callback_failed";
+        if (isSignupFlow) {
+          errorCode = "confirm_link_expired";
+        } else if (type === "recovery") {
+          errorCode = "invalid_reset_link";
+        }
+
+        return buildFailureRedirect(
+          request,
+          nextTarget,
+          errorCode,
+          isSignupFlow ? "signup" : "login"
+        );
       }
 
       return response;

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -1,0 +1,120 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+import {
+  DEFAULT_AUTH_REDIRECT,
+  buildSignupCallbackUrl,
+  resolvePostAuthRedirect,
+} from "@/lib/auth-routing";
+
+function createRouteHandlerSupabaseClient(
+  request: NextRequest,
+  response: NextResponse
+) {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseKey) {
+    throw new Error("DEMO_MODE");
+  }
+
+  return createServerClient(supabaseUrl, supabaseKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll();
+      },
+      setAll(cookiesToSet) {
+        cookiesToSet.forEach(({ name, value, options }) => {
+          response.cookies.set(name, value, options);
+        });
+      },
+    },
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const origin = request.nextUrl.origin;
+
+  try {
+    const body = (await request.json()) as {
+      email?: string;
+      password?: string;
+      name?: string;
+      next?: string | null;
+    };
+    const email = body.email?.trim() || "";
+    const password = body.password || "";
+    const name = body.name?.trim() || "";
+    const nextTarget = resolvePostAuthRedirect(body.next, {
+      allowedOrigin: origin,
+      fallback: DEFAULT_AUTH_REDIRECT,
+    });
+
+    if (!email || !password) {
+      return NextResponse.json(
+        { error: "missing_fields", message: "Email and password are required." },
+        { status: 400 }
+      );
+    }
+
+    if (password.length < 8) {
+      return NextResponse.json(
+        {
+          error: "weak_password",
+          message: "Password must be at least 8 characters.",
+        },
+        { status: 400 }
+      );
+    }
+
+    const response = NextResponse.json({
+      ok: true,
+      redirect: nextTarget,
+      requiresConfirmation: false,
+    });
+    const supabase = createRouteHandlerSupabaseClient(request, response);
+    const signup = await supabase.auth.signUp({
+      email,
+      password,
+      options: {
+        data: { full_name: name },
+        emailRedirectTo: buildSignupCallbackUrl(origin, nextTarget),
+      },
+    });
+
+    if (signup.error) {
+      return NextResponse.json(
+        {
+          error: "signup_failed",
+          message:
+            "We couldn't create your account. If you already have one, try signing in instead.",
+        },
+        { status: 400 }
+      );
+    }
+
+    if (!signup.data?.session) {
+      return NextResponse.json(
+        {
+          ok: true,
+          requiresConfirmation: true,
+          message:
+            "Check your email to confirm your account. You can resend the email and enter the 6-digit code here if the link expires.",
+        }
+      );
+    }
+
+    return response;
+  } catch (error) {
+    if (error instanceof Error && error.message === "DEMO_MODE") {
+      return NextResponse.json({ ok: true, redirect: DEFAULT_AUTH_REDIRECT });
+    }
+
+    return NextResponse.json(
+      {
+        error: "server_error",
+        message: "We couldn't create your account right now. Please try again.",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/auth/verify-signup-code/route.ts
+++ b/src/app/api/auth/verify-signup-code/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+import {
+  buildSignupPath,
+  DEFAULT_AUTH_REDIRECT,
+  resolvePostAuthRedirect,
+} from "@/lib/auth-routing";
+
+function createRouteHandlerSupabaseClient(
+  request: NextRequest,
+  response: NextResponse
+) {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseKey) {
+    throw new Error("DEMO_MODE");
+  }
+
+  return createServerClient(supabaseUrl, supabaseKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll();
+      },
+      setAll(cookiesToSet) {
+        cookiesToSet.forEach(({ name, value, options }) => {
+          response.cookies.set(name, value, options);
+        });
+      },
+    },
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const origin = request.nextUrl.origin;
+
+  try {
+    const body = (await request.json()) as {
+      email?: string;
+      token?: string;
+      next?: string | null;
+    };
+    const email = body.email?.trim() || "";
+    const token = body.token?.trim() || "";
+    const nextTarget = resolvePostAuthRedirect(body.next, {
+      allowedOrigin: origin,
+      fallback: DEFAULT_AUTH_REDIRECT,
+    });
+
+    if (!email || !token) {
+      return NextResponse.json(
+        { error: "missing_fields", message: "Email and confirmation code are required." },
+        { status: 400 }
+      );
+    }
+
+    const response = NextResponse.json({ ok: true, redirect: nextTarget });
+    const supabase = createRouteHandlerSupabaseClient(request, response);
+
+    const signupVerify = await supabase.auth.verifyOtp({
+      email,
+      token,
+      type: "signup",
+    });
+
+    let data = signupVerify.data;
+    let verifyError = signupVerify.error;
+
+    if (verifyError) {
+      const emailVerify = await supabase.auth.verifyOtp({
+        email,
+        token,
+        type: "email",
+      });
+      data = emailVerify.data;
+      verifyError = emailVerify.error;
+    }
+
+    if (verifyError) {
+      return NextResponse.json(
+        {
+          error: "invalid_code",
+          message: verifyError.message,
+          redirect: buildSignupPath(nextTarget, { error: "confirm_link_expired" }),
+        },
+        { status: 400 }
+      );
+    }
+
+    if (!data.session) {
+      return NextResponse.json(
+        {
+          error: "no_session",
+          message: "Verification succeeded but no session was created.",
+          redirect: buildSignupPath(nextTarget, { error: "auth_callback_failed" }),
+        },
+        { status: 500 }
+      );
+    }
+
+    return response;
+  } catch (error) {
+    if (error instanceof Error && error.message === "DEMO_MODE") {
+      return NextResponse.json({ ok: true, redirect: DEFAULT_AUTH_REDIRECT });
+    }
+
+    return NextResponse.json(
+      { error: "server_error", message: "Could not verify the confirmation code." },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import {
   isPrivateTesterModeEnabled,
   PRIVATE_TESTER_MODE_RUNTIME_ATTRIBUTE,
 } from "@/lib/private-tester-access";
+import AuthErrorRedirect from "@/components/auth/auth-error-redirect";
 import RecoveryRedirect from "@/components/auth/recovery-redirect";
 import "./globals.css";
 
@@ -75,6 +76,7 @@ export default function RootLayout({
         }}
       >
         <RecoveryRedirect />
+        <AuthErrorRedirect />
         {children}
         <SpeedInsights />
       </body>

--- a/src/components/auth/auth-error-redirect.tsx
+++ b/src/components/auth/auth-error-redirect.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect } from "react";
+import {
+  buildSignupPath,
+  DEFAULT_AUTH_REDIRECT,
+  sanitizeRedirectTarget,
+} from "@/lib/auth-routing";
+import { replaceWithBrowser } from "@/lib/browser-navigation";
+
+const SIGNUP_LANDING_ERRORS = new Set(["otp_expired"]);
+const AUTH_PAGE_PREFIXES = ["/login", "/signup"];
+
+function shouldIgnoreCurrentPath(pathname: string) {
+  return AUTH_PAGE_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+}
+
+function resolveSafeRedirectTarget(url: URL) {
+  return (
+    sanitizeRedirectTarget(url.searchParams.get("redirect")) ||
+    sanitizeRedirectTarget(url.searchParams.get("next")) ||
+    DEFAULT_AUTH_REDIRECT
+  );
+}
+
+function resolveSignupErrorCode(params: URLSearchParams): string | null {
+  const errorCode = params.get("error_code");
+  if (errorCode && SIGNUP_LANDING_ERRORS.has(errorCode)) {
+    return errorCode;
+  }
+
+  const error = params.get("error");
+  if (error && SIGNUP_LANDING_ERRORS.has(error)) {
+    return error;
+  }
+
+  return null;
+}
+
+function buildSignupErrorRedirect(url: URL, errorCode: string) {
+  if (!SIGNUP_LANDING_ERRORS.has(errorCode)) {
+    return null;
+  }
+
+  const redirectTarget = resolveSafeRedirectTarget(url);
+  return buildSignupPath(redirectTarget, { error: errorCode });
+}
+
+function buildQuerySignupErrorRedirect(url: URL) {
+  const errorCode = resolveSignupErrorCode(url.searchParams);
+  if (!errorCode) {
+    return null;
+  }
+
+  return buildSignupErrorRedirect(url, errorCode);
+}
+
+function buildHashSignupErrorRedirect(url: URL) {
+  const hash = url.hash;
+  if (!hash) {
+    return null;
+  }
+
+  const hashParams = new URLSearchParams(hash.slice(1));
+  const errorCode = resolveSignupErrorCode(hashParams);
+  if (!errorCode) {
+    return null;
+  }
+
+  const redirectFromHash =
+    sanitizeRedirectTarget(hashParams.get("redirect")) ||
+    sanitizeRedirectTarget(hashParams.get("next"));
+  const redirectTarget =
+    redirectFromHash || resolveSafeRedirectTarget(url);
+
+  return buildSignupPath(redirectTarget, { error: errorCode });
+}
+
+function getSignupErrorRedirectFromCurrentUrl() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const url = new URL(window.location.href);
+  if (shouldIgnoreCurrentPath(url.pathname)) {
+    return null;
+  }
+
+  return buildQuerySignupErrorRedirect(url) || buildHashSignupErrorRedirect(url);
+}
+
+export default function AuthErrorRedirect() {
+  useEffect(() => {
+    const redirectPath = getSignupErrorRedirectFromCurrentUrl();
+    if (!redirectPath) {
+      return;
+    }
+
+    replaceWithBrowser(redirectPath);
+  }, []);
+
+  return null;
+}

--- a/src/components/symptom-checker/speech-input-button.tsx
+++ b/src/components/symptom-checker/speech-input-button.tsx
@@ -37,7 +37,7 @@ export function SpeechInputButton({
     return null;
   }
 
-  const isUnavailable = state === "disabled";
+  const isUnavailable = state === "disabled" && !error;
   const title = titleForState(state, error);
 
   return (

--- a/src/hooks/useAzureSpeechInput.ts
+++ b/src/hooks/useAzureSpeechInput.ts
@@ -54,11 +54,42 @@ export type UseAzureSpeechInputOptions = {
   onText(text: string): void;
 };
 
+type WebSpeechRecognition = {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  maxAlternatives: number;
+  onerror: ((event: { error?: string }) => void) | null;
+  onresult: ((event: { results: { [index: number]: { [index: number]: { transcript?: string } } } }) => void) | null;
+  start(): void;
+  stop(): void;
+};
+
+type WebSpeechWindow = Window & {
+  SpeechRecognition?: new () => WebSpeechRecognition;
+  webkitSpeechRecognition?: new () => WebSpeechRecognition;
+};
+
 function browserSupportsMicrophone(): boolean {
   return (
     typeof navigator !== "undefined" &&
     Boolean(navigator.mediaDevices?.getUserMedia)
   );
+}
+
+function browserSupportsWebSpeech(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  const speechWindow = window as WebSpeechWindow;
+  return Boolean(
+    speechWindow.SpeechRecognition || speechWindow.webkitSpeechRecognition
+  );
+}
+
+export function browserSupportsSpeechInput(): boolean {
+  return browserSupportsMicrophone() || browserSupportsWebSpeech();
 }
 
 export async function requestAzureSpeechBrowserToken(): Promise<AzureSpeechBrowserToken | null> {
@@ -106,6 +137,37 @@ function recognizeOnce(
   });
 }
 
+function recognizeWithWebSpeech(language: string): Promise<string> {
+  const speechWindow = window as WebSpeechWindow;
+  const SpeechRecognitionCtor =
+    speechWindow.SpeechRecognition || speechWindow.webkitSpeechRecognition;
+
+  if (!SpeechRecognitionCtor) {
+    return Promise.reject(new Error("Web Speech API unavailable"));
+  }
+
+  const recognition = new SpeechRecognitionCtor();
+  recognition.lang = language;
+  recognition.continuous = false;
+  recognition.interimResults = false;
+  recognition.maxAlternatives = 1;
+
+  return new Promise((resolve, reject) => {
+    recognition.onresult = (event) => {
+      const transcript = event.results[0]?.[0]?.transcript?.trim();
+      if (transcript) {
+        resolve(transcript);
+        return;
+      }
+      reject(new Error("empty transcript"));
+    };
+    recognition.onerror = (event) => {
+      reject(new Error(event.error || "speech_recognition_failed"));
+    };
+    recognition.start();
+  });
+}
+
 export function useAzureSpeechInput({
   fetchToken = requestAzureSpeechBrowserToken,
   language = "en-US",
@@ -120,7 +182,7 @@ export function useAzureSpeechInput({
 
   useEffect(() => {
     mountedRef.current = true;
-    setIsSupported(browserSupportsMicrophone());
+    setIsSupported(browserSupportsSpeechInput());
     return () => {
       mountedRef.current = false;
     };
@@ -131,7 +193,7 @@ export function useAzureSpeechInput({
   }, [onText]);
 
   const start = useCallback(async () => {
-    if (!mountedRef.current || !browserSupportsMicrophone()) {
+    if (!mountedRef.current || !browserSupportsSpeechInput()) {
       setState("disabled");
       return;
     }
@@ -145,36 +207,50 @@ export function useAzureSpeechInput({
       if (!mountedRef.current) {
         return;
       }
-      if (!token) {
-        setState("disabled");
+
+      if (token) {
+        const sdk = await loadSdk();
+        if (!mountedRef.current) {
+          return;
+        }
+        const speechConfig = sdk.SpeechConfig.fromAuthorizationToken(
+          token.token,
+          token.region
+        );
+        speechConfig.speechRecognitionLanguage = language;
+
+        recognizer = new sdk.SpeechRecognizer(
+          speechConfig,
+          sdk.AudioConfig.fromDefaultMicrophoneInput()
+        );
+
+        setState("listening");
+        const result = await recognizeOnce(recognizer);
+        if (!mountedRef.current) {
+          return;
+        }
+        const transcript = result.text?.trim();
+        if (transcript) {
+          onTextRef.current(transcript);
+        }
+        setState("idle");
         return;
       }
 
-      const sdk = await loadSdk();
-      if (!mountedRef.current) {
+      if (browserSupportsWebSpeech()) {
+        setState("listening");
+        const transcript = await recognizeWithWebSpeech(language);
+        if (!mountedRef.current) {
+          return;
+        }
+        if (transcript) {
+          onTextRef.current(transcript);
+        }
+        setState("idle");
         return;
       }
-      const speechConfig = sdk.SpeechConfig.fromAuthorizationToken(
-        token.token,
-        token.region
-      );
-      speechConfig.speechRecognitionLanguage = language;
 
-      recognizer = new sdk.SpeechRecognizer(
-        speechConfig,
-        sdk.AudioConfig.fromDefaultMicrophoneInput()
-      );
-
-      setState("listening");
-      const result = await recognizeOnce(recognizer);
-      if (!mountedRef.current) {
-        return;
-      }
-      const transcript = result.text?.trim();
-      if (transcript) {
-        onTextRef.current(transcript);
-      }
-      setState("idle");
+      setState("disabled");
     } catch {
       if (mountedRef.current) {
         setError("Speech input failed");

--- a/src/lib/auth-routing.ts
+++ b/src/lib/auth-routing.ts
@@ -23,6 +23,10 @@ export const AUTH_PAGE_PREFIXES = ["/login", "/signup", "/forgot-password"];
 export const AUTH_CALLBACK_ERROR_MESSAGES: Record<string, string> = {
   auth_callback_failed: "We couldn't complete sign-in from that link. Please try again.",
   invalid_reset_link: "That password reset link is invalid or has expired.",
+  otp_expired:
+    "That email confirmation link has expired. Please sign up again to receive a new one.",
+  confirm_link_expired:
+    "That email confirmation link has expired. Please sign up again to receive a new one.",
 };
 
 export const AUTH_REASON_MESSAGES: Record<string, string> = {
@@ -160,6 +164,16 @@ export function buildCallbackUrl(origin: string, redirectTarget: string | null |
   return url.toString();
 }
 
+export function buildSignupCallbackUrl(
+  origin: string,
+  redirectTarget: string | null | undefined
+) {
+  const url = new URL(buildCallbackUrl(origin, redirectTarget));
+  url.searchParams.set("type", "signup");
+
+  return url.toString();
+}
+
 export function buildBrowserCallbackUrl(
   origin: string,
   redirectTarget: string | null | undefined
@@ -203,6 +217,26 @@ export function buildLoginPath(
 
   if (options?.reason) {
     url.searchParams.set("reason", options.reason);
+  }
+
+  if (options?.error) {
+    url.searchParams.set("error", options.error);
+  }
+
+  return `${url.pathname}${url.search}`;
+}
+
+export function buildSignupPath(
+  redirectTarget: string | null | undefined,
+  options?: {
+    error?: string;
+  }
+) {
+  const url = new URL("/signup", INTERNAL_BASE_URL);
+  const safeTarget = sanitizeRedirectTarget(redirectTarget);
+
+  if (safeTarget) {
+    url.searchParams.set("redirect", safeTarget);
   }
 
   if (options?.error) {

--- a/src/lib/symptom-chat/extraction-helpers.ts
+++ b/src/lib/symptom-chat/extraction-helpers.ts
@@ -727,12 +727,19 @@ export function buildDeterministicQuestionFallback(
 ): string {
   const memory = ensureStructuredCaseMemory(session);
   const chiefComplaint = memory.chief_complaints[0]?.replace(/_/g, " ") || null;
+  const confirmedSummary = buildConfirmedQASummary(session, 1);
+  const latestAnswer = confirmedSummary
+    .split("\n")
+    .map((line) => line.match(/^- .+ -> (.+)$/)?.[1]?.trim())
+    .find(Boolean);
 
   let acknowledgment: string;
   if (hasPhoto && allowPhotoMention) {
     acknowledgment = `Thanks for sharing that about ${petName}; I'm combining your answer with the photo and the rest of the history.`;
+  } else if (latestAnswer) {
+    acknowledgment = `Got it - ${latestAnswer}.`;
   } else if (chiefComplaint) {
-    acknowledgment = `I'm keeping track of what you've shared so far about ${petName}'s ${chiefComplaint}.`;
+    acknowledgment = `Thanks for telling me about ${petName}'s ${chiefComplaint}.`;
   } else {
     acknowledgment = `Thanks for sharing that about ${petName}.`;
   }

--- a/src/lib/symptom-chat/question-phrasing.ts
+++ b/src/lib/symptom-chat/question-phrasing.ts
@@ -18,7 +18,8 @@ import {
 } from "@/lib/symptom-chat/extraction-helpers";
 
 const useNvidia = isNvidiaConfigured();
-export const TEXT_ONLY_QUESTION_PHRASING_BUDGET_MS = 10_000;
+// Shared between Nemotron preflight gate + Llama phrasing on text-only turns.
+export const TEXT_ONLY_QUESTION_PHRASING_BUDGET_MS = 25_000;
 
 export interface SymptomChatTurnMessage {
   role: "user" | "assistant";

--- a/src/lib/symptom-chat/request-timeout.ts
+++ b/src/lib/symptom-chat/request-timeout.ts
@@ -1,1 +1,4 @@
-export const SYMPTOM_CHAT_REQUEST_TIMEOUT_MS = 30000;
+// Must exceed the server route's worst-case model latency (phrasing 12s +
+// extraction 45s budgets can overlap); 30s raced the route and aborted
+// responses that were about to arrive.
+export const SYMPTOM_CHAT_REQUEST_TIMEOUT_MS = 90000;

--- a/src/lib/symptom-checker/session-progress.ts
+++ b/src/lib/symptom-checker/session-progress.ts
@@ -1,0 +1,43 @@
+import type { TriageSession } from "@/lib/triage-engine";
+
+type ProgressSession = Partial<
+  Pick<TriageSession, "answered_questions" | "case_memory" | "last_question_asked">
+>;
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function toString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+export function computeConversationProgress(session: ProgressSession): {
+  answered: number;
+  total: number;
+} {
+  const answeredQuestions = toStringArray(session.answered_questions);
+  const answered = answeredQuestions.length;
+  const unresolvedIds = toStringArray(
+    session.case_memory?.unresolved_question_ids
+  );
+  const pendingId =
+    toString(session.case_memory?.pending_question_id) ??
+    toString(session.last_question_asked);
+
+  const pendingIsOpen =
+    Boolean(pendingId) &&
+    !answeredQuestions.includes(pendingId) &&
+    !unresolvedIds.includes(pendingId);
+
+  const total = answered + unresolvedIds.length + (pendingIsOpen ? 1 : 0);
+
+  return {
+    answered,
+    total: Math.max(total, answered),
+  };
+}

--- a/tests/auth-callback.route.test.ts
+++ b/tests/auth-callback.route.test.ts
@@ -2,6 +2,7 @@ import { NextRequest } from "next/server";
 
 const mockExchangeCodeForSession = jest.fn();
 const mockVerifyOtp = jest.fn();
+
 const mockCreateServerClient = jest.fn(
   (
     _url: string,
@@ -193,6 +194,92 @@ describe("VET-1215 auth callback route", () => {
 
     expect(response.headers.get("location")).toBe(
       "https://app.pawvital.ai/login?redirect=%2Fdashboard&error=auth_callback_failed"
+    );
+  });
+
+  it("verifies signup email links with token_hash and redirects to the post-confirmation target", async () => {
+    mockVerifyOtp.mockResolvedValue({ error: null });
+
+    const { GET } = await import("@/app/api/auth/callback/route");
+    const response = await GET(
+      new NextRequest(
+        "https://app.pawvital.ai/api/auth/callback?token_hash=signup-token&type=signup&next=%2Fpets%2Fpet-1"
+      )
+    );
+
+    expect(mockVerifyOtp).toHaveBeenCalledWith({
+      token_hash: "signup-token",
+      type: "signup",
+    });
+    expect(response.headers.get("location")).toBe(
+      "https://app.pawvital.ai/pets/pet-1"
+    );
+    expect(response.headers.get("set-cookie")).toContain("sb-test-auth-token");
+    expect(mockExchangeCodeForSession).not.toHaveBeenCalled();
+  });
+
+  it("redirects expired signup confirmation links back to signup with a friendly error", async () => {
+    mockVerifyOtp.mockResolvedValue({
+      error: new Error("Email link is invalid or has expired"),
+    });
+
+    const { GET } = await import("@/app/api/auth/callback/route");
+    const response = await GET(
+      new NextRequest(
+        "https://app.pawvital.ai/api/auth/callback?token_hash=signup-token&type=signup&next=%2Fdashboard"
+      )
+    );
+
+    expect(response.headers.get("location")).toBe(
+      "https://app.pawvital.ai/signup?redirect=%2Fdashboard&error=confirm_link_expired"
+    );
+  });
+
+  it("routes Supabase expired signup callback errors back to signup", async () => {
+    const { GET } = await import("@/app/api/auth/callback/route");
+    const response = await GET(
+      new NextRequest(
+        "https://app.pawvital.ai/api/auth/callback?type=signup&next=%2Fdashboard&error=access_denied&error_code=otp_expired"
+      )
+    );
+
+    expect(response.headers.get("location")).toBe(
+      "https://app.pawvital.ai/signup?redirect=%2Fdashboard&error=confirm_link_expired"
+    );
+    expect(mockVerifyOtp).not.toHaveBeenCalled();
+    expect(mockExchangeCodeForSession).not.toHaveBeenCalled();
+  });
+
+  it("exchanges signup PKCE codes and redirects to the post-confirmation target", async () => {
+    mockExchangeCodeForSession.mockResolvedValue({ error: null });
+
+    const { GET } = await import("@/app/api/auth/callback/route");
+    const response = await GET(
+      new NextRequest(
+        "https://app.pawvital.ai/api/auth/callback?code=signup-code&type=signup&next=%2Fdashboard"
+      )
+    );
+
+    expect(mockExchangeCodeForSession).toHaveBeenCalledWith("signup-code");
+    expect(mockVerifyOtp).not.toHaveBeenCalled();
+    expect(response.headers.get("location")).toBe("https://app.pawvital.ai/dashboard");
+    expect(response.headers.get("set-cookie")).toContain("sb-test-auth-token");
+  });
+
+  it("redirects failed signup PKCE exchanges back to signup with a friendly error", async () => {
+    mockExchangeCodeForSession.mockResolvedValue({
+      error: new Error("PKCE code verifier not found"),
+    });
+
+    const { GET } = await import("@/app/api/auth/callback/route");
+    const response = await GET(
+      new NextRequest(
+        "https://app.pawvital.ai/api/auth/callback?code=signup-code&type=signup&next=%2Fdashboard"
+      )
+    );
+
+    expect(response.headers.get("location")).toBe(
+      "https://app.pawvital.ai/signup?redirect=%2Fdashboard&error=auth_callback_failed"
     );
   });
 });

--- a/tests/auth-error-redirect.test.tsx
+++ b/tests/auth-error-redirect.test.tsx
@@ -1,0 +1,95 @@
+/** @jest-environment jsdom */
+
+import * as React from "react";
+import { render, waitFor } from "@testing-library/react";
+import AuthErrorRedirect from "@/components/auth/auth-error-redirect";
+
+const mockReplaceWithBrowser = jest.fn();
+
+jest.mock("@/lib/browser-navigation", () => ({
+  replaceWithBrowser: (...args: unknown[]) => mockReplaceWithBrowser(...args),
+}));
+
+describe("auth error redirect guard", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("redirects otp_expired landing errors to signup with a friendly error code", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/?error=otp_expired&error_description=Email+link+is+invalid+or+has+expired"
+    );
+
+    render(React.createElement(AuthErrorRedirect));
+
+    await waitFor(() => expect(mockReplaceWithBrowser).toHaveBeenCalledTimes(1));
+    expect(mockReplaceWithBrowser).toHaveBeenCalledWith(
+      "/signup?redirect=%2Fdashboard&error=otp_expired"
+    );
+  });
+
+  it("redirects Supabase access_denied + error_code=otp_expired query and hash to signup", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/?error=access_denied&error_code=otp_expired&error_description=Email+link+is+invalid+or+has+expired#error=access_denied&error_code=otp_expired&error_description=Email+link+is+invalid+or+has+expired"
+    );
+
+    render(React.createElement(AuthErrorRedirect));
+
+    await waitFor(() => expect(mockReplaceWithBrowser).toHaveBeenCalledTimes(1));
+    expect(mockReplaceWithBrowser).toHaveBeenCalledWith(
+      "/signup?redirect=%2Fdashboard&error=otp_expired"
+    );
+  });
+
+  it("preserves safe redirect targets when rerouting otp_expired errors", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/?error=otp_expired&redirect=%2Fsymptom-checker"
+    );
+
+    render(React.createElement(AuthErrorRedirect));
+
+    await waitFor(() => expect(mockReplaceWithBrowser).toHaveBeenCalledTimes(1));
+    expect(mockReplaceWithBrowser).toHaveBeenCalledWith(
+      "/signup?redirect=%2Fsymptom-checker&error=otp_expired"
+    );
+  });
+
+  it("drops unsafe external redirect targets from otp_expired errors", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/?error=otp_expired&redirect=https%3A%2F%2Fevil.example%2Fsteal"
+    );
+
+    render(React.createElement(AuthErrorRedirect));
+
+    await waitFor(() => expect(mockReplaceWithBrowser).toHaveBeenCalledTimes(1));
+
+    const destination = mockReplaceWithBrowser.mock.calls[0][0] as string;
+    expect(destination).toBe("/signup?redirect=%2Fdashboard&error=otp_expired");
+    expect(destination).not.toContain("evil.example");
+  });
+
+  it("does not reroute auth errors when already on signup or login", () => {
+    window.history.replaceState({}, "", "/signup?error=otp_expired");
+
+    render(React.createElement(AuthErrorRedirect));
+
+    expect(mockReplaceWithBrowser).not.toHaveBeenCalled();
+  });
+
+  it("does not reroute unrelated landing-page query params", () => {
+    window.history.replaceState({}, "", "/?utm_source=email");
+
+    render(React.createElement(AuthErrorRedirect));
+
+    expect(mockReplaceWithBrowser).not.toHaveBeenCalled();
+  });
+});

--- a/tests/auth-pages.network-error.test.tsx
+++ b/tests/auth-pages.network-error.test.tsx
@@ -7,6 +7,7 @@ import LoginPage from "@/app/(auth)/login/page";
 import SignupPage from "@/app/(auth)/signup/page";
 
 const mockReplace = jest.fn();
+const mockReplaceWithBrowser = jest.fn();
 const mockSearchParams = new URLSearchParams();
 const mockCreateClient = jest.fn();
 const mockCreateRecoveryClient = jest.fn();
@@ -34,6 +35,10 @@ jest.mock("next/navigation", () => ({
   useSearchParams: () => mockSearchParams,
 }));
 
+jest.mock("@/lib/browser-navigation", () => ({
+  replaceWithBrowser: (...args: unknown[]) => mockReplaceWithBrowser(...args),
+}));
+
 jest.mock("@/lib/supabase", () => ({
   createClient: () => mockCreateClient(),
   createRecoveryClient: () => mockCreateRecoveryClient(),
@@ -52,6 +57,9 @@ function fillRequiredAuthFields() {
 describe("auth page network error handling", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSearchParams.forEach((_, key) => {
+      mockSearchParams.delete(key);
+    });
     mockCreateRecoveryClient.mockImplementation(() => mockCreateClient());
   });
 
@@ -111,13 +119,11 @@ describe("auth page network error handling", () => {
 
   it("shows the friendly network message on account creation failure", async () => {
     const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
-    mockCreateClient.mockReturnValue({
-      auth: {
-        signUp: jest
-          .fn()
-          .mockRejectedValue(new TypeError("Network request failed")),
-      },
-    });
+    const fetchMock = jest
+      .fn()
+      .mockRejectedValue(new TypeError("Network request failed"));
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as typeof fetch;
 
     try {
       render(React.createElement(SignupPage));
@@ -137,6 +143,7 @@ describe("auth page network error handling", () => {
         ).toBeTruthy()
       );
     } finally {
+      globalThis.fetch = originalFetch;
       errorSpy.mockRestore();
     }
   });
@@ -169,6 +176,242 @@ describe("auth page network error handling", () => {
     } finally {
       errorSpy.mockRestore();
     }
+  });
+
+  it("redirects after signup when the server route establishes a session", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ok: true,
+        redirect: "/dashboard",
+        requiresConfirmation: false,
+      }),
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    try {
+      render(React.createElement(SignupPage));
+
+      fireEvent.change(screen.getByPlaceholderText("Your name"), {
+        target: { value: "Dog Parent" },
+      });
+      fillRequiredAuthFields();
+
+      fireEvent.click(screen.getByRole("button", { name: "Start Free Trial" }));
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+      expect(fetchMock).toHaveBeenCalledWith("/api/auth/signup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: "owner@example.com",
+          password: "super-secret-password",
+          name: "Dog Parent",
+          next: "/dashboard",
+        }),
+      });
+      expect(mockReplaceWithBrowser).toHaveBeenCalledWith("/dashboard");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("shows confirmation instructions when signup requires email verification", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ok: true,
+        requiresConfirmation: true,
+        message: "Check your email to confirm your account.",
+      }),
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    try {
+      render(React.createElement(SignupPage));
+
+      fireEvent.change(screen.getByPlaceholderText("Your name"), {
+        target: { value: "Dog Parent" },
+      });
+      fillRequiredAuthFields();
+
+      fireEvent.click(screen.getByRole("button", { name: "Start Free Trial" }));
+
+      await waitFor(() =>
+        expect(
+          screen.getByText("Check your email to confirm your account.")
+        ).toBeTruthy()
+      );
+
+      expect(mockReplaceWithBrowser).not.toHaveBeenCalled();
+      expect(
+        screen.getByRole("button", { name: "Resend confirmation email" })
+      ).toBeTruthy();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("shows a resend confirmation button when signup lands with otp_expired", () => {
+    mockSearchParams.set("error", "otp_expired");
+    mockCreateClient.mockReturnValue({ auth: {} });
+
+    render(React.createElement(SignupPage));
+
+    expect(
+      screen.getByRole("button", { name: "Resend confirmation email" })
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        "That email confirmation link has expired. Please sign up again to receive a new one."
+      )
+    ).toBeTruthy();
+  });
+
+  it("shows a resend confirmation button when signup lands with confirm_link_expired", () => {
+    mockSearchParams.set("error", "confirm_link_expired");
+    mockCreateClient.mockReturnValue({ auth: {} });
+
+    render(React.createElement(SignupPage));
+
+    expect(
+      screen.getByRole("button", { name: "Resend confirmation email" })
+    ).toBeTruthy();
+  });
+
+  it("shows a server signup error when the signup route rejects the request", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({
+        message:
+          "An account with this email already exists. Sign in with your password, or reset it from the login page.",
+      }),
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    try {
+      render(React.createElement(SignupPage));
+
+      fireEvent.change(screen.getByPlaceholderText("Your name"), {
+        target: { value: "Dog Parent" },
+      });
+      fillRequiredAuthFields();
+      fireEvent.click(screen.getByRole("button", { name: "Start Free Trial" }));
+
+      await waitFor(() =>
+        expect(
+          screen.getByText(
+            "An account with this email already exists. Sign in with your password, or reset it from the login page."
+          )
+        ).toBeTruthy()
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("resends signup confirmation emails through the API auth callback", async () => {
+    const resend = jest.fn().mockResolvedValue({ error: null });
+    mockSearchParams.set("error", "otp_expired");
+    mockCreateClient.mockReturnValue({
+      auth: { resend },
+    });
+
+    render(React.createElement(SignupPage));
+
+    fireEvent.change(screen.getByPlaceholderText("you@example.com"), {
+      target: { value: "owner@example.com" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Resend confirmation email" })
+    );
+
+    await waitFor(() => expect(resend).toHaveBeenCalled());
+
+    expect(resend).toHaveBeenCalledWith({
+      type: "signup",
+      email: "owner@example.com",
+      options: {
+        emailRedirectTo:
+          "http://localhost/api/auth/callback?next=%2Fdashboard&type=signup",
+      },
+    });
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "We sent another confirmation email. Enter the 6-digit code from that email below."
+        )
+      ).toBeTruthy()
+    );
+  });
+
+  it("verifies signup with a 6-digit confirmation code through the server route", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, redirect: "/dashboard" }),
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as typeof fetch;
+    mockSearchParams.set("error", "otp_expired");
+    mockCreateClient.mockReturnValue({
+      auth: {},
+    });
+
+    try {
+      render(React.createElement(SignupPage));
+
+      fireEvent.change(screen.getByPlaceholderText("you@example.com"), {
+        target: { value: "owner@example.com" },
+      });
+      fireEvent.change(screen.getByPlaceholderText("6-digit code"), {
+        target: { value: "123456" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Confirm with code" }));
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+      expect(fetchMock).toHaveBeenCalledWith("/api/auth/verify-signup-code", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: "owner@example.com",
+          token: "123456",
+          next: "/dashboard",
+        }),
+      });
+      expect(mockReplaceWithBrowser).toHaveBeenCalledWith("/dashboard");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("requires an email before resending signup confirmation", async () => {
+    mockSearchParams.set("error", "otp_expired");
+    mockCreateClient.mockReturnValue({
+      auth: {
+        resend: jest.fn(),
+      },
+    });
+
+    render(React.createElement(SignupPage));
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Resend confirmation email" })
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("Enter your email above to resend the confirmation link.")
+      ).toBeTruthy()
+    );
   });
 
   it("sends password reset emails through the implicit recovery client", async () => {

--- a/tests/auth-routing.test.ts
+++ b/tests/auth-routing.test.ts
@@ -6,6 +6,7 @@ import {
   buildRecoveryPageUrl,
   buildRecoveryRedirectPath,
   buildRedirectTarget,
+  buildSignupCallbackUrl,
   buildLoginPath,
   getAuthFeedbackMessage,
   getAuthActionErrorMessage,
@@ -72,6 +73,11 @@ describe("VET-1215 auth routing helpers", () => {
     expect(buildRecoveryPageUrl("https://pawvital.ai", "/pets/1")).toBe(
       "https://pawvital.ai/reset-password?redirect=%2Fpets%2F1"
     );
+    expect(
+      buildSignupCallbackUrl("https://pawvital.ai", "/dashboard")
+    ).toBe(
+      "https://pawvital.ai/api/auth/callback?next=%2Fdashboard&type=signup"
+    );
   });
 
   it("surfaces private-tester access redirects as friendly login feedback", () => {
@@ -126,5 +132,26 @@ describe("VET-1215 auth routing helpers", () => {
         "Fallback"
       )
     ).toBe("Invalid login credentials");
+  });
+
+  it("surfaces expired email confirmation links with friendly signup feedback", () => {
+    expect(getAuthFeedbackMessage(null, "otp_expired")).toEqual({
+      tone: "error",
+      text: "That email confirmation link has expired. Please sign up again to receive a new one.",
+    });
+    expect(getAuthFeedbackMessage(null, "confirm_link_expired")).toEqual({
+      tone: "error",
+      text: "That email confirmation link has expired. Please sign up again to receive a new one.",
+    });
+  });
+
+  it("routes signup email confirmation through the API callback instead of the browser page", () => {
+    const apiCallback = buildCallbackUrl("https://pawvital.ai", "/dashboard");
+    const browserCallback = buildBrowserCallbackUrl("https://pawvital.ai", "/dashboard");
+
+    expect(apiCallback).toBe("https://pawvital.ai/api/auth/callback?next=%2Fdashboard");
+    expect(browserCallback).toBe("https://pawvital.ai/auth/callback?next=%2Fdashboard");
+    expect(new URL(apiCallback).pathname).toBe("/api/auth/callback");
+    expect(new URL(browserCallback).pathname).toBe("/auth/callback");
   });
 });

--- a/tests/azure-speech-input-hook.test.ts
+++ b/tests/azure-speech-input-hook.test.ts
@@ -125,8 +125,25 @@ describe("useAzureSpeechInput", () => {
     expect(screen.getByTestId("speech-state").textContent).toBe("idle");
   });
 
-  it("disables itself without calling the SDK when no token is available", async () => {
+  it("falls back to browser speech when Azure token is unavailable", async () => {
     const { sdk } = makeSpeechSdk("ignored transcript");
+    const start = jest.fn();
+    const stop = jest.fn();
+    const SpeechRecognitionMock = jest.fn(() => ({
+      continuous: false,
+      interimResults: false,
+      lang: "en-US",
+      maxAlternatives: 1,
+      onerror: null,
+      onresult: null,
+      start,
+      stop,
+    }));
+
+    Object.defineProperty(window, "SpeechRecognition", {
+      configurable: true,
+      value: SpeechRecognitionMock,
+    });
 
     render(
       React.createElement(SpeechHarness, {
@@ -142,10 +159,18 @@ describe("useAzureSpeechInput", () => {
     );
     fireEvent.click(screen.getByRole("button", { name: "start" }));
 
+    await waitFor(() => expect(start).toHaveBeenCalled());
+    const recognition = SpeechRecognitionMock.mock.results[0]?.value;
+    recognition.onresult({
+      results: { 0: { 0: { transcript: "my dog is limping" } } },
+    });
+
     await waitFor(() =>
-      expect(screen.getByTestId("speech-state").textContent).toBe("disabled")
+      expect(screen.getByTestId("transcript").textContent).toBe(
+        "my dog is limping"
+      )
     );
     expect(sdk.SpeechRecognizer).not.toHaveBeenCalled();
-    expect(screen.getByTestId("transcript").textContent).toBe("");
+    expect(screen.getByTestId("speech-state").textContent).toBe("idle");
   });
 });

--- a/tests/question-phrasing.test.ts
+++ b/tests/question-phrasing.test.ts
@@ -39,6 +39,7 @@ import {
   gateQuestionBeforePhrasing,
   phraseQuestion,
   sanitizeQuestionDraft,
+  TEXT_ONLY_QUESTION_PHRASING_BUDGET_MS,
 } from "@/lib/symptom-chat/question-phrasing";
 
 const pet: PetProfile = {
@@ -118,7 +119,7 @@ describe("question phrasing helpers", () => {
         settled = true;
       });
 
-      await jest.advanceTimersByTimeAsync(10_001);
+      await jest.advanceTimersByTimeAsync(TEXT_ONLY_QUESTION_PHRASING_BUDGET_MS + 1);
 
       expect(settled).toBe(true);
       await expect(resultPromise).resolves.toEqual({
@@ -188,7 +189,7 @@ describe("question phrasing helpers", () => {
         settled = true;
       });
 
-      await jest.advanceTimersByTimeAsync(10_001);
+      await jest.advanceTimersByTimeAsync(TEXT_ONLY_QUESTION_PHRASING_BUDGET_MS + 1);
 
       expect(settled).toBe(true);
       await expect(resultPromise).resolves.toBe(
@@ -231,7 +232,7 @@ describe("question phrasing helpers", () => {
         settled = true;
       });
 
-      await jest.advanceTimersByTimeAsync(10_001);
+      await jest.advanceTimersByTimeAsync(TEXT_ONLY_QUESTION_PHRASING_BUDGET_MS + 1);
 
       expect(settled).toBe(true);
       await expect(resultPromise).resolves.toBe(

--- a/tests/security-headers-config.test.ts
+++ b/tests/security-headers-config.test.ts
@@ -48,7 +48,7 @@ describe("security header config", () => {
     expect(headers.get("X-Content-Type-Options")).toBe("nosniff");
     expect(headers.get("X-Frame-Options")).toBe("DENY");
     expect(headers.get("Permissions-Policy")).toBe(
-      "camera=(), geolocation=(), microphone=()",
+      "camera=(), geolocation=(), microphone=(self)",
     );
     expect(headers.get("Strict-Transport-Security")).toBe(
       "max-age=63072000; includeSubDomains; preload",

--- a/tests/session-progress.test.ts
+++ b/tests/session-progress.test.ts
@@ -1,0 +1,58 @@
+import { computeConversationProgress } from "@/lib/symptom-checker/session-progress";
+import { createSession } from "@/lib/triage-engine";
+
+describe("computeConversationProgress", () => {
+  it("counts answered questions and pending follow-up separately", () => {
+    const session = createSession();
+    session.answered_questions = ["water_intake", "appetite_duration"];
+    session.last_question_asked = "weight_loss";
+    session.case_memory = {
+      ...session.case_memory!,
+      unresolved_question_ids: ["vomit_frequency"],
+      pending_question_id: "weight_loss",
+    };
+
+    expect(computeConversationProgress(session)).toEqual({
+      answered: 2,
+      total: 4,
+    });
+  });
+
+  it("does not double-count pending question already in unresolved list", () => {
+    const session = createSession();
+    session.answered_questions = ["water_intake"];
+    session.last_question_asked = "appetite_duration";
+    session.case_memory = {
+      ...session.case_memory!,
+      unresolved_question_ids: ["appetite_duration"],
+      pending_question_id: "appetite_duration",
+    };
+
+    expect(computeConversationProgress(session)).toEqual({
+      answered: 1,
+      total: 2,
+    });
+  });
+
+  it("does not crash on malformed legacy session payloads", () => {
+    const malformedSession = {
+      answered_questions: { water_intake: true },
+      case_memory: {
+        unresolved_question_ids: "appetite_duration",
+        pending_question_id: 42,
+      },
+      last_question_asked: "weight_loss",
+    };
+
+    expect(
+      computeConversationProgress(
+        malformedSession as unknown as Parameters<
+          typeof computeConversationProgress
+        >[0]
+      )
+    ).toEqual({
+      answered: 0,
+      total: 1,
+    });
+  });
+});

--- a/tests/signup.route.test.ts
+++ b/tests/signup.route.test.ts
@@ -1,0 +1,207 @@
+import { NextRequest } from "next/server";
+
+const mockSignUp = jest.fn();
+
+const mockCreateServerClient = jest.fn(
+  (
+    _url: string,
+    _key: string,
+    options: {
+      cookies: {
+        setAll: (
+          cookies: Array<{
+            name: string;
+            value: string;
+            options?: Record<string, unknown>;
+          }>
+        ) => void;
+      };
+    }
+  ) => ({
+    auth: {
+      signUp: async (payload: {
+        email: string;
+        password: string;
+        options: {
+          data: { full_name: string };
+          emailRedirectTo: string;
+        };
+      }) => {
+        const result = await mockSignUp(payload);
+        if (result.data?.session && !result.error) {
+          options.cookies.setAll([
+            {
+              name: "sb-test-auth-token",
+              value: "session-cookie",
+              options: { httpOnly: true, path: "/" },
+            },
+          ]);
+        }
+        return result;
+      },
+    },
+  })
+);
+
+jest.mock("@supabase/ssr", () => ({
+  createServerClient: (...args: unknown[]) => mockCreateServerClient(...args),
+}));
+
+describe("signup route", () => {
+  const originalSupabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const originalSupabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://supabase.example";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+    mockSignUp.mockResolvedValue({
+      data: { session: { access_token: "token" } },
+      error: null,
+    });
+  });
+
+  afterAll(() => {
+    if (originalSupabaseUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    } else {
+      process.env.NEXT_PUBLIC_SUPABASE_URL = originalSupabaseUrl;
+    }
+
+    if (originalSupabaseAnonKey === undefined) {
+      delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+    } else {
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = originalSupabaseAnonKey;
+    }
+  });
+
+  it("signs up through the anon auth boundary and redirects when a session is created", async () => {
+    const { POST } = await import("@/app/api/auth/signup/route");
+    const response = await POST(
+      new NextRequest("https://app.pawvital.ai/api/auth/signup", {
+        method: "POST",
+        body: JSON.stringify({
+          email: " OWNER@example.com ",
+          password: "super-secret-password",
+          name: "Dog Parent",
+          next: "/symptom-checker",
+        }),
+      })
+    );
+
+    expect(mockSignUp).toHaveBeenCalledWith({
+      email: "OWNER@example.com",
+      password: "super-secret-password",
+      options: {
+        data: { full_name: "Dog Parent" },
+        emailRedirectTo:
+          "https://app.pawvital.ai/api/auth/callback?next=%2Fsymptom-checker&type=signup",
+      },
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("set-cookie")).toContain("sb-test-auth-token");
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      redirect: "/symptom-checker",
+      requiresConfirmation: false,
+    });
+  });
+
+  it("keeps the user on signup when email confirmation is required", async () => {
+    mockSignUp.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+
+    const { POST } = await import("@/app/api/auth/signup/route");
+    const response = await POST(
+      new NextRequest("https://app.pawvital.ai/api/auth/signup", {
+        method: "POST",
+        body: JSON.stringify({
+          email: "owner@example.com",
+          password: "super-secret-password",
+          next: "/dashboard",
+        }),
+      })
+    );
+
+    expect(response.headers.get("set-cookie")).toBeNull();
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      requiresConfirmation: true,
+      message:
+        "Check your email to confirm your account. You can resend the email and enter the 6-digit code here if the link expires.",
+    });
+  });
+
+  it("sanitizes unsafe redirects before building the confirmation callback", async () => {
+    const { POST } = await import("@/app/api/auth/signup/route");
+    const response = await POST(
+      new NextRequest("https://app.pawvital.ai/api/auth/signup", {
+        method: "POST",
+        body: JSON.stringify({
+          email: "owner@example.com",
+          password: "super-secret-password",
+          next: "https://evil.example/steal",
+        }),
+      })
+    );
+
+    expect(mockSignUp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          emailRedirectTo:
+            "https://app.pawvital.ai/api/auth/callback?next=%2Fdashboard&type=signup",
+        }),
+      })
+    );
+    await expect(response.json()).resolves.toMatchObject({
+      redirect: "/dashboard",
+    });
+  });
+
+  it("does not confirm existing accounts from the public route", async () => {
+    mockSignUp.mockResolvedValue({
+      data: { session: null },
+      error: { message: "User already registered", status: 422 },
+    });
+
+    const { POST } = await import("@/app/api/auth/signup/route");
+    const response = await POST(
+      new NextRequest("https://app.pawvital.ai/api/auth/signup", {
+        method: "POST",
+        body: JSON.stringify({
+          email: "owner@example.com",
+          password: "existing-password",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "signup_failed",
+      message:
+        "We couldn't create your account. If you already have one, try signing in instead.",
+    });
+  });
+
+  it("does not create weak-password accounts", async () => {
+    const { POST } = await import("@/app/api/auth/signup/route");
+    const response = await POST(
+      new NextRequest("https://app.pawvital.ai/api/auth/signup", {
+        method: "POST",
+        body: JSON.stringify({
+          email: "owner@example.com",
+          password: "short",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockSignUp).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({
+      error: "weak_password",
+    });
+  });
+});

--- a/tests/verify-signup-code.route.test.ts
+++ b/tests/verify-signup-code.route.test.ts
@@ -1,0 +1,127 @@
+import { NextRequest } from "next/server";
+
+const mockVerifyOtp = jest.fn();
+const mockCreateServerClient = jest.fn(
+  (
+    _url: string,
+    _key: string,
+    options: {
+      cookies: {
+        setAll: (
+          cookies: Array<{
+            name: string;
+            value: string;
+            options?: Record<string, unknown>;
+          }>
+        ) => void;
+      };
+    }
+  ) => ({
+    auth: {
+      verifyOtp: async (payload: { email: string; token: string; type: string }) => {
+        const result = await mockVerifyOtp(payload);
+        if (!result.error) {
+          options.cookies.setAll([
+            {
+              name: "sb-test-auth-token",
+              value: "session-cookie",
+              options: { httpOnly: true, path: "/" },
+            },
+          ]);
+        }
+        return result;
+      },
+    },
+  })
+);
+
+jest.mock("@supabase/ssr", () => ({
+  createServerClient: (...args: unknown[]) => mockCreateServerClient(...args),
+}));
+
+describe("verify signup code route", () => {
+  const originalSupabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const originalSupabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://supabase.example";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+  });
+
+  afterAll(() => {
+    if (originalSupabaseUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    } else {
+      process.env.NEXT_PUBLIC_SUPABASE_URL = originalSupabaseUrl;
+    }
+
+    if (originalSupabaseAnonKey === undefined) {
+      delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+    } else {
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = originalSupabaseAnonKey;
+    }
+  });
+
+  it("verifies signup codes server-side and sets auth cookies", async () => {
+    mockVerifyOtp.mockResolvedValue({
+      data: { session: { user: { id: "user-1" } } },
+      error: null,
+    });
+
+    const { POST } = await import("@/app/api/auth/verify-signup-code/route");
+    const response = await POST(
+      new NextRequest("https://app.pawvital.ai/api/auth/verify-signup-code", {
+        method: "POST",
+        body: JSON.stringify({
+          email: "owner@example.com",
+          token: "123456",
+          next: "/dashboard",
+        }),
+      })
+    );
+
+    expect(mockVerifyOtp).toHaveBeenCalledWith({
+      email: "owner@example.com",
+      token: "123456",
+      type: "signup",
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("set-cookie")).toContain("sb-test-auth-token");
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      redirect: "/dashboard",
+    });
+  });
+
+  it("returns a signup redirect when verification fails", async () => {
+    mockVerifyOtp
+      .mockResolvedValueOnce({
+        data: { session: null },
+        error: new Error("expired"),
+      })
+      .mockResolvedValueOnce({
+        data: { session: null },
+        error: new Error("expired"),
+      });
+
+    const { POST } = await import("@/app/api/auth/verify-signup-code/route");
+    const response = await POST(
+      new NextRequest("https://app.pawvital.ai/api/auth/verify-signup-code", {
+        method: "POST",
+        body: JSON.stringify({
+          email: "owner@example.com",
+          token: "123456",
+          next: "/dashboard",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "invalid_code",
+      redirect: "/signup?redirect=%2Fdashboard&error=confirm_link_expired",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a safe server signup route through the anon Supabase signup boundary, plus signup callback/error-code handling for expired confirmation links.
- Adds resend + 6-digit confirmation-code recovery on signup without public service-role auto-confirm.
- Fixes local symptom-checker UX around progress counting, speech fallback, same-origin microphone permission, and longer owner-visible request/phrasing budgets.
- Adds focused regression coverage for auth routing/callbacks/signup, session progress, speech input, security headers, and phrasing.

## Verification

- Focused Jest auth/checker/security suite: 10 suites, 69 tests passed.
- `git diff --check`: pass.
- Warm marketing token scope scan: no matches.
- Narrowed auth scan for service-role/admin/signup-confirm leftovers: no matches.
- Changed-file ESLint: 0 errors, 3 existing `@next/next/no-img-element` warnings in `src/app/(dashboard)/symptom-checker/page.tsx`.
- Build: `NODE_PATH=G:\MY Website\pawvital-ai\node_modules node scripts/build.js` passed, 62 static pages generated.
- AutoScientists verifier: pass.
- TecjLead final re-review: GO.

## Notes

- Draft PR because normal PR gates still need to run.
- Manual browser smoke was not run in this pass.
- VET-1571 still owns symptom-chat route `maxDuration`/serverless deadline alignment.
- Clean worktree `npm ci` failed locally with npm `TAR_ENTRY_ERROR` under `jsdom`, so tests/build used the original known-good dependency tree.

AutoScientists run: `G:\MY Website\.agents\autoscientists\runs\vet-land-land-signup-and-checker-local-fixes`

Thermo-review verdict: pass; kickoff blocking findings and auth review blockers resolved.

SIA: verifier=focused auth/checker/security tests + build + diff/scope hygiene + TecjLead review | trajectory=scaffold, branch/scope audit, clean worktree port, review HOLD cycles, callback fix, test/build evidence | decision=stop after TecjLead GO | Goodhart=negative-path callback regression plus no out-of-scope marketing/Azure/VET-1580/protected clinical edits.

AutoLab: baseline=unverified mixed dirty tree | benchmark=focused auth/checker tests plus build/diff hygiene | iterations=4, best=10 suites/69 tests passed + build passed + TecjLead GO | budget=4/3 used to resolve blocking auth review findings | outcome=improved, stop for PR.