### PR TITLE
VET-1573 set standard turn depth guard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,7 @@ API_NINJAS_KEY=
 
 # ─── Model rollout flags (server-side) ───────────────────────────────────────
 MODEL_ROUTER_VERSION=v1
+SYMPTOM_CHAT_TURN_DEPTH=standard
 SECOND_OPINION_EXTRACTOR=shadow
 GROK_FINAL_SAFETY=off
 GROK_FINAL_REPORT=off

--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,7 @@ next-env.d.ts
 !/scripts/shadow-readout-gate-runner.mjs
 !/scripts/shadow-readout-gate-runner-logic.cjs
 !/scripts/check-supabase-env-split-brain.mjs
+!/scripts/check-symptom-turn-depth-config.mjs
 !/scripts/synthetic-prod-probe.mjs
 !/scripts/synthetic-latency-scorecard.mjs
 !/scripts/build-model-candidate-selection-packet.mjs

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "smoke:private-tester:access": "node scripts/private-tester-smoke.mjs tester-access",
     "smoke:private-tester:emergency-bypass": "node scripts/private-tester-smoke.mjs emergency-bypass",
     "ops:supabase-env-guard": "node scripts/check-supabase-env-split-brain.mjs",
+    "ops:turn-depth-guard": "node scripts/check-symptom-turn-depth-config.mjs",
     "ops:prod-probe": "node scripts/synthetic-prod-probe.mjs",
     "ops:latency-scorecard": "node scripts/synthetic-latency-scorecard.mjs",
     "smoke:azure": "node scripts/azure-ecosystem-smoke.mjs",

