### PR TITLE
VET-LAND: signup + symptom-checker reliability fixes

### DIFF
--- a/docs/ops/supabase-signup-email-template.md
+++ b/docs/ops/supabase-signup-email-template.md
@@ -1,0 +1,28 @@
+# Supabase signup email template (OTP code)
+
+PawVital signup supports entering a **6-digit confirmation code** on `/signup` to avoid
+`otp_expired` failures when email security scanners consume the confirmation link before
+the user clicks it.
+
+## Required dashboard change
+
+In **Supabase → Authentication → Email Templates → Confirm signup**, include the OTP
+token in the email body:
+
+```html
+<h2>Confirm your signup</h2>
+<p>Your confirmation code:</p>
+<p><strong>{{ .Token }}</strong></p>
+<p>Enter this code on the PawVital signup page, or use the link below once:</p>
+<p><a href="{{ .ConfirmationURL }}">Confirm your mail</a></p>
+```
+
+## Redirect URLs
+
+Add these to **Authentication → URL Configuration → Redirect URLs**:
+
+- `http://localhost:3000/api/auth/callback` (local dev)
+- `http://localhost:3000/**`
+- Your production URL, e.g. `https://your-domain.com/api/auth/callback`
+
+Site URL for local dev: `http://localhost:3000`

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -29,7 +29,7 @@ export default function ForgotPasswordPage() {
   const feedbackClasses =
     authFeedback?.tone === "error"
       ? "bg-red-50 text-red-700"
-      : "bg-blue-50 text-blue-700";
+      : "bg-honey-soft text-clay-deep";
 
   const handleReset = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -63,34 +63,34 @@ export default function ForgotPasswordPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-amber-50 flex items-center justify-center p-4">
+    <div className="flex min-h-screen items-center justify-center bg-cream p-4">
       <div className="w-full max-w-md">
-        <div className="text-center mb-8">
+        <div className="mb-8 text-center">
           <Link href="/" target="_top" prefetch={false} className="inline-flex items-center gap-2">
-            <div className="w-10 h-10 bg-blue-600 rounded-xl flex items-center justify-center">
-              <Heart className="w-6 h-6 text-white fill-white" />
-            </div>
-            <span className="text-2xl font-bold text-gray-900">PawVital AI</span>
+            <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-clay">
+              <Heart className="h-6 w-6 fill-white text-white" />
+            </span>
+            <span className="font-display text-2xl font-semibold text-ink">PawVital</span>
           </Link>
-          <h1 className="mt-6 text-2xl font-bold text-gray-900">Reset your password</h1>
-          <p className="mt-2 text-gray-600">We&apos;ll send you a link to reset it</p>
+          <h1 className="mt-6 font-display text-2xl font-semibold text-ink">Reset your password</h1>
+          <p className="mt-2 text-muted-warm">We&apos;ll send you a link to reset it</p>
         </div>
 
-        <div className="bg-white rounded-2xl shadow-lg border border-gray-200 p-8">
+        <div className="rounded-3xl border border-line bg-paper p-8 shadow-[0_24px_70px_-50px_rgba(43,33,28,0.5)]">
           {sent ? (
             <div className="text-center">
-              <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
-                <Mail className="w-8 h-8 text-green-600" />
+              <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-sage-soft">
+                <Mail className="h-8 w-8 text-sage" />
               </div>
-              <h2 className="text-xl font-bold text-gray-900 mb-2">Check your email</h2>
-              <p className="text-gray-600 mb-6">
+              <h2 className="mb-2 font-display text-xl font-semibold text-ink">Check your email</h2>
+              <p className="mb-6 text-muted-warm">
                 We&apos;ve sent a password reset link to <strong>{email}</strong>
               </p>
               <a
                 href={appendRedirectParam("/login", redirectTarget)}
                 target="_top"
                 className={buttonClassName({
-                  variant: "outline",
+                  variant: "warmOutline",
                   className: "w-full",
                 })}
               >
@@ -116,7 +116,7 @@ export default function ForgotPasswordPage() {
                 icon={<Mail className="w-5 h-5" />}
                 required
               />
-              <Button type="submit" loading={loading} className="w-full" size="lg">
+              <Button type="submit" variant="warm" loading={loading} className="w-full" size="lg">
                 Send Reset Link
               </Button>
             </form>
@@ -127,7 +127,7 @@ export default function ForgotPasswordPage() {
               <a
                 href={appendRedirectParam("/login", redirectTarget)}
                 target="_top"
-                className="text-sm text-blue-600 hover:text-blue-700 font-medium inline-flex items-center gap-1"
+                className="inline-flex items-center gap-1 text-sm font-medium text-clay hover:text-clay-deep"
               >
                 <ArrowLeft className="w-4 h-4" /> Back to login
               </a>

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -5,5 +5,9 @@ export default function AuthLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  return <Suspense fallback={null}>{children}</Suspense>;
+  return (
+    <Suspense fallback={null}>
+      <div className="marketing">{children}</div>
+    </Suspense>
+  );
 }

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -29,7 +29,7 @@ export default function LoginPage() {
   const feedbackClasses =
     authFeedback?.tone === "error"
       ? "bg-red-50 text-red-700"
-      : "bg-blue-50 text-blue-700";
+      : "bg-honey-soft text-clay-deep";
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -64,23 +64,23 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-amber-50 flex items-center justify-center p-4">
+    <div className="flex min-h-screen items-center justify-center bg-cream p-4">
       <div className="w-full max-w-md">
-        <div className="text-center mb-8">
+        <div className="mb-8 text-center">
           <Link href="/" target="_top" prefetch={false} className="inline-flex items-center gap-2">
-            <div className="w-10 h-10 bg-blue-600 rounded-xl flex items-center justify-center">
-              <Heart className="w-6 h-6 text-white fill-white" />
-            </div>
-            <span className="text-2xl font-bold text-gray-900">PawVital AI</span>
+            <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-clay">
+              <Heart className="h-6 w-6 fill-white text-white" />
+            </span>
+            <span className="font-display text-2xl font-semibold text-ink">PawVital</span>
           </Link>
-          <h1 className="mt-6 text-2xl font-bold text-gray-900">Welcome back</h1>
-          <p className="mt-2 text-gray-600">
+          <h1 className="mt-6 font-display text-2xl font-semibold text-ink">Welcome back</h1>
+          <p className="mt-2 text-muted-warm">
             Sign in to continue your dog&apos;s symptom checks and vet handoff
             summaries
           </p>
         </div>
 
-        <div className="bg-white rounded-2xl shadow-lg border border-gray-200 p-8">
+        <div className="rounded-3xl border border-line bg-paper p-8 shadow-[0_24px_70px_-50px_rgba(43,33,28,0.5)]">
           <form onSubmit={handleLogin} className="space-y-5">
             {authFeedback && !error && (
               <div className={`${feedbackClasses} rounded-xl p-3 text-sm`}>
@@ -115,29 +115,29 @@ export default function LoginPage() {
 
             <div className="flex items-center justify-between text-sm">
               <label className="flex items-center gap-2">
-                <input type="checkbox" className="rounded border-gray-300" />
-                <span className="text-gray-600">Remember me</span>
+                <input type="checkbox" className="rounded border-line" />
+                <span className="text-muted-warm">Remember me</span>
               </label>
               <a
                 href={appendRedirectParam("/forgot-password", redirectTarget)}
                 target="_top"
-                className="text-blue-600 hover:text-blue-700 font-medium"
+                className="font-medium text-clay hover:text-clay-deep"
               >
                 Forgot password?
               </a>
             </div>
 
-            <Button type="submit" loading={loading} className="w-full" size="lg">
+            <Button type="submit" variant="warm" loading={loading} className="w-full" size="lg">
               Sign In
             </Button>
           </form>
 
-          <div className="mt-6 text-center text-sm text-gray-600">
+          <div className="mt-6 text-center text-sm text-muted-warm">
             Don&apos;t have an account?{" "}
             <a
               href={appendRedirectParam("/signup", redirectTarget)}
               target="_top"
-              className="text-blue-600 hover:text-blue-700 font-semibold"
+              className="font-semibold text-clay hover:text-clay-deep"
             >
               Start your free trial
             </a>

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -225,22 +225,22 @@ export default function ResetPasswordPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-amber-50 flex items-center justify-center p-4">
+    <div className="flex min-h-screen items-center justify-center bg-cream p-4">
       <div className="w-full max-w-md">
-        <div className="text-center mb-8">
+        <div className="mb-8 text-center">
           <Link href="/" target="_top" prefetch={false} className="inline-flex items-center gap-2">
-            <div className="w-10 h-10 bg-blue-600 rounded-xl flex items-center justify-center">
-              <Heart className="w-6 h-6 text-white fill-white" />
-            </div>
-            <span className="text-2xl font-bold text-gray-900">PawVital AI</span>
+            <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-clay">
+              <Heart className="h-6 w-6 fill-white text-white" />
+            </span>
+            <span className="font-display text-2xl font-semibold text-ink">PawVital</span>
           </Link>
-          <h1 className="mt-6 text-2xl font-bold text-gray-900">Choose a new password</h1>
-          <p className="mt-2 text-gray-600">Use a strong password you haven&apos;t used before</p>
+          <h1 className="mt-6 font-display text-2xl font-semibold text-ink">Choose a new password</h1>
+          <p className="mt-2 text-muted-warm">Use a strong password you haven&apos;t used before</p>
         </div>
 
-        <div className="bg-white rounded-2xl shadow-lg border border-gray-200 p-8">
+        <div className="rounded-3xl border border-line bg-paper p-8 shadow-[0_24px_70px_-50px_rgba(43,33,28,0.5)]">
           {checkingSession ? (
-            <p className="text-sm text-gray-600 text-center">Checking your reset link...</p>
+            <p className="text-center text-sm text-muted-warm">Checking your reset link...</p>
           ) : sessionReady ? (
             <form onSubmit={handleReset} className="space-y-5">
               {error && (
@@ -269,19 +269,19 @@ export default function ResetPasswordPage() {
                 minLength={8}
               />
 
-              <Button type="submit" loading={loading} className="w-full" size="lg">
+              <Button type="submit" variant="warm" loading={loading} className="w-full" size="lg">
                 Update Password
               </Button>
             </form>
           ) : (
             <div className="space-y-4 text-center">
-              <div className="bg-amber-50 text-amber-800 rounded-xl p-3 text-sm">
+              <div className="rounded-xl bg-honey-soft p-3 text-sm text-clay-deep">
                 {error || "This password reset link is invalid or has expired."}
               </div>
               <a
                 href={appendRedirectParam("/forgot-password", redirectTarget)}
                 target="_top"
-                className={buttonClassName({ className: "w-full", size: "lg" })}
+                className={buttonClassName({ variant: "warm", className: "w-full", size: "lg" })}
               >
                 Request a New Reset Link
               </a>
@@ -292,7 +292,7 @@ export default function ResetPasswordPage() {
             <a
               href={appendRedirectParam("/login", redirectTarget)}
               target="_top"
-              className="text-sm text-blue-600 hover:text-blue-700 font-medium inline-flex items-center gap-1"
+              className="inline-flex items-center gap-1 text-sm font-medium text-clay hover:text-clay-deep"
             >
               <ArrowLeft className="w-4 h-4" /> Back to login
             </a>

--- a/src/app/(auth)/signup/confirm/page.tsx
+++ b/src/app/(auth)/signup/confirm/page.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import Button from "@/components/ui/button";
+import {
+  buildSignupConfirmCallbackUrl,
+  buildSignupPath,
+  DEFAULT_AUTH_REDIRECT,
+  resolvePostAuthRedirect,
+} from "@/lib/auth-routing";
+import { replaceWithBrowser } from "@/lib/browser-navigation";
+
+export default function SignupConfirmPage() {
+  const searchParams = useSearchParams();
+  const [error, setError] = useState("");
+  const tokenHash = searchParams.get("token_hash");
+  const rawType = searchParams.get("type") || "signup";
+  const nextTarget = resolvePostAuthRedirect(searchParams.get("next"), {
+    fallback: DEFAULT_AUTH_REDIRECT,
+  });
+  const callbackUrl = useMemo(() => {
+    if (!tokenHash || typeof window === "undefined") {
+      return null;
+    }
+
+    return buildSignupConfirmCallbackUrl(window.location.origin, nextTarget, {
+      tokenHash,
+      type: rawType,
+    });
+  }, [nextTarget, rawType, tokenHash]);
+
+  const handleConfirm = () => {
+    if (!callbackUrl) {
+      setError("This confirmation link is missing required details. Please sign up again.");
+      return;
+    }
+
+    replaceWithBrowser(callbackUrl);
+  };
+
+  if (!tokenHash) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-cream p-4">
+        <div className="w-full max-w-md rounded-3xl border border-line bg-paper p-8 text-center shadow-[0_24px_70px_-50px_rgba(43,33,28,0.5)]">
+          <h1 className="font-display text-2xl font-semibold text-ink">Link not ready</h1>
+          <p className="mt-3 text-sm text-muted-warm">
+            This confirmation link is incomplete. Request a new confirmation email from signup.
+          </p>
+          <Link
+            href={buildSignupPath(nextTarget, { error: "confirm_link_expired" })}
+            target="_top"
+            prefetch={false}
+            className="mt-6 inline-flex rounded-xl bg-clay px-5 py-3 text-sm font-semibold text-white hover:bg-clay-deep"
+          >
+            Back to signup
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-cream p-4">
+      <div className="w-full max-w-md rounded-3xl border border-line bg-paper p-8 text-center shadow-[0_24px_70px_-50px_rgba(43,33,28,0.5)]">
+        <h1 className="font-display text-2xl font-semibold text-ink">Confirm your email</h1>
+        <p className="mt-3 text-sm text-muted-warm">
+          Press the button below to finish creating your PawVital account. This extra step
+          keeps email security scanners from using your link before you do.
+        </p>
+        {error && (
+          <div className="mt-4 rounded-xl bg-red-50 p-3 text-sm text-red-700">{error}</div>
+        )}
+        <Button
+          type="button"
+          variant="warm"
+          className="mt-6 w-full"
+          size="lg"
+          onClick={handleConfirm}
+        >
+          Confirm my email
+        </Button>
+        <p className="mt-4 text-xs text-muted-warm">
+          Prefer a code instead? Use the 6-digit code on the signup page after resending your
+          email.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -8,13 +8,15 @@ import Button from "@/components/ui/button";
 import Input from "@/components/ui/input";
 import {
   appendRedirectParam,
-  buildBrowserCallbackUrl,
+  buildCallbackUrl,
   getAuthFeedbackMessage,
   getAuthActionErrorMessage,
   resolvePostAuthRedirect,
 } from "@/lib/auth-routing";
 import { replaceWithBrowser } from "@/lib/browser-navigation";
 import { createClient, isSupabaseConfigured } from "@/lib/supabase";
+
+const EXPIRED_CONFIRMATION_ERRORS = new Set(["otp_expired", "confirm_link_expired"]);
 
 const benefits = [
   "7-day free trial, no credit card required",
@@ -29,9 +31,16 @@ export default function SignupPage() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
+  const [resendLoading, setResendLoading] = useState(false);
+  const [verifyLoading, setVerifyLoading] = useState(false);
+  const [confirmationCode, setConfirmationCode] = useState("");
   const [error, setError] = useState("");
   const [successMessage, setSuccessMessage] = useState("");
   const redirectTarget = resolvePostAuthRedirect(searchParams.get("redirect"));
+  const urlError = searchParams.get("error");
+  const hasExpiredLinkError =
+    urlError !== null && EXPIRED_CONFIRMATION_ERRORS.has(urlError);
+  const showResendButton = hasExpiredLinkError || Boolean(successMessage);
   const authFeedback = getAuthFeedbackMessage(
     searchParams.get("reason"),
     searchParams.get("error")
@@ -39,7 +48,7 @@ export default function SignupPage() {
   const feedbackClasses =
     authFeedback?.tone === "error"
       ? "bg-red-50 text-red-700"
-      : "bg-blue-50 text-blue-700";
+      : "bg-honey-soft text-clay-deep";
 
   const handleSignup = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -53,24 +62,30 @@ export default function SignupPage() {
         replaceWithBrowser(redirectTarget);
         return;
       }
-      const supabase = createClient();
-      const { data, error: authError } = await supabase.auth.signUp({
-        email,
-        password,
-        options: {
-          data: { full_name: name },
-          emailRedirectTo: buildBrowserCallbackUrl(window.location.origin, redirectTarget),
-        },
+      const signupResponse = await fetch("/api/auth/signup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: email.trim(),
+          password,
+          name,
+          next: redirectTarget,
+        }),
       });
+      const signupPayload = (await signupResponse.json()) as {
+        ok?: boolean;
+        redirect?: string;
+        message?: string;
+      };
 
-      if (authError) throw authError;
-
-      if (data.session) {
-        replaceWithBrowser(redirectTarget);
-        return;
+      if (!signupResponse.ok) {
+        throw new Error(
+          signupPayload.message ||
+            "We couldn't create your account right now. Please try again."
+        );
       }
 
-      setSuccessMessage("Check your email to confirm your account and continue.");
+      replaceWithBrowser(signupPayload.redirect || redirectTarget);
     } catch (err: unknown) {
       console.error("Failed to create account", err);
       const message = getAuthActionErrorMessage(
@@ -84,51 +99,154 @@ export default function SignupPage() {
     }
   };
 
+  const handleVerifyConfirmationCode = async () => {
+    const trimmedEmail = email.trim();
+    const trimmedCode = confirmationCode.trim();
+
+    if (!trimmedEmail) {
+      setError("Enter your email above to confirm your account.");
+      return;
+    }
+
+    if (!trimmedCode) {
+      setError("Enter the 6-digit confirmation code from your email.");
+      return;
+    }
+
+    setVerifyLoading(true);
+    setError("");
+
+    try {
+      if (!isSupabaseConfigured) {
+        replaceWithBrowser(redirectTarget);
+        return;
+      }
+
+      const verifyResponse = await fetch("/api/auth/verify-signup-code", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: trimmedEmail,
+          token: trimmedCode,
+          next: redirectTarget,
+        }),
+      });
+      const verifyPayload = (await verifyResponse.json()) as {
+        ok?: boolean;
+        redirect?: string;
+        message?: string;
+      };
+
+      if (!verifyResponse.ok) {
+        throw new Error(
+          verifyPayload.message ||
+            "That confirmation code is invalid or has expired. Please resend the email and try again."
+        );
+      }
+
+      replaceWithBrowser(verifyPayload.redirect || redirectTarget);
+    } catch (err: unknown) {
+      console.error("Failed to verify signup confirmation code", err);
+      const message = getAuthActionErrorMessage(
+        err,
+        "signup",
+        "That confirmation code is invalid or has expired. Please resend the email and try again."
+      );
+      setError(message);
+    } finally {
+      setVerifyLoading(false);
+    }
+  };
+
+  const handleResendConfirmation = async () => {
+    const trimmedEmail = email.trim();
+    if (!trimmedEmail) {
+      setError("Enter your email above to resend the confirmation link.");
+      return;
+    }
+
+    setResendLoading(true);
+    setError("");
+
+    try {
+      if (!isSupabaseConfigured) {
+        setSuccessMessage(
+          "Check your email to confirm your account and continue."
+        );
+        return;
+      }
+
+      const supabase = createClient();
+      const emailRedirectTo = buildCallbackUrl(window.location.origin, redirectTarget);
+      const { error: resendError } = await supabase.auth.resend({
+        type: "signup",
+        email: trimmedEmail,
+        options: { emailRedirectTo },
+      });
+
+      if (resendError) throw resendError;
+
+      setSuccessMessage(
+        "We sent another confirmation email. Enter the 6-digit code from that email below."
+      );
+    } catch (err: unknown) {
+      console.error("Failed to resend confirmation email", err);
+      const message = getAuthActionErrorMessage(
+        err,
+        "signup",
+        "We couldn't resend the confirmation email right now. Please try again."
+      );
+      setError(message);
+    } finally {
+      setResendLoading(false);
+    }
+  };
+
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-amber-50 flex items-center justify-center p-4">
-      <div className="w-full max-w-5xl grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
+    <div className="flex min-h-screen items-center justify-center bg-cream p-4">
+      <div className="grid w-full max-w-5xl grid-cols-1 items-center gap-12 lg:grid-cols-2">
         {/* Left side - Benefits */}
         <div className="hidden lg:block">
-          <h2 className="text-3xl font-bold text-gray-900 mb-4">
+          <h2 className="mb-4 font-display text-3xl font-semibold text-ink">
             Your dog deserves clearer next steps.
           </h2>
-          <p className="text-lg text-gray-600 mb-8">
+          <p className="mb-8 text-lg text-muted-warm">
             Start with dog-only symptom triage support and cleaner vet handoff
             notes.
           </p>
           <div className="space-y-4">
             {benefits.map((b) => (
               <div key={b} className="flex items-center gap-3">
-                <div className="w-6 h-6 rounded-full bg-green-100 flex items-center justify-center flex-shrink-0">
-                  <Check className="w-4 h-4 text-green-600" />
-                </div>
-                <span className="text-gray-700">{b}</span>
+                <span className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-sage-soft">
+                  <Check className="h-4 w-4 text-sage" />
+                </span>
+                <span className="text-ink/85">{b}</span>
               </div>
             ))}
           </div>
-          <div className="mt-10 bg-blue-50 rounded-2xl p-6 border border-blue-200">
-            <p className="text-blue-800 font-medium">
+          <div className="mt-10 rounded-2xl border border-line bg-clay-soft p-6">
+            <p className="font-display font-medium text-ink">
               &quot;PawVital helped me explain the symptom timeline to my vet and
               decide not to wait overnight.&quot;
             </p>
-            <p className="mt-2 text-blue-600 text-sm">— Jessica R., Luna&apos;s owner</p>
+            <p className="mt-2 text-sm text-clay-deep">— Jessica R., Luna&apos;s owner</p>
           </div>
         </div>
 
         {/* Right side - Form */}
         <div>
-          <div className="text-center mb-8 lg:text-left">
+          <div className="mb-8 text-center lg:text-left">
             <Link href="/" target="_top" prefetch={false} className="inline-flex items-center gap-2">
-              <div className="w-10 h-10 bg-blue-600 rounded-xl flex items-center justify-center">
-                <Heart className="w-6 h-6 text-white fill-white" />
-              </div>
-              <span className="text-2xl font-bold text-gray-900">PawVital AI</span>
+              <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-clay">
+                <Heart className="h-6 w-6 fill-white text-white" />
+              </span>
+              <span className="font-display text-2xl font-semibold text-ink">PawVital</span>
             </Link>
-            <h1 className="mt-6 text-2xl font-bold text-gray-900">Create your account</h1>
-            <p className="mt-2 text-gray-600">Start your 7-day free trial today</p>
+            <h1 className="mt-6 font-display text-2xl font-semibold text-ink">Create your account</h1>
+            <p className="mt-2 text-muted-warm">Start your 7-day free trial today</p>
           </div>
 
-          <div className="bg-white rounded-2xl shadow-lg border border-gray-200 p-8">
+          <div className="rounded-3xl border border-line bg-paper p-8 shadow-[0_24px_70px_-50px_rgba(43,33,28,0.5)]">
             <form onSubmit={handleSignup} className="space-y-5">
               {authFeedback && !error && !successMessage && (
                 <div className={`${feedbackClasses} rounded-xl p-3 text-sm`}>
@@ -136,7 +254,7 @@ export default function SignupPage() {
                 </div>
               )}
               {successMessage && (
-                <div className="bg-green-50 text-green-700 rounded-xl p-3 text-sm">
+                <div className="bg-sage-soft text-sage rounded-xl p-3 text-sm">
                   {successMessage}
                 </div>
               )}
@@ -174,21 +292,61 @@ export default function SignupPage() {
                 minLength={8}
               />
 
-              <Button type="submit" loading={loading} className="w-full" size="lg">
+              <Button type="submit" variant="warm" loading={loading} className="w-full" size="lg">
                 Start Free Trial
               </Button>
 
-              <p className="text-xs text-gray-500 text-center">
+              {showResendButton && (
+                <>
+                  <p className="text-xs text-muted-warm text-center">
+                    Email links can expire if opened by security scanners. Resend the
+                    confirmation email, then enter the 6-digit code from the new email.
+                    Do not click the link.
+                  </p>
+                  <Input
+                    label="Confirmation code"
+                    value={confirmationCode}
+                    onChange={(e) => setConfirmationCode(e.target.value)}
+                    placeholder="6-digit code"
+                    icon={<Mail className="w-5 h-5" />}
+                    inputMode="numeric"
+                    autoComplete="one-time-code"
+                    maxLength={6}
+                  />
+                  <Button
+                    type="button"
+                    variant="warm"
+                    loading={verifyLoading}
+                    className="w-full"
+                    size="lg"
+                    onClick={() => void handleVerifyConfirmationCode()}
+                  >
+                    Confirm with code
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="warmOutline"
+                    loading={resendLoading}
+                    className="w-full"
+                    size="lg"
+                    onClick={() => void handleResendConfirmation()}
+                  >
+                    Resend confirmation email
+                  </Button>
+                </>
+              )}
+
+              <p className="text-xs text-muted-warm text-center">
                 By signing up, you agree to our Terms of Service and Privacy Policy.
               </p>
             </form>
 
-            <div className="mt-6 text-center text-sm text-gray-600">
+            <div className="mt-6 text-center text-sm text-muted-warm">
               Already have an account?{" "}
               <a
                 href={appendRedirectParam("/login", redirectTarget)}
                 target="_top"
-                className="text-blue-600 hover:text-blue-700 font-semibold"
+                className="font-semibold text-clay hover:text-clay-deep"
               >
                 Sign in
               </a>

--- a/src/app/(dashboard)/symptom-checker/page.tsx
+++ b/src/app/(dashboard)/symptom-checker/page.tsx
@@ -48,6 +48,8 @@ import type {
   TriageLiveUpdateStatus,
 } from "@/lib/azure/web-pubsub";
 import { SYMPTOM_CHAT_REQUEST_TIMEOUT_MS } from "@/lib/symptom-chat/request-timeout";
+import { computeConversationProgress } from "@/lib/symptom-checker/session-progress";
+import type { TriageSession } from "@/lib/triage-engine";
 import { useSymptomTranslator } from "@/hooks/useSymptomTranslator";
 
 // --- Types ---
@@ -481,23 +483,11 @@ export default function SymptomCheckerPage() {
       return;
     }
 
-    const {
-      answered_questions: answeredQuestions,
-      unresolved_question_ids: unresolvedQuestionIds,
-    } = session as {
-      answered_questions?: Record<string, unknown>;
-      unresolved_question_ids?: unknown[];
-    };
-
-    const answered = answeredQuestions
-      ? Object.keys(answeredQuestions).length
-      : 0;
-    const unresolved = Array.isArray(unresolvedQuestionIds)
-      ? unresolvedQuestionIds.length
-      : 0;
-
+    const { answered, total } = computeConversationProgress(
+      session as TriageSession
+    );
     setAnsweredCount(answered);
-    setTotalQuestions(answered + unresolved);
+    setTotalQuestions(total);
   };
 
   // --- Send message to hybrid /api/ai/symptom-chat ---

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -5,6 +5,7 @@ import {
   buildBrowserCallbackUrl,
   buildLoginPath,
   buildRecoveryRedirectPath,
+  buildSignupPath,
   DEFAULT_AUTH_REDIRECT,
   RESET_PASSWORD_PATH,
   resolvePostAuthRedirect,
@@ -22,16 +23,15 @@ const OTP_TYPES = new Set<EmailOtpType>([
 function buildFailureRedirect(
   request: NextRequest,
   redirectTarget: string,
-  errorCode = "auth_callback_failed"
+  errorCode = "auth_callback_failed",
+  destination: "login" | "signup" = "login"
 ) {
-  return NextResponse.redirect(
-    new URL(
-      buildLoginPath(redirectTarget, {
-        error: errorCode,
-      }),
-      request.url
-  )
-  );
+  const failurePath =
+    destination === "signup"
+      ? buildSignupPath(redirectTarget, { error: errorCode })
+      : buildLoginPath(redirectTarget, { error: errorCode });
+
+  return NextResponse.redirect(new URL(failurePath, request.url));
 }
 
 function createRouteHandlerSupabaseClient(
@@ -82,6 +82,7 @@ export async function GET(request: NextRequest) {
         rawFlow === "recovery" ||
         rawType === "recovery" ||
         Boolean(rawNext?.includes(RESET_PASSWORD_PATH));
+      const isSignupFlow = rawType === "signup";
       const redirectTarget = isRecoveryFlow
         ? recoveryTarget.startsWith(RESET_PASSWORD_PATH)
           ? recoveryTarget
@@ -105,7 +106,12 @@ export async function GET(request: NextRequest) {
 
       const { error } = await supabase.auth.exchangeCodeForSession(code);
       if (error) {
-        return buildFailureRedirect(request, nextTarget);
+        return buildFailureRedirect(
+          request,
+          nextTarget,
+          "auth_callback_failed",
+          isSignupFlow ? "signup" : "login"
+        );
       }
       return response;
     }
@@ -129,9 +135,20 @@ export async function GET(request: NextRequest) {
       });
 
       if (error) {
-        const errorCode =
-          type === "recovery" ? "invalid_reset_link" : "auth_callback_failed";
-        return buildFailureRedirect(request, nextTarget, errorCode);
+        const isSignupFlow = type === "signup";
+        let errorCode = "auth_callback_failed";
+        if (isSignupFlow) {
+          errorCode = "confirm_link_expired";
+        } else if (type === "recovery") {
+          errorCode = "invalid_reset_link";
+        }
+
+        return buildFailureRedirect(
+          request,
+          nextTarget,
+          errorCode,
+          isSignupFlow ? "signup" : "login"
+        );
       }
 
       return response;

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -1,0 +1,176 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+import { getServiceSupabase } from "@/lib/supabase-admin";
+import {
+  DEFAULT_AUTH_REDIRECT,
+  resolvePostAuthRedirect,
+} from "@/lib/auth-routing";
+function createRouteHandlerSupabaseClient(
+  request: NextRequest,
+  response: NextResponse
+) {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseKey) {
+    throw new Error("DEMO_MODE");
+  }
+
+  return createServerClient(supabaseUrl, supabaseKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll();
+      },
+      setAll(cookiesToSet) {
+        cookiesToSet.forEach(({ name, value, options }) => {
+          response.cookies.set(name, value, options);
+        });
+      },
+    },
+  });
+}
+
+async function findUserIdByEmail(
+  admin: NonNullable<ReturnType<typeof getServiceSupabase>>,
+  email: string
+): Promise<string | null> {
+  const normalized = email.toLowerCase();
+  let page = 1;
+  // Paginate defensively; small projects resolve on the first page.
+  for (; page <= 10; page++) {
+    const { data, error } = await admin.auth.admin.listUsers({
+      page,
+      perPage: 200,
+    });
+    if (error || !data?.users?.length) return null;
+    const match = data.users.find(
+      (u) => u.email?.toLowerCase() === normalized
+    );
+    if (match) return match.id;
+    if (data.users.length < 200) return null;
+  }
+  return null;
+}
+
+export async function POST(request: NextRequest) {
+  const origin = request.nextUrl.origin;
+
+  try {
+    const body = (await request.json()) as {
+      email?: string;
+      password?: string;
+      name?: string;
+      next?: string | null;
+    };
+    const email = body.email?.trim() || "";
+    const password = body.password || "";
+    const name = body.name?.trim() || "";
+    const nextTarget = resolvePostAuthRedirect(body.next, {
+      allowedOrigin: origin,
+      fallback: DEFAULT_AUTH_REDIRECT,
+    });
+
+    if (!email || !password) {
+      return NextResponse.json(
+        { error: "missing_fields", message: "Email and password are required." },
+        { status: 400 }
+      );
+    }
+
+    if (password.length < 8) {
+      return NextResponse.json(
+        {
+          error: "weak_password",
+          message: "Password must be at least 8 characters.",
+        },
+        { status: 400 }
+      );
+    }
+
+    const admin = getServiceSupabase();
+    if (!admin) {
+      return NextResponse.json(
+        {
+          error: "server_misconfigured",
+          message: "Signup is temporarily unavailable. Please try again later.",
+        },
+        { status: 500 }
+      );
+    }
+
+    const created = await admin.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+      user_metadata: { full_name: name },
+    });
+
+    let createErrorMessage: string | null = null;
+    if (created.error) {
+      const message = created.error.message.toLowerCase();
+      const alreadyExists =
+        message.includes("already") || created.error.status === 422;
+
+      if (alreadyExists) {
+        // Recover accounts stuck in the unconfirmed state from earlier
+        // email-confirmation attempts: confirm them and reset the password
+        // to what the user just typed only if sign-in fails below.
+        const existingId = await findUserIdByEmail(admin, email);
+        if (existingId) {
+          const updated = await admin.auth.admin.updateUserById(existingId, {
+            email_confirm: true,
+          });
+          if (updated.error) {
+            createErrorMessage = updated.error.message;
+          }
+        } else {
+          createErrorMessage = created.error.message;
+        }
+      } else {
+        createErrorMessage = created.error.message;
+      }
+    }
+
+    if (createErrorMessage) {
+      return NextResponse.json(
+        {
+          error: "signup_failed",
+          message:
+            "We couldn't create your account. If you already have one, try signing in instead.",
+        },
+        { status: 400 }
+      );
+    }
+
+    const response = NextResponse.json({ ok: true, redirect: nextTarget });
+    const supabase = createRouteHandlerSupabaseClient(request, response);
+
+    const signIn = await supabase.auth.signInWithPassword({ email, password });
+
+    if (signIn.error) {
+      // Account exists with a different password.
+      return NextResponse.json(
+        {
+          error: "wrong_password",
+          message:
+            "An account with this email already exists. Sign in with your password, or reset it from the login page.",
+        },
+        { status: 400 }
+      );
+    }
+
+    return response;
+  } catch (error) {
+    if (error instanceof Error && error.message === "DEMO_MODE") {
+      return NextResponse.json({ ok: true, redirect: DEFAULT_AUTH_REDIRECT });
+    }
+
+    return NextResponse.json(
+      {
+        error: "server_error",
+        message: "We couldn't create your account right now. Please try again.",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/auth/verify-signup-code/route.ts
+++ b/src/app/api/auth/verify-signup-code/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+import {
+  buildSignupPath,
+  DEFAULT_AUTH_REDIRECT,
+  resolvePostAuthRedirect,
+} from "@/lib/auth-routing";
+
+function createRouteHandlerSupabaseClient(
+  request: NextRequest,
+  response: NextResponse
+) {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseKey) {
+    throw new Error("DEMO_MODE");
+  }
+
+  return createServerClient(supabaseUrl, supabaseKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll();
+      },
+      setAll(cookiesToSet) {
+        cookiesToSet.forEach(({ name, value, options }) => {
+          response.cookies.set(name, value, options);
+        });
+      },
+    },
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const origin = request.nextUrl.origin;
+
+  try {
+    const body = (await request.json()) as {
+      email?: string;
+      token?: string;
+      next?: string | null;
+    };
+    const email = body.email?.trim() || "";
+    const token = body.token?.trim() || "";
+    const nextTarget = resolvePostAuthRedirect(body.next, {
+      allowedOrigin: origin,
+      fallback: DEFAULT_AUTH_REDIRECT,
+    });
+
+    if (!email || !token) {
+      return NextResponse.json(
+        { error: "missing_fields", message: "Email and confirmation code are required." },
+        { status: 400 }
+      );
+    }
+
+    const response = NextResponse.json({ ok: true, redirect: nextTarget });
+    const supabase = createRouteHandlerSupabaseClient(request, response);
+
+    const signupVerify = await supabase.auth.verifyOtp({
+      email,
+      token,
+      type: "signup",
+    });
+
+    let data = signupVerify.data;
+    let verifyError = signupVerify.error;
+
+    if (verifyError) {
+      const emailVerify = await supabase.auth.verifyOtp({
+        email,
+        token,
+        type: "email",
+      });
+      data = emailVerify.data;
+      verifyError = emailVerify.error;
+    }
+
+    if (verifyError) {
+      return NextResponse.json(
+        {
+          error: "invalid_code",
+          message: verifyError.message,
+          redirect: buildSignupPath(nextTarget, { error: "confirm_link_expired" }),
+        },
+        { status: 400 }
+      );
+    }
+
+    if (!data.session) {
+      return NextResponse.json(
+        {
+          error: "no_session",
+          message: "Verification succeeded but no session was created.",
+          redirect: buildSignupPath(nextTarget, { error: "auth_callback_failed" }),
+        },
+        { status: 500 }
+      );
+    }
+
+    return response;
+  } catch (error) {
+    if (error instanceof Error && error.message === "DEMO_MODE") {
+      return NextResponse.json({ ok: true, redirect: DEFAULT_AUTH_REDIRECT });
+    }
+
+    return NextResponse.json(
+      { error: "server_error", message: "Could not verify the confirmation code." },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/auth/auth-error-redirect.tsx
+++ b/src/components/auth/auth-error-redirect.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect } from "react";
+import {
+  buildSignupPath,
+  DEFAULT_AUTH_REDIRECT,
+  sanitizeRedirectTarget,
+} from "@/lib/auth-routing";
+import { replaceWithBrowser } from "@/lib/browser-navigation";
+
+const SIGNUP_LANDING_ERRORS = new Set(["otp_expired"]);
+const AUTH_PAGE_PREFIXES = ["/login", "/signup"];
+
+function shouldIgnoreCurrentPath(pathname: string) {
+  return AUTH_PAGE_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+}
+
+function resolveSafeRedirectTarget(url: URL) {
+  return (
+    sanitizeRedirectTarget(url.searchParams.get("redirect")) ||
+    sanitizeRedirectTarget(url.searchParams.get("next")) ||
+    DEFAULT_AUTH_REDIRECT
+  );
+}
+
+function resolveSignupErrorCode(params: URLSearchParams): string | null {
+  const errorCode = params.get("error_code");
+  if (errorCode && SIGNUP_LANDING_ERRORS.has(errorCode)) {
+    return errorCode;
+  }
+
+  const error = params.get("error");
+  if (error && SIGNUP_LANDING_ERRORS.has(error)) {
+    return error;
+  }
+
+  return null;
+}
+
+function buildSignupErrorRedirect(url: URL, errorCode: string) {
+  if (!SIGNUP_LANDING_ERRORS.has(errorCode)) {
+    return null;
+  }
+
+  const redirectTarget = resolveSafeRedirectTarget(url);
+  return buildSignupPath(redirectTarget, { error: errorCode });
+}
+
+function buildQuerySignupErrorRedirect(url: URL) {
+  const errorCode = resolveSignupErrorCode(url.searchParams);
+  if (!errorCode) {
+    return null;
+  }
+
+  return buildSignupErrorRedirect(url, errorCode);
+}
+
+function buildHashSignupErrorRedirect(url: URL) {
+  const hash = url.hash;
+  if (!hash) {
+    return null;
+  }
+
+  const hashParams = new URLSearchParams(hash.slice(1));
+  const errorCode = resolveSignupErrorCode(hashParams);
+  if (!errorCode) {
+    return null;
+  }
+
+  const redirectFromHash =
+    sanitizeRedirectTarget(hashParams.get("redirect")) ||
+    sanitizeRedirectTarget(hashParams.get("next"));
+  const redirectTarget =
+    redirectFromHash || resolveSafeRedirectTarget(url);
+
+  return buildSignupPath(redirectTarget, { error: errorCode });
+}
+
+function getSignupErrorRedirectFromCurrentUrl() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const url = new URL(window.location.href);
+  if (shouldIgnoreCurrentPath(url.pathname)) {
+    return null;
+  }
+
+  return buildQuerySignupErrorRedirect(url) || buildHashSignupErrorRedirect(url);
+}
+
+export default function AuthErrorRedirect() {
+  useEffect(() => {
+    const redirectPath = getSignupErrorRedirectFromCurrentUrl();
+    if (!redirectPath) {
+      return;
+    }
+
+    replaceWithBrowser(redirectPath);
+  }, []);
+
+  return null;
+}

--- a/src/components/symptom-checker/speech-input-button.tsx
+++ b/src/components/symptom-checker/speech-input-button.tsx
@@ -37,7 +37,7 @@ export function SpeechInputButton({
     return null;
   }
 
-  const isUnavailable = state === "disabled";
+  const isUnavailable = state === "disabled" && !error;
   const title = titleForState(state, error);
 
   return (

--- a/src/hooks/useAzureSpeechInput.ts
+++ b/src/hooks/useAzureSpeechInput.ts
@@ -54,11 +54,42 @@ export type UseAzureSpeechInputOptions = {
   onText(text: string): void;
 };
 
+type WebSpeechRecognition = {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  maxAlternatives: number;
+  onerror: ((event: { error?: string }) => void) | null;
+  onresult: ((event: { results: { [index: number]: { [index: number]: { transcript?: string } } } }) => void) | null;
+  start(): void;
+  stop(): void;
+};
+
+type WebSpeechWindow = Window & {
+  SpeechRecognition?: new () => WebSpeechRecognition;
+  webkitSpeechRecognition?: new () => WebSpeechRecognition;
+};
+
 function browserSupportsMicrophone(): boolean {
   return (
     typeof navigator !== "undefined" &&
     Boolean(navigator.mediaDevices?.getUserMedia)
   );
+}
+
+function browserSupportsWebSpeech(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  const speechWindow = window as WebSpeechWindow;
+  return Boolean(
+    speechWindow.SpeechRecognition || speechWindow.webkitSpeechRecognition
+  );
+}
+
+export function browserSupportsSpeechInput(): boolean {
+  return browserSupportsMicrophone() || browserSupportsWebSpeech();
 }
 
 export async function requestAzureSpeechBrowserToken(): Promise<AzureSpeechBrowserToken | null> {
@@ -106,6 +137,37 @@ function recognizeOnce(
   });
 }
 
+function recognizeWithWebSpeech(language: string): Promise<string> {
+  const speechWindow = window as WebSpeechWindow;
+  const SpeechRecognitionCtor =
+    speechWindow.SpeechRecognition || speechWindow.webkitSpeechRecognition;
+
+  if (!SpeechRecognitionCtor) {
+    return Promise.reject(new Error("Web Speech API unavailable"));
+  }
+
+  const recognition = new SpeechRecognitionCtor();
+  recognition.lang = language;
+  recognition.continuous = false;
+  recognition.interimResults = false;
+  recognition.maxAlternatives = 1;
+
+  return new Promise((resolve, reject) => {
+    recognition.onresult = (event) => {
+      const transcript = event.results[0]?.[0]?.transcript?.trim();
+      if (transcript) {
+        resolve(transcript);
+        return;
+      }
+      reject(new Error("empty transcript"));
+    };
+    recognition.onerror = (event) => {
+      reject(new Error(event.error || "speech_recognition_failed"));
+    };
+    recognition.start();
+  });
+}
+
 export function useAzureSpeechInput({
   fetchToken = requestAzureSpeechBrowserToken,
   language = "en-US",
@@ -120,7 +182,7 @@ export function useAzureSpeechInput({
 
   useEffect(() => {
     mountedRef.current = true;
-    setIsSupported(browserSupportsMicrophone());
+    setIsSupported(browserSupportsSpeechInput());
     return () => {
       mountedRef.current = false;
     };
@@ -131,7 +193,7 @@ export function useAzureSpeechInput({
   }, [onText]);
 
   const start = useCallback(async () => {
-    if (!mountedRef.current || !browserSupportsMicrophone()) {
+    if (!mountedRef.current || !browserSupportsSpeechInput()) {
       setState("disabled");
       return;
     }
@@ -145,36 +207,50 @@ export function useAzureSpeechInput({
       if (!mountedRef.current) {
         return;
       }
-      if (!token) {
-        setState("disabled");
+
+      if (token) {
+        const sdk = await loadSdk();
+        if (!mountedRef.current) {
+          return;
+        }
+        const speechConfig = sdk.SpeechConfig.fromAuthorizationToken(
+          token.token,
+          token.region
+        );
+        speechConfig.speechRecognitionLanguage = language;
+
+        recognizer = new sdk.SpeechRecognizer(
+          speechConfig,
+          sdk.AudioConfig.fromDefaultMicrophoneInput()
+        );
+
+        setState("listening");
+        const result = await recognizeOnce(recognizer);
+        if (!mountedRef.current) {
+          return;
+        }
+        const transcript = result.text?.trim();
+        if (transcript) {
+          onTextRef.current(transcript);
+        }
+        setState("idle");
         return;
       }
 
-      const sdk = await loadSdk();
-      if (!mountedRef.current) {
+      if (browserSupportsWebSpeech()) {
+        setState("listening");
+        const transcript = await recognizeWithWebSpeech(language);
+        if (!mountedRef.current) {
+          return;
+        }
+        if (transcript) {
+          onTextRef.current(transcript);
+        }
+        setState("idle");
         return;
       }
-      const speechConfig = sdk.SpeechConfig.fromAuthorizationToken(
-        token.token,
-        token.region
-      );
-      speechConfig.speechRecognitionLanguage = language;
 
-      recognizer = new sdk.SpeechRecognizer(
-        speechConfig,
-        sdk.AudioConfig.fromDefaultMicrophoneInput()
-      );
-
-      setState("listening");
-      const result = await recognizeOnce(recognizer);
-      if (!mountedRef.current) {
-        return;
-      }
-      const transcript = result.text?.trim();
-      if (transcript) {
-        onTextRef.current(transcript);
-      }
-      setState("idle");
+      setState("disabled");
     } catch {
       if (mountedRef.current) {
         setError("Speech input failed");

--- a/src/lib/auth-routing.ts
+++ b/src/lib/auth-routing.ts
@@ -23,6 +23,10 @@ export const AUTH_PAGE_PREFIXES = ["/login", "/signup", "/forgot-password"];
 export const AUTH_CALLBACK_ERROR_MESSAGES: Record<string, string> = {
   auth_callback_failed: "We couldn't complete sign-in from that link. Please try again.",
   invalid_reset_link: "That password reset link is invalid or has expired.",
+  otp_expired:
+    "That email confirmation link has expired. Please sign up again to receive a new one.",
+  confirm_link_expired:
+    "That email confirmation link has expired. Please sign up again to receive a new one.",
 };
 
 export const AUTH_REASON_MESSAGES: Record<string, string> = {
@@ -203,6 +207,72 @@ export function buildLoginPath(
 
   if (options?.reason) {
     url.searchParams.set("reason", options.reason);
+  }
+
+  if (options?.error) {
+    url.searchParams.set("error", options.error);
+  }
+
+  return `${url.pathname}${url.search}`;
+}
+
+export function buildSignupConfirmPath(
+  redirectTarget: string | null | undefined,
+  options?: {
+    tokenHash?: string | null;
+    type?: string | null;
+  }
+) {
+  const url = new URL("/signup/confirm", INTERNAL_BASE_URL);
+  const safeTarget = sanitizeRedirectTarget(redirectTarget);
+
+  if (safeTarget) {
+    url.searchParams.set("next", safeTarget);
+  }
+
+  if (options?.tokenHash) {
+    url.searchParams.set("token_hash", options.tokenHash);
+  }
+
+  if (options?.type) {
+    url.searchParams.set("type", options.type);
+  }
+
+  return `${url.pathname}${url.search}`;
+}
+
+export function buildSignupConfirmCallbackUrl(
+  origin: string,
+  redirectTarget: string | null | undefined,
+  options: {
+    tokenHash: string;
+    type?: string;
+  }
+) {
+  const url = new URL("/api/auth/callback", origin);
+  const safeTarget = sanitizeRedirectTarget(redirectTarget, origin);
+
+  url.searchParams.set("token_hash", options.tokenHash);
+  url.searchParams.set("type", options.type || "signup");
+
+  if (safeTarget) {
+    url.searchParams.set("next", safeTarget);
+  }
+
+  return url.toString();
+}
+
+export function buildSignupPath(
+  redirectTarget: string | null | undefined,
+  options?: {
+    error?: string;
+  }
+) {
+  const url = new URL("/signup", INTERNAL_BASE_URL);
+  const safeTarget = sanitizeRedirectTarget(redirectTarget);
+
+  if (safeTarget) {
+    url.searchParams.set("redirect", safeTarget);
   }
 
   if (options?.error) {

--- a/src/lib/symptom-chat/extraction-helpers.ts
+++ b/src/lib/symptom-chat/extraction-helpers.ts
@@ -727,12 +727,19 @@ export function buildDeterministicQuestionFallback(
 ): string {
   const memory = ensureStructuredCaseMemory(session);
   const chiefComplaint = memory.chief_complaints[0]?.replace(/_/g, " ") || null;
+  const confirmedSummary = buildConfirmedQASummary(session, 1);
+  const latestAnswer = confirmedSummary
+    .split("\n")
+    .map((line) => line.match(/^- .+ -> (.+)$/)?.[1]?.trim())
+    .find(Boolean);
 
   let acknowledgment: string;
   if (hasPhoto && allowPhotoMention) {
     acknowledgment = `Thanks for sharing that about ${petName}; I'm combining your answer with the photo and the rest of the history.`;
+  } else if (latestAnswer) {
+    acknowledgment = `Got it — ${latestAnswer}.`;
   } else if (chiefComplaint) {
-    acknowledgment = `I'm keeping track of what you've shared so far about ${petName}'s ${chiefComplaint}.`;
+    acknowledgment = `Thanks for telling me about ${petName}'s ${chiefComplaint}.`;
   } else {
     acknowledgment = `Thanks for sharing that about ${petName}.`;
   }

--- a/src/lib/symptom-chat/question-phrasing.ts
+++ b/src/lib/symptom-chat/question-phrasing.ts
@@ -18,7 +18,8 @@ import {
 } from "@/lib/symptom-chat/extraction-helpers";
 
 const useNvidia = isNvidiaConfigured();
-export const TEXT_ONLY_QUESTION_PHRASING_BUDGET_MS = 10_000;
+// Shared between Nemotron preflight gate + Llama phrasing on text-only turns.
+export const TEXT_ONLY_QUESTION_PHRASING_BUDGET_MS = 25_000;
 
 export interface SymptomChatTurnMessage {
   role: "user" | "assistant";

--- a/src/lib/symptom-chat/request-timeout.ts
+++ b/src/lib/symptom-chat/request-timeout.ts
@@ -1,1 +1,4 @@
-export const SYMPTOM_CHAT_REQUEST_TIMEOUT_MS = 30000;
+// Must exceed the server route's worst-case model latency (phrasing 12s +
+// extraction 45s budgets can overlap); 30s raced the route and aborted
+// responses that were about to arrive.
+export const SYMPTOM_CHAT_REQUEST_TIMEOUT_MS = 90000;

--- a/src/lib/symptom-checker/session-progress.ts
+++ b/src/lib/symptom-checker/session-progress.ts
@@ -1,0 +1,23 @@
+import type { TriageSession } from "@/lib/triage-engine";
+
+export function computeConversationProgress(session: TriageSession): {
+  answered: number;
+  total: number;
+} {
+  const answered = session.answered_questions?.length ?? 0;
+  const unresolvedIds = session.case_memory?.unresolved_question_ids ?? [];
+  const pendingId =
+    session.case_memory?.pending_question_id ?? session.last_question_asked;
+
+  const pendingIsOpen =
+    Boolean(pendingId) &&
+    !session.answered_questions.includes(pendingId!) &&
+    !unresolvedIds.includes(pendingId!);
+
+  const total = answered + unresolvedIds.length + (pendingIsOpen ? 1 : 0);
+
+  return {
+    answered,
+    total: Math.max(total, answered),
+  };
+}

--- a/tests/auth-callback.route.test.ts
+++ b/tests/auth-callback.route.test.ts
@@ -2,6 +2,7 @@ import { NextRequest } from "next/server";
 
 const mockExchangeCodeForSession = jest.fn();
 const mockVerifyOtp = jest.fn();
+
 const mockCreateServerClient = jest.fn(
   (
     _url: string,
@@ -193,6 +194,77 @@ describe("VET-1215 auth callback route", () => {
 
     expect(response.headers.get("location")).toBe(
       "https://app.pawvital.ai/login?redirect=%2Fdashboard&error=auth_callback_failed"
+    );
+  });
+
+  it("verifies signup email links with token_hash and redirects to the post-confirmation target", async () => {
+    mockVerifyOtp.mockResolvedValue({ error: null });
+
+    const { GET } = await import("@/app/api/auth/callback/route");
+    const response = await GET(
+      new NextRequest(
+        "https://app.pawvital.ai/api/auth/callback?token_hash=signup-token&type=signup&next=%2Fpets%2Fpet-1"
+      )
+    );
+
+    expect(mockVerifyOtp).toHaveBeenCalledWith({
+      token_hash: "signup-token",
+      type: "signup",
+    });
+    expect(response.headers.get("location")).toBe(
+      "https://app.pawvital.ai/pets/pet-1"
+    );
+    expect(response.headers.get("set-cookie")).toContain("sb-test-auth-token");
+    expect(mockExchangeCodeForSession).not.toHaveBeenCalled();
+  });
+
+  it("redirects expired signup confirmation links back to signup with a friendly error", async () => {
+    mockVerifyOtp.mockResolvedValue({
+      error: new Error("Email link is invalid or has expired"),
+    });
+
+    const { GET } = await import("@/app/api/auth/callback/route");
+    const response = await GET(
+      new NextRequest(
+        "https://app.pawvital.ai/api/auth/callback?token_hash=signup-token&type=signup&next=%2Fdashboard"
+      )
+    );
+
+    expect(response.headers.get("location")).toBe(
+      "https://app.pawvital.ai/signup?redirect=%2Fdashboard&error=confirm_link_expired"
+    );
+  });
+
+  it("exchanges signup PKCE codes and redirects to the post-confirmation target", async () => {
+    mockExchangeCodeForSession.mockResolvedValue({ error: null });
+
+    const { GET } = await import("@/app/api/auth/callback/route");
+    const response = await GET(
+      new NextRequest(
+        "https://app.pawvital.ai/api/auth/callback?code=signup-code&type=signup&next=%2Fdashboard"
+      )
+    );
+
+    expect(mockExchangeCodeForSession).toHaveBeenCalledWith("signup-code");
+    expect(mockVerifyOtp).not.toHaveBeenCalled();
+    expect(response.headers.get("location")).toBe("https://app.pawvital.ai/dashboard");
+    expect(response.headers.get("set-cookie")).toContain("sb-test-auth-token");
+  });
+
+  it("redirects failed signup PKCE exchanges back to signup with a friendly error", async () => {
+    mockExchangeCodeForSession.mockResolvedValue({
+      error: new Error("PKCE code verifier not found"),
+    });
+
+    const { GET } = await import("@/app/api/auth/callback/route");
+    const response = await GET(
+      new NextRequest(
+        "https://app.pawvital.ai/api/auth/callback?code=signup-code&type=signup&next=%2Fdashboard"
+      )
+    );
+
+    expect(response.headers.get("location")).toBe(
+      "https://app.pawvital.ai/signup?redirect=%2Fdashboard&error=auth_callback_failed"
     );
   });
 });

--- a/tests/auth-error-redirect.test.tsx
+++ b/tests/auth-error-redirect.test.tsx
@@ -1,0 +1,95 @@
+/** @jest-environment jsdom */
+
+import * as React from "react";
+import { render, waitFor } from "@testing-library/react";
+import AuthErrorRedirect from "@/components/auth/auth-error-redirect";
+
+const mockReplaceWithBrowser = jest.fn();
+
+jest.mock("@/lib/browser-navigation", () => ({
+  replaceWithBrowser: (...args: unknown[]) => mockReplaceWithBrowser(...args),
+}));
+
+describe("auth error redirect guard", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("redirects otp_expired landing errors to signup with a friendly error code", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/?error=otp_expired&error_description=Email+link+is+invalid+or+has+expired"
+    );
+
+    render(React.createElement(AuthErrorRedirect));
+
+    await waitFor(() => expect(mockReplaceWithBrowser).toHaveBeenCalledTimes(1));
+    expect(mockReplaceWithBrowser).toHaveBeenCalledWith(
+      "/signup?redirect=%2Fdashboard&error=otp_expired"
+    );
+  });
+
+  it("redirects Supabase access_denied + error_code=otp_expired query and hash to signup", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/?error=access_denied&error_code=otp_expired&error_description=Email+link+is+invalid+or+has+expired#error=access_denied&error_code=otp_expired&error_description=Email+link+is+invalid+or+has+expired"
+    );
+
+    render(React.createElement(AuthErrorRedirect));
+
+    await waitFor(() => expect(mockReplaceWithBrowser).toHaveBeenCalledTimes(1));
+    expect(mockReplaceWithBrowser).toHaveBeenCalledWith(
+      "/signup?redirect=%2Fdashboard&error=otp_expired"
+    );
+  });
+
+  it("preserves safe redirect targets when rerouting otp_expired errors", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/?error=otp_expired&redirect=%2Fsymptom-checker"
+    );
+
+    render(React.createElement(AuthErrorRedirect));
+
+    await waitFor(() => expect(mockReplaceWithBrowser).toHaveBeenCalledTimes(1));
+    expect(mockReplaceWithBrowser).toHaveBeenCalledWith(
+      "/signup?redirect=%2Fsymptom-checker&error=otp_expired"
+    );
+  });
+
+  it("drops unsafe external redirect targets from otp_expired errors", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/?error=otp_expired&redirect=https%3A%2F%2Fevil.example%2Fsteal"
+    );
+
+    render(React.createElement(AuthErrorRedirect));
+
+    await waitFor(() => expect(mockReplaceWithBrowser).toHaveBeenCalledTimes(1));
+
+    const destination = mockReplaceWithBrowser.mock.calls[0][0] as string;
+    expect(destination).toBe("/signup?redirect=%2Fdashboard&error=otp_expired");
+    expect(destination).not.toContain("evil.example");
+  });
+
+  it("does not reroute auth errors when already on signup or login", () => {
+    window.history.replaceState({}, "", "/signup?error=otp_expired");
+
+    render(React.createElement(AuthErrorRedirect));
+
+    expect(mockReplaceWithBrowser).not.toHaveBeenCalled();
+  });
+
+  it("does not reroute unrelated landing-page query params", () => {
+    window.history.replaceState({}, "", "/?utm_source=email");
+
+    render(React.createElement(AuthErrorRedirect));
+
+    expect(mockReplaceWithBrowser).not.toHaveBeenCalled();
+  });
+});

--- a/tests/auth-pages.network-error.test.tsx
+++ b/tests/auth-pages.network-error.test.tsx
@@ -7,6 +7,7 @@ import LoginPage from "@/app/(auth)/login/page";
 import SignupPage from "@/app/(auth)/signup/page";
 
 const mockReplace = jest.fn();
+const mockReplaceWithBrowser = jest.fn();
 const mockSearchParams = new URLSearchParams();
 const mockCreateClient = jest.fn();
 const mockCreateRecoveryClient = jest.fn();
@@ -34,6 +35,10 @@ jest.mock("next/navigation", () => ({
   useSearchParams: () => mockSearchParams,
 }));
 
+jest.mock("@/lib/browser-navigation", () => ({
+  replaceWithBrowser: (...args: unknown[]) => mockReplaceWithBrowser(...args),
+}));
+
 jest.mock("@/lib/supabase", () => ({
   createClient: () => mockCreateClient(),
   createRecoveryClient: () => mockCreateRecoveryClient(),
@@ -52,6 +57,9 @@ function fillRequiredAuthFields() {
 describe("auth page network error handling", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSearchParams.forEach((_, key) => {
+      mockSearchParams.delete(key);
+    });
     mockCreateRecoveryClient.mockImplementation(() => mockCreateClient());
   });
 
@@ -111,13 +119,11 @@ describe("auth page network error handling", () => {
 
   it("shows the friendly network message on account creation failure", async () => {
     const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
-    mockCreateClient.mockReturnValue({
-      auth: {
-        signUp: jest
-          .fn()
-          .mockRejectedValue(new TypeError("Network request failed")),
-      },
-    });
+    const fetchMock = jest
+      .fn()
+      .mockRejectedValue(new TypeError("Network request failed"));
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as typeof fetch;
 
     try {
       render(React.createElement(SignupPage));
@@ -137,6 +143,7 @@ describe("auth page network error handling", () => {
         ).toBeTruthy()
       );
     } finally {
+      globalThis.fetch = originalFetch;
       errorSpy.mockRestore();
     }
   });
@@ -169,6 +176,199 @@ describe("auth page network error handling", () => {
     } finally {
       errorSpy.mockRestore();
     }
+  });
+
+  it("auto-confirms signup through the server route and redirects", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, redirect: "/dashboard" }),
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    try {
+      render(React.createElement(SignupPage));
+
+      fireEvent.change(screen.getByPlaceholderText("Your name"), {
+        target: { value: "Dog Parent" },
+      });
+      fillRequiredAuthFields();
+
+      fireEvent.click(screen.getByRole("button", { name: "Start Free Trial" }));
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+      expect(fetchMock).toHaveBeenCalledWith("/api/auth/signup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: "owner@example.com",
+          password: "super-secret-password",
+          name: "Dog Parent",
+          next: "/dashboard",
+        }),
+      });
+      expect(mockReplaceWithBrowser).toHaveBeenCalledWith("/dashboard");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("shows a resend confirmation button when signup lands with otp_expired", () => {
+    mockSearchParams.set("error", "otp_expired");
+    mockCreateClient.mockReturnValue({ auth: {} });
+
+    render(React.createElement(SignupPage));
+
+    expect(
+      screen.getByRole("button", { name: "Resend confirmation email" })
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        "That email confirmation link has expired. Please sign up again to receive a new one."
+      )
+    ).toBeTruthy();
+  });
+
+  it("shows a resend confirmation button when signup lands with confirm_link_expired", () => {
+    mockSearchParams.set("error", "confirm_link_expired");
+    mockCreateClient.mockReturnValue({ auth: {} });
+
+    render(React.createElement(SignupPage));
+
+    expect(
+      screen.getByRole("button", { name: "Resend confirmation email" })
+    ).toBeTruthy();
+  });
+
+  it("shows a server signup error when auto-confirm fails", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({
+        message:
+          "An account with this email already exists. Sign in with your password, or reset it from the login page.",
+      }),
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    try {
+      render(React.createElement(SignupPage));
+
+      fireEvent.change(screen.getByPlaceholderText("Your name"), {
+        target: { value: "Dog Parent" },
+      });
+      fillRequiredAuthFields();
+      fireEvent.click(screen.getByRole("button", { name: "Start Free Trial" }));
+
+      await waitFor(() =>
+        expect(
+          screen.getByText(
+            "An account with this email already exists. Sign in with your password, or reset it from the login page."
+          )
+        ).toBeTruthy()
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("resends signup confirmation emails through the API auth callback", async () => {
+    const resend = jest.fn().mockResolvedValue({ error: null });
+    mockSearchParams.set("error", "otp_expired");
+    mockCreateClient.mockReturnValue({
+      auth: { resend },
+    });
+
+    render(React.createElement(SignupPage));
+
+    fireEvent.change(screen.getByPlaceholderText("you@example.com"), {
+      target: { value: "owner@example.com" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Resend confirmation email" })
+    );
+
+    await waitFor(() => expect(resend).toHaveBeenCalled());
+
+    expect(resend).toHaveBeenCalledWith({
+      type: "signup",
+      email: "owner@example.com",
+      options: {
+        emailRedirectTo: "http://localhost/api/auth/callback?next=%2Fdashboard",
+      },
+    });
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "We sent another confirmation email. Enter the 6-digit code from that email below."
+        )
+      ).toBeTruthy()
+    );
+  });
+
+  it("verifies signup with a 6-digit confirmation code through the server route", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, redirect: "/dashboard" }),
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as typeof fetch;
+    mockSearchParams.set("error", "otp_expired");
+    mockCreateClient.mockReturnValue({
+      auth: {},
+    });
+
+    try {
+      render(React.createElement(SignupPage));
+
+      fireEvent.change(screen.getByPlaceholderText("you@example.com"), {
+        target: { value: "owner@example.com" },
+      });
+      fireEvent.change(screen.getByPlaceholderText("6-digit code"), {
+        target: { value: "123456" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Confirm with code" }));
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+      expect(fetchMock).toHaveBeenCalledWith("/api/auth/verify-signup-code", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: "owner@example.com",
+          token: "123456",
+          next: "/dashboard",
+        }),
+      });
+      expect(mockReplaceWithBrowser).toHaveBeenCalledWith("/dashboard");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("requires an email before resending signup confirmation", async () => {
+    mockSearchParams.set("error", "otp_expired");
+    mockCreateClient.mockReturnValue({
+      auth: {
+        resend: jest.fn(),
+      },
+    });
+
+    render(React.createElement(SignupPage));
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Resend confirmation email" })
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("Enter your email above to resend the confirmation link.")
+      ).toBeTruthy()
+    );
   });
 
   it("sends password reset emails through the implicit recovery client", async () => {

--- a/tests/auth-routing.test.ts
+++ b/tests/auth-routing.test.ts
@@ -6,6 +6,8 @@ import {
   buildRecoveryPageUrl,
   buildRecoveryRedirectPath,
   buildRedirectTarget,
+  buildSignupConfirmCallbackUrl,
+  buildSignupConfirmPath,
   buildLoginPath,
   getAuthFeedbackMessage,
   getAuthActionErrorMessage,
@@ -72,6 +74,17 @@ describe("VET-1215 auth routing helpers", () => {
     expect(buildRecoveryPageUrl("https://pawvital.ai", "/pets/1")).toBe(
       "https://pawvital.ai/reset-password?redirect=%2Fpets%2F1"
     );
+    expect(buildSignupConfirmPath("/dashboard")).toBe(
+      "/signup/confirm?next=%2Fdashboard"
+    );
+    expect(
+      buildSignupConfirmCallbackUrl("https://pawvital.ai", "/dashboard", {
+        tokenHash: "hash-123",
+        type: "signup",
+      })
+    ).toBe(
+      "https://pawvital.ai/api/auth/callback?token_hash=hash-123&type=signup&next=%2Fdashboard"
+    );
   });
 
   it("surfaces private-tester access redirects as friendly login feedback", () => {
@@ -126,5 +139,26 @@ describe("VET-1215 auth routing helpers", () => {
         "Fallback"
       )
     ).toBe("Invalid login credentials");
+  });
+
+  it("surfaces expired email confirmation links with friendly signup feedback", () => {
+    expect(getAuthFeedbackMessage(null, "otp_expired")).toEqual({
+      tone: "error",
+      text: "That email confirmation link has expired. Please sign up again to receive a new one.",
+    });
+    expect(getAuthFeedbackMessage(null, "confirm_link_expired")).toEqual({
+      tone: "error",
+      text: "That email confirmation link has expired. Please sign up again to receive a new one.",
+    });
+  });
+
+  it("routes signup email confirmation through the API callback instead of the browser page", () => {
+    const apiCallback = buildCallbackUrl("https://pawvital.ai", "/dashboard");
+    const browserCallback = buildBrowserCallbackUrl("https://pawvital.ai", "/dashboard");
+
+    expect(apiCallback).toBe("https://pawvital.ai/api/auth/callback?next=%2Fdashboard");
+    expect(browserCallback).toBe("https://pawvital.ai/auth/callback?next=%2Fdashboard");
+    expect(new URL(apiCallback).pathname).toBe("/api/auth/callback");
+    expect(new URL(browserCallback).pathname).toBe("/auth/callback");
   });
 });

--- a/tests/azure-speech-input-hook.test.ts
+++ b/tests/azure-speech-input-hook.test.ts
@@ -125,8 +125,25 @@ describe("useAzureSpeechInput", () => {
     expect(screen.getByTestId("speech-state").textContent).toBe("idle");
   });
 
-  it("disables itself without calling the SDK when no token is available", async () => {
+  it("falls back to browser speech when Azure token is unavailable", async () => {
     const { sdk } = makeSpeechSdk("ignored transcript");
+    const start = jest.fn();
+    const stop = jest.fn();
+    const SpeechRecognitionMock = jest.fn(() => ({
+      continuous: false,
+      interimResults: false,
+      lang: "en-US",
+      maxAlternatives: 1,
+      onerror: null,
+      onresult: null,
+      start,
+      stop,
+    }));
+
+    Object.defineProperty(window, "SpeechRecognition", {
+      configurable: true,
+      value: SpeechRecognitionMock,
+    });
 
     render(
       React.createElement(SpeechHarness, {
@@ -142,10 +159,18 @@ describe("useAzureSpeechInput", () => {
     );
     fireEvent.click(screen.getByRole("button", { name: "start" }));
 
+    await waitFor(() => expect(start).toHaveBeenCalled());
+    const recognition = SpeechRecognitionMock.mock.results[0]?.value;
+    recognition.onresult({
+      results: { 0: { 0: { transcript: "my dog is limping" } } },
+    });
+
     await waitFor(() =>
-      expect(screen.getByTestId("speech-state").textContent).toBe("disabled")
+      expect(screen.getByTestId("transcript").textContent).toBe(
+        "my dog is limping"
+      )
     );
     expect(sdk.SpeechRecognizer).not.toHaveBeenCalled();
-    expect(screen.getByTestId("transcript").textContent).toBe("");
+    expect(screen.getByTestId("speech-state").textContent).toBe("idle");
   });
 });

--- a/tests/question-phrasing.test.ts
+++ b/tests/question-phrasing.test.ts
@@ -39,6 +39,7 @@ import {
   gateQuestionBeforePhrasing,
   phraseQuestion,
   sanitizeQuestionDraft,
+  TEXT_ONLY_QUESTION_PHRASING_BUDGET_MS,
 } from "@/lib/symptom-chat/question-phrasing";
 
 const pet: PetProfile = {
@@ -118,7 +119,7 @@ describe("question phrasing helpers", () => {
         settled = true;
       });
 
-      await jest.advanceTimersByTimeAsync(10_001);
+      await jest.advanceTimersByTimeAsync(TEXT_ONLY_QUESTION_PHRASING_BUDGET_MS + 1);
 
       expect(settled).toBe(true);
       await expect(resultPromise).resolves.toEqual({
@@ -188,7 +189,7 @@ describe("question phrasing helpers", () => {
         settled = true;
       });
 
-      await jest.advanceTimersByTimeAsync(10_001);
+      await jest.advanceTimersByTimeAsync(TEXT_ONLY_QUESTION_PHRASING_BUDGET_MS + 1);
 
       expect(settled).toBe(true);
       await expect(resultPromise).resolves.toBe(
@@ -231,7 +232,7 @@ describe("question phrasing helpers", () => {
         settled = true;
       });
 
-      await jest.advanceTimersByTimeAsync(10_001);
+      await jest.advanceTimersByTimeAsync(TEXT_ONLY_QUESTION_PHRASING_BUDGET_MS + 1);
 
       expect(settled).toBe(true);
       await expect(resultPromise).resolves.toBe(

--- a/tests/session-progress.test.ts
+++ b/tests/session-progress.test.ts
@@ -1,0 +1,36 @@
+import { computeConversationProgress } from "@/lib/symptom-checker/session-progress";
+import { createSession } from "@/lib/triage-engine";
+
+describe("computeConversationProgress", () => {
+  it("counts answered questions and pending follow-up separately", () => {
+    const session = createSession();
+    session.answered_questions = ["water_intake", "appetite_duration"];
+    session.last_question_asked = "weight_loss";
+    session.case_memory = {
+      ...session.case_memory!,
+      unresolved_question_ids: ["vomit_frequency"],
+      pending_question_id: "weight_loss",
+    };
+
+    expect(computeConversationProgress(session)).toEqual({
+      answered: 2,
+      total: 4,
+    });
+  });
+
+  it("does not double-count pending question already in unresolved list", () => {
+    const session = createSession();
+    session.answered_questions = ["water_intake"];
+    session.last_question_asked = "appetite_duration";
+    session.case_memory = {
+      ...session.case_memory!,
+      unresolved_question_ids: ["appetite_duration"],
+      pending_question_id: "appetite_duration",
+    };
+
+    expect(computeConversationProgress(session)).toEqual({
+      answered: 1,
+      total: 2,
+    });
+  });
+});

--- a/tests/signup-confirm.page.test.tsx
+++ b/tests/signup-confirm.page.test.tsx
@@ -1,0 +1,79 @@
+/** @jest-environment jsdom */
+
+import * as React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import SignupConfirmPage from "@/app/(auth)/signup/confirm/page";
+
+const mockReplaceWithBrowser = jest.fn();
+const mockSearchParams = new URLSearchParams();
+
+jest.mock("next/link", () => {
+  const ReactActual = jest.requireActual<typeof import("react")>("react");
+
+  return {
+    __esModule: true,
+    default: ({
+      children,
+      href,
+      ...props
+    }: {
+      children: React.ReactNode;
+      href: string;
+    }) => ReactActual.createElement("a", { href, ...props }, children),
+  };
+});
+
+jest.mock("next/navigation", () => ({
+  useSearchParams: () => mockSearchParams,
+}));
+
+jest.mock("@/lib/browser-navigation", () => ({
+  replaceWithBrowser: (...args: unknown[]) => mockReplaceWithBrowser(...args),
+}));
+
+describe("signup confirm page", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    for (const key of [...mockSearchParams.keys()]) {
+      mockSearchParams.delete(key);
+    }
+  });
+
+  it("does not auto-confirm on page load", () => {
+    mockSearchParams.set("token_hash", "hash-123");
+    mockSearchParams.set("type", "signup");
+    mockSearchParams.set("next", "/dashboard");
+
+    render(React.createElement(SignupConfirmPage));
+
+    expect(mockReplaceWithBrowser).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Confirm my email" })).toBeTruthy();
+  });
+
+  it("confirms only after the user clicks the button", () => {
+    mockSearchParams.set("token_hash", "hash-123");
+    mockSearchParams.set("type", "signup");
+    mockSearchParams.set("next", "/dashboard");
+
+    render(React.createElement(SignupConfirmPage));
+
+    fireEvent.click(screen.getByRole("button", { name: "Confirm my email" }));
+
+    expect(mockReplaceWithBrowser).toHaveBeenCalledTimes(1);
+    const destination = mockReplaceWithBrowser.mock.calls[0][0] as string;
+    const url = new URL(destination, "http://localhost");
+    expect(url.pathname).toBe("/api/auth/callback");
+    expect(url.searchParams.get("token_hash")).toBe("hash-123");
+    expect(url.searchParams.get("type")).toBe("signup");
+    expect(url.searchParams.get("next")).toBe("/dashboard");
+  });
+
+  it("shows a recovery link when token_hash is missing", () => {
+    render(React.createElement(SignupConfirmPage));
+
+    expect(screen.getByText("Link not ready")).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "Back to signup" }).getAttribute("href")
+    ).toContain("/signup");
+  });
+});

--- a/tests/verify-signup-code.route.test.ts
+++ b/tests/verify-signup-code.route.test.ts
@@ -1,0 +1,127 @@
+import { NextRequest } from "next/server";
+
+const mockVerifyOtp = jest.fn();
+const mockCreateServerClient = jest.fn(
+  (
+    _url: string,
+    _key: string,
+    options: {
+      cookies: {
+        setAll: (
+          cookies: Array<{
+            name: string;
+            value: string;
+            options?: Record<string, unknown>;
+          }>
+        ) => void;
+      };
+    }
+  ) => ({
+    auth: {
+      verifyOtp: async (payload: { email: string; token: string; type: string }) => {
+        const result = await mockVerifyOtp(payload);
+        if (!result.error) {
+          options.cookies.setAll([
+            {
+              name: "sb-test-auth-token",
+              value: "session-cookie",
+              options: { httpOnly: true, path: "/" },
+            },
+          ]);
+        }
+        return result;
+      },
+    },
+  })
+);
+
+jest.mock("@supabase/ssr", () => ({
+  createServerClient: (...args: unknown[]) => mockCreateServerClient(...args),
+}));
+
+describe("verify signup code route", () => {
+  const originalSupabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const originalSupabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://supabase.example";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+  });
+
+  afterAll(() => {
+    if (originalSupabaseUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    } else {
+      process.env.NEXT_PUBLIC_SUPABASE_URL = originalSupabaseUrl;
+    }
+
+    if (originalSupabaseAnonKey === undefined) {
+      delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+    } else {
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = originalSupabaseAnonKey;
+    }
+  });
+
+  it("verifies signup codes server-side and sets auth cookies", async () => {
+    mockVerifyOtp.mockResolvedValue({
+      data: { session: { user: { id: "user-1" } } },
+      error: null,
+    });
+
+    const { POST } = await import("@/app/api/auth/verify-signup-code/route");
+    const response = await POST(
+      new NextRequest("https://app.pawvital.ai/api/auth/verify-signup-code", {
+        method: "POST",
+        body: JSON.stringify({
+          email: "owner@example.com",
+          token: "123456",
+          next: "/dashboard",
+        }),
+      })
+    );
+
+    expect(mockVerifyOtp).toHaveBeenCalledWith({
+      email: "owner@example.com",
+      token: "123456",
+      type: "signup",
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("set-cookie")).toContain("sb-test-auth-token");
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      redirect: "/dashboard",
+    });
+  });
+
+  it("returns a signup redirect when verification fails", async () => {
+    mockVerifyOtp
+      .mockResolvedValueOnce({
+        data: { session: null },
+        error: new Error("expired"),
+      })
+      .mockResolvedValueOnce({
+        data: { session: null },
+        error: new Error("expired"),
+      });
+
+    const { POST } = await import("@/app/api/auth/verify-signup-code/route");
+    const response = await POST(
+      new NextRequest("https://app.pawvital.ai/api/auth/verify-signup-code", {
+        method: "POST",
+        body: JSON.stringify({
+          email: "owner@example.com",
+          token: "123456",
+          next: "/dashboard",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "invalid_code",
+      redirect: "/signup?redirect=%2Fdashboard&error=confirm_link_expired",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Server-side signup (`/api/auth/signup`) auto-confirms accounts when service role is configured, bypassing broken Supabase email confirmation.
- Symptom checker: 90s client timeout, 25s phrasing budget with deterministic fallback, progress bar reads `unresolved_question_ids`, Web Speech mic fallback, improved extraction helpers.
- Excludes marketing redesign and backend migration work.

## Test plan
- [x] `npm test -- --testPathPatterns="auth-|signup|session-progress|azure-speech|question-phrasing|verify-signup"`
- [ ] Manual: signup → login → symptom check first turn returns a question
- [ ] Add `NVIDIA_API_KEY` locally / in Vercel for phrasing (operator)