--- a/scripts/check-symptom-turn-depth-config.mjs
+++ b/scripts/check-symptom-turn-depth-config.mjs
@@ -1,0 +1,98 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const EXPECTED_TURN_DEPTH = "standard";
+
+function resolveRoot(argv) {
+  const rootIndex = argv.indexOf("--root");
+  if (rootIndex >= 0) {
+    return path.resolve(argv[rootIndex + 1] ?? ".");
+  }
+
+  const rootArg = argv.find((arg) => arg.startsWith("--root="));
+  if (rootArg) {
+    return path.resolve(rootArg.slice("--root=".length));
+  }
+
+  return process.cwd();
+}
+
+function parseEnvTemplate(text) {
+  const values = new Map();
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const equalsIndex = line.indexOf("=");
+    if (equalsIndex <= 0) continue;
+
+    const key = line.slice(0, equalsIndex).trim();
+    let value = line.slice(equalsIndex + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    values.set(key, value);
+  }
+  return values;
+}
+
+function readText(root, relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), "utf8");
+}
+
+function main() {
+  const root = resolveRoot(process.argv.slice(2));
+  const failures = [];
+
+  const envValues = parseEnvTemplate(readText(root, ".env.example"));
+  if (envValues.get("SYMPTOM_CHAT_TURN_DEPTH") !== EXPECTED_TURN_DEPTH) {
+    failures.push(
+      `.env.example must set SYMPTOM_CHAT_TURN_DEPTH=${EXPECTED_TURN_DEPTH}`
+    );
+  }
+
+  const vercelConfig = JSON.parse(readText(root, "vercel.json"));
+  if (vercelConfig.env?.SYMPTOM_CHAT_TURN_DEPTH !== EXPECTED_TURN_DEPTH) {
+    failures.push(
+      `vercel.json env.SYMPTOM_CHAT_TURN_DEPTH must be ${EXPECTED_TURN_DEPTH}`
+    );
+  }
+
+  const flowSource = readText(
+    root,
+    "src/lib/symptom-chat/question-response-flow.ts"
+  );
+  if (
+    !/DEFAULT_SYMPTOM_CHAT_TURN_DEPTH:\s*SymptomChatTurnDepth\s*=\s*["']standard["']/.test(
+      flowSource
+    )
+  ) {
+    failures.push(
+      "question-response-flow.ts must keep DEFAULT_SYMPTOM_CHAT_TURN_DEPTH as standard"
+    );
+  }
+
+  const packageJson = JSON.parse(readText(root, "package.json"));
+  if (
+    packageJson.scripts?.["ops:turn-depth-guard"] !==
+    "node scripts/check-symptom-turn-depth-config.mjs"
+  ) {
+    failures.push("package.json must expose ops:turn-depth-guard");
+  }
+
+  if (failures.length > 0) {
+    console.error("Symptom chat turn-depth guard failed:");
+    for (const failure of failures) {
+      console.error(`- ${failure}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(
+    `Symptom chat turn-depth guard passed: SYMPTOM_CHAT_TURN_DEPTH=${EXPECTED_TURN_DEPTH}`
+  );
+}
+
+main();

--- a/src/lib/symptom-chat/question-response-flow.ts
+++ b/src/lib/symptom-chat/question-response-flow.ts
@@ -49,6 +49,7 @@ interface BuildQuestionResponseFlowInput {
 }
 
 export type SymptomChatTurnDepth = "lean" | "standard" | "deep";
+export const DEFAULT_SYMPTOM_CHAT_TURN_DEPTH: SymptomChatTurnDepth = "standard";
 
 export function getSymptomChatTurnDepth(
   rawValue = process.env.SYMPTOM_CHAT_TURN_DEPTH
@@ -62,7 +63,7 @@ export function getSymptomChatTurnDepth(
     return normalized;
   }
 
-  return "standard";
+  return DEFAULT_SYMPTOM_CHAT_TURN_DEPTH;
 }
 
 export async function buildQuestionResponseFlow(

--- a/tests/symptom-turn-depth-config.test.ts
+++ b/tests/symptom-turn-depth-config.test.ts
@@ -1,0 +1,100 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  DEFAULT_SYMPTOM_CHAT_TURN_DEPTH,
+  getSymptomChatTurnDepth,
+} from "@/lib/symptom-chat/question-response-flow";
+
+const originalSymptomChatTurnDepth = process.env.SYMPTOM_CHAT_TURN_DEPTH;
+
+describe("symptom chat turn-depth config", () => {
+  beforeEach(() => {
+    delete process.env.SYMPTOM_CHAT_TURN_DEPTH;
+  });
+
+  afterEach(() => {
+    if (originalSymptomChatTurnDepth === undefined) {
+      delete process.env.SYMPTOM_CHAT_TURN_DEPTH;
+    } else {
+      process.env.SYMPTOM_CHAT_TURN_DEPTH = originalSymptomChatTurnDepth;
+    }
+  });
+
+  it("defaults to standard and rejects unknown values", () => {
+    expect(DEFAULT_SYMPTOM_CHAT_TURN_DEPTH).toBe("standard");
+    expect(getSymptomChatTurnDepth(undefined)).toBe("standard");
+    expect(getSymptomChatTurnDepth("")).toBe("standard");
+    expect(getSymptomChatTurnDepth("invalid")).toBe("standard");
+    expect(getSymptomChatTurnDepth("lean")).toBe("lean");
+    expect(getSymptomChatTurnDepth("DEEP")).toBe("deep");
+  });
+
+  it("passes the repository turn-depth guard", () => {
+    const result = spawnSync(
+      process.execPath,
+      ["scripts/check-symptom-turn-depth-config.mjs"],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+      }
+    );
+
+    expect(result.stderr).toBe("");
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(
+      "SYMPTOM_CHAT_TURN_DEPTH=standard"
+    );
+  });
+
+  it("fails the guard when the env template drifts", () => {
+    const tmpRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "pawvital-turn-depth-")
+    );
+    try {
+      fs.cpSync(".env.example", path.join(tmpRoot, ".env.example"));
+      fs.cpSync("vercel.json", path.join(tmpRoot, "vercel.json"));
+      fs.mkdirSync(path.join(tmpRoot, "src/lib/symptom-chat"), {
+        recursive: true,
+      });
+      fs.copyFileSync(
+        "src/lib/symptom-chat/question-response-flow.ts",
+        path.join(tmpRoot, "src/lib/symptom-chat/question-response-flow.ts")
+      );
+      fs.copyFileSync("package.json", path.join(tmpRoot, "package.json"));
+      fs.mkdirSync(path.join(tmpRoot, "scripts"), { recursive: true });
+      fs.copyFileSync(
+        "scripts/check-symptom-turn-depth-config.mjs",
+        path.join(tmpRoot, "scripts/check-symptom-turn-depth-config.mjs")
+      );
+
+      fs.writeFileSync(
+        path.join(tmpRoot, ".env.example"),
+        fs
+          .readFileSync(path.join(tmpRoot, ".env.example"), "utf8")
+          .replace(
+            "SYMPTOM_CHAT_TURN_DEPTH=standard",
+            "SYMPTOM_CHAT_TURN_DEPTH=lean"
+          )
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        ["scripts/check-symptom-turn-depth-config.mjs", "--root", tmpRoot],
+        {
+          cwd: tmpRoot,
+          encoding: "utf8",
+        }
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        ".env.example must set SYMPTOM_CHAT_TURN_DEPTH=standard"
+      );
+    } finally {
+      fs.rmSync(tmpRoot, { force: true, recursive: true });
+    }
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,8 @@
   "buildCommand": "next build",
   "outputDirectory": ".next",
   "framework": "nextjs",
-  "installCommand": "npm install"
+  "installCommand": "npm install",
+  "env": {
+    "SYMPTOM_CHAT_TURN_DEPTH": "standard"
+  }
 }


### PR DESCRIPTION
## Summary
- Make `SYMPTOM_CHAT_TURN_DEPTH=standard` explicit in repo env and deployment config.
- Export the runtime default as a named constant so the default is testable.
- Add `ops:turn-depth-guard` plus Jest coverage to catch config/default drift before deployment.

## Verification
- `node scripts/check-symptom-turn-depth-config.mjs` passed from clean verifier worktree.
- Focused Jest passed: 2 suites / 10 tests (`tests/symptom-turn-depth-config.test.ts`, `tests/question-response-flow.test.ts`).
- `git diff --check HEAD~1..HEAD` passed.
- `node scripts/build.js` passed with known Next root/metadata warnings.
- Bumblebee project scan passed: packages=971, findings=0, diagnostics=0.
- AutoScientists verifier passed for `G:\MY Website\.agents\autoscientists\runs\vet-1573-set-symptom-chat-turn-depth-standard`.
- TecjLead review: GO, no blocking/important findings.

## Notes
- Draft/stacked on #604 because the runtime `SYMPTOM_CHAT_TURN_DEPTH` hook is introduced by VET-1571.
- Maintainers should consciously accept the top-level non-secret `vercel.json` env setting before merge.
- No clinical authority change: deterministic clinical matrix/triage engine/question planning remain authoritative.