### PR TITLE
VET-LAND hotfix: restore safe signup confirmation flow

### DIFF
--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -8,7 +8,7 @@ import Button from "@/components/ui/button";
 import Input from "@/components/ui/input";
 import {
   appendRedirectParam,
-  buildCallbackUrl,
+  buildSignupCallbackUrl,
   getAuthFeedbackMessage,
   getAuthActionErrorMessage,
   resolvePostAuthRedirect,
@@ -75,6 +75,7 @@ export default function SignupPage() {
       const signupPayload = (await signupResponse.json()) as {
         ok?: boolean;
         redirect?: string;
+        requiresConfirmation?: boolean;
         message?: string;
       };
 
@@ -83,6 +84,14 @@ export default function SignupPage() {
           signupPayload.message ||
             "We couldn't create your account right now. Please try again."
         );
+      }
+
+      if (signupPayload.requiresConfirmation) {
+        setSuccessMessage(
+          signupPayload.message ||
+            "Check your email to confirm your account and continue."
+        );
+        return;
       }
 
       replaceWithBrowser(signupPayload.redirect || redirectTarget);
@@ -177,7 +186,10 @@ export default function SignupPage() {
       }
 
       const supabase = createClient();
-      const emailRedirectTo = buildCallbackUrl(window.location.origin, redirectTarget);
+      const emailRedirectTo = buildSignupCallbackUrl(
+        window.location.origin,
+        redirectTarget
+      );
       const { error: resendError } = await supabase.auth.resend({
         type: "signup",
         email: trimmedEmail,

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -66,6 +66,8 @@ export async function GET(request: NextRequest) {
   const rawType = searchParams.get("type");
   const rawFlow = searchParams.get("flow");
   const rawNext = searchParams.get("next");
+  const rawErrorCode =
+    searchParams.get("error_code") || searchParams.get("error");
   const nextTarget = resolvePostAuthRedirect(rawNext, {
     allowedOrigin: origin,
     fallback: DEFAULT_AUTH_REDIRECT,
@@ -77,6 +79,21 @@ export async function GET(request: NextRequest) {
   });
 
   try {
+    if (rawErrorCode) {
+      const isSignupFlow = rawType === "signup";
+      const errorCode =
+        isSignupFlow && rawErrorCode === "otp_expired"
+          ? "confirm_link_expired"
+          : "auth_callback_failed";
+
+      return buildFailureRedirect(
+        request,
+        nextTarget,
+        errorCode,
+        isSignupFlow ? "signup" : "login"
+      );
+    }
+
     if (code) {
       const isRecoveryFlow =
         rawFlow === "recovery" ||

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createServerClient } from "@supabase/ssr";
-import { getServiceSupabase } from "@/lib/supabase-admin";
 import {
   DEFAULT_AUTH_REDIRECT,
+  buildSignupCallbackUrl,
   resolvePostAuthRedirect,
 } from "@/lib/auth-routing";
+
 function createRouteHandlerSupabaseClient(
   request: NextRequest,
   response: NextResponse
@@ -30,26 +31,10 @@ function createRouteHandlerSupabaseClient(
   });
 }
 
-async function findUserIdByEmail(
-  admin: NonNullable<ReturnType<typeof getServiceSupabase>>,
-  email: string
-): Promise<string | null> {
-  const normalized = email.toLowerCase();
-  let page = 1;
-  // Paginate defensively; small projects resolve on the first page.
-  for (; page <= 10; page++) {
-    const { data, error } = await admin.auth.admin.listUsers({
-      page,
-      perPage: 200,
-    });
-    if (error || !data?.users?.length) return null;
-    const match = data.users.find(
-      (u) => u.email?.toLowerCase() === normalized
-    );
-    if (match) return match.id;
-    if (data.users.length < 200) return null;
-  }
-  return null;
+function copyResponseCookies(source: NextResponse, target: NextResponse) {
+  source.cookies.getAll().forEach((cookie) => {
+    target.cookies.set(cookie);
+  });
 }
 
 export async function POST(request: NextRequest) {
@@ -87,51 +72,22 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const admin = getServiceSupabase();
-    if (!admin) {
-      return NextResponse.json(
-        {
-          error: "server_misconfigured",
-          message: "Signup is temporarily unavailable. Please try again later.",
-        },
-        { status: 500 }
-      );
-    }
-
-    const created = await admin.auth.admin.createUser({
+    const response = NextResponse.json({
+      ok: true,
+      redirect: nextTarget,
+      requiresConfirmation: false,
+    });
+    const supabase = createRouteHandlerSupabaseClient(request, response);
+    const signup = await supabase.auth.signUp({
       email,
       password,
-      email_confirm: true,
-      user_metadata: { full_name: name },
+      options: {
+        data: { full_name: name },
+        emailRedirectTo: buildSignupCallbackUrl(origin, nextTarget),
+      },
     });
 
-    let createErrorMessage: string | null = null;
-    if (created.error) {
-      const message = created.error.message.toLowerCase();
-      const alreadyExists =
-        message.includes("already") || created.error.status === 422;
-
-      if (alreadyExists) {
-        // Recover accounts stuck in the unconfirmed state from earlier
-        // email-confirmation attempts: confirm them and reset the password
-        // to what the user just typed only if sign-in fails below.
-        const existingId = await findUserIdByEmail(admin, email);
-        if (existingId) {
-          const updated = await admin.auth.admin.updateUserById(existingId, {
-            email_confirm: true,
-          });
-          if (updated.error) {
-            createErrorMessage = updated.error.message;
-          }
-        } else {
-          createErrorMessage = created.error.message;
-        }
-      } else {
-        createErrorMessage = created.error.message;
-      }
-    }
-
-    if (createErrorMessage) {
+    if (signup.error) {
       return NextResponse.json(
         {
           error: "signup_failed",
@@ -142,21 +98,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const response = NextResponse.json({ ok: true, redirect: nextTarget });
-    const supabase = createRouteHandlerSupabaseClient(request, response);
-
-    const signIn = await supabase.auth.signInWithPassword({ email, password });
-
-    if (signIn.error) {
-      // Account exists with a different password.
-      return NextResponse.json(
-        {
-          error: "wrong_password",
-          message:
-            "An account with this email already exists. Sign in with your password, or reset it from the login page.",
-        },
-        { status: 400 }
-      );
+    if (!signup.data?.session) {
+      const confirmationResponse = NextResponse.json({
+        ok: true,
+        requiresConfirmation: true,
+        message:
+          "Check your email to confirm your account. You can resend the email and enter the 6-digit code here if the link expires.",
+      });
+      copyResponseCookies(response, confirmationResponse);
+      return confirmationResponse;
     }
 
     return response;

--- a/src/lib/auth-routing.ts
+++ b/src/lib/auth-routing.ts
@@ -164,6 +164,16 @@ export function buildCallbackUrl(origin: string, redirectTarget: string | null |
   return url.toString();
 }
 
+export function buildSignupCallbackUrl(
+  origin: string,
+  redirectTarget: string | null | undefined
+) {
+  const url = new URL(buildCallbackUrl(origin, redirectTarget));
+  url.searchParams.set("type", "signup");
+
+  return url.toString();
+}
+
 export function buildBrowserCallbackUrl(
   origin: string,
   redirectTarget: string | null | undefined

--- a/tests/auth-callback.route.test.ts
+++ b/tests/auth-callback.route.test.ts
@@ -235,6 +235,21 @@ describe("VET-1215 auth callback route", () => {
     );
   });
 
+  it("routes Supabase expired signup callback errors back to signup", async () => {
+    const { GET } = await import("@/app/api/auth/callback/route");
+    const response = await GET(
+      new NextRequest(
+        "https://app.pawvital.ai/api/auth/callback?error=access_denied&error_code=otp_expired&type=signup&next=%2Fdashboard"
+      )
+    );
+
+    expect(mockExchangeCodeForSession).not.toHaveBeenCalled();
+    expect(mockVerifyOtp).not.toHaveBeenCalled();
+    expect(response.headers.get("location")).toBe(
+      "https://app.pawvital.ai/signup?redirect=%2Fdashboard&error=confirm_link_expired"
+    );
+  });
+
   it("exchanges signup PKCE codes and redirects to the post-confirmation target", async () => {
     mockExchangeCodeForSession.mockResolvedValue({ error: null });
 

--- a/tests/auth-pages.network-error.test.tsx
+++ b/tests/auth-pages.network-error.test.tsx
@@ -297,7 +297,8 @@ describe("auth page network error handling", () => {
       type: "signup",
       email: "owner@example.com",
       options: {
-        emailRedirectTo: "http://localhost/api/auth/callback?next=%2Fdashboard",
+        emailRedirectTo:
+          "http://localhost/api/auth/callback?next=%2Fdashboard&type=signup",
       },
     });
     await waitFor(() =>

--- a/tests/signup.route.test.ts
+++ b/tests/signup.route.test.ts
@@ -1,0 +1,217 @@
+import { NextRequest } from "next/server";
+
+const mockSignUp = jest.fn();
+
+const mockCreateServerClient = jest.fn(
+  (
+    _url: string,
+    _key: string,
+    options: {
+      cookies: {
+        setAll: (
+          cookies: Array<{
+            name: string;
+            value: string;
+            options?: Record<string, unknown>;
+          }>
+        ) => void;
+      };
+    }
+  ) => ({
+    auth: {
+      signUp: async (payload: {
+        email: string;
+        password: string;
+        options: {
+          data: { full_name: string };
+          emailRedirectTo: string;
+        };
+      }) => {
+        const result = await mockSignUp(payload);
+        if (!result.error && result.data?.session) {
+          options.cookies.setAll([
+            {
+              name: "sb-test-auth-token",
+              value: "session-cookie",
+              options: { httpOnly: true, path: "/" },
+            },
+          ]);
+        } else if (!result.error) {
+          options.cookies.setAll([
+            {
+              name: "sb-test-code-verifier",
+              value: "pkce-verifier",
+              options: { httpOnly: true, path: "/", sameSite: "lax" },
+            },
+          ]);
+        }
+        return result;
+      },
+    },
+  })
+);
+
+jest.mock("@supabase/ssr", () => ({
+  createServerClient: (...args: unknown[]) => mockCreateServerClient(...args),
+}));
+
+describe("signup route", () => {
+  const originalSupabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const originalSupabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://supabase.example";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+    mockSignUp.mockResolvedValue({
+      data: { session: { access_token: "token" } },
+      error: null,
+    });
+  });
+
+  afterAll(() => {
+    if (originalSupabaseUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    } else {
+      process.env.NEXT_PUBLIC_SUPABASE_URL = originalSupabaseUrl;
+    }
+
+    if (originalSupabaseAnonKey === undefined) {
+      delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+    } else {
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = originalSupabaseAnonKey;
+    }
+  });
+
+  it("signs up through the anon auth boundary and redirects when a session is created", async () => {
+    const { POST } = await import("@/app/api/auth/signup/route");
+    const response = await POST(
+      new NextRequest("https://app.pawvital.ai/api/auth/signup", {
+        method: "POST",
+        body: JSON.stringify({
+          email: " OWNER@example.com ",
+          password: "super-secret-password",
+          name: "Dog Parent",
+          next: "/symptom-checker",
+        }),
+      })
+    );
+
+    expect(mockSignUp).toHaveBeenCalledWith({
+      email: "OWNER@example.com",
+      password: "super-secret-password",
+      options: {
+        data: { full_name: "Dog Parent" },
+        emailRedirectTo:
+          "https://app.pawvital.ai/api/auth/callback?next=%2Fsymptom-checker&type=signup",
+      },
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("set-cookie")).toContain("sb-test-auth-token");
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      redirect: "/symptom-checker",
+      requiresConfirmation: false,
+    });
+  });
+
+  it("keeps the user on signup when email confirmation is required", async () => {
+    mockSignUp.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+
+    const { POST } = await import("@/app/api/auth/signup/route");
+    const response = await POST(
+      new NextRequest("https://app.pawvital.ai/api/auth/signup", {
+        method: "POST",
+        body: JSON.stringify({
+          email: "owner@example.com",
+          password: "super-secret-password",
+          next: "/dashboard",
+        }),
+      })
+    );
+
+    expect(response.headers.get("set-cookie")).toContain(
+      "sb-test-code-verifier=pkce-verifier"
+    );
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      requiresConfirmation: true,
+      message:
+        "Check your email to confirm your account. You can resend the email and enter the 6-digit code here if the link expires.",
+    });
+  });
+
+  it("sanitizes unsafe redirects before building the confirmation callback", async () => {
+    const { POST } = await import("@/app/api/auth/signup/route");
+    const response = await POST(
+      new NextRequest("https://app.pawvital.ai/api/auth/signup", {
+        method: "POST",
+        body: JSON.stringify({
+          email: "owner@example.com",
+          password: "super-secret-password",
+          next: "https://evil.example/steal",
+        }),
+      })
+    );
+
+    expect(mockSignUp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          emailRedirectTo:
+            "https://app.pawvital.ai/api/auth/callback?next=%2Fdashboard&type=signup",
+        }),
+      })
+    );
+    await expect(response.json()).resolves.toMatchObject({
+      redirect: "/dashboard",
+    });
+  });
+
+  it("does not confirm existing accounts from the public route", async () => {
+    mockSignUp.mockResolvedValue({
+      data: { session: null },
+      error: { message: "User already registered", status: 422 },
+    });
+
+    const { POST } = await import("@/app/api/auth/signup/route");
+    const response = await POST(
+      new NextRequest("https://app.pawvital.ai/api/auth/signup", {
+        method: "POST",
+        body: JSON.stringify({
+          email: "owner@example.com",
+          password: "existing-password",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "signup_failed",
+      message:
+        "We couldn't create your account. If you already have one, try signing in instead.",
+    });
+  });
+
+  it("does not create weak-password accounts", async () => {
+    const { POST } = await import("@/app/api/auth/signup/route");
+    const response = await POST(
+      new NextRequest("https://app.pawvital.ai/api/auth/signup", {
+        method: "POST",
+        body: JSON.stringify({
+          email: "owner@example.com",
+          password: "short",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockSignUp).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({
+      error: "weak_password",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Restore public signup to the anon Supabase `signUp` boundary instead of service-role/admin auto-confirm.
- Keep owners on signup when email confirmation is required and tag signup callback/resend URLs with `type=signup`.
- Route expired signup callback errors back to signup and add regressions for existing-account denial, PKCE verifier-cookie preservation, and expired signup callback handling.

## Verification
- Current head: `25677099a8b3e10eab195ab52d44a151baa60f17`.
- Focused auth Jest after final amended push: 6 suites, 48 tests passed.
- `git diff --check`: pass.
- Targeted public signup route scan: no `service`, `admin`, `createUser`, `email_confirm`, `signInWithPassword`, `listUsers`, or `updateUserById` matches.
- Build: `NODE_PATH=G:\MY Website\pawvital-ai\node_modules node scripts/build.js` passed, 63 static pages generated with existing Next workspace-root/metadata warnings.
- AutoScientists verifier: pass.
- PR reviewThreads: empty.

## Notes
- This is a hotfix for the unsafe signup behavior that landed through #607; it intentionally does not touch clinical/P0/Azure work.
- TecjLead/code-review subagent result: GO_REVIEW_ONLY for the code path after the PKCE-cookie and expired-link regression gaps were fixed; HOLD for merge/public beta until checks, merge/deploy, and browser signup smoke pass.
- GitHub still reports no checks on this branch, so it is not merge-ready under the repo gate.
- Browser signup smoke is still required after deployment before public-beta GO.

AutoScientists run: `G:\MY Website\.agents\autoscientists\runs\vet-land-hotfix-restore-safe-signup-after-merged-recovery-pr`

Thermo-review verdict: pass; public service-role signup auto-confirm blocker, confirmation-required PKCE cookie blocker, and direct expired-signup-callback regression gap resolved in a narrow auth-only hotfix.

SIA: verifier=focused auth route/page/callback tests + build + route service/admin scan + AutoScientists verifier + code-review subagent | trajectory=merged #607 regression identified, hotfix branch from current master, anon signup restored, review blocker fixed, expired-link callback regression added, tests/build passed | decision=harness/code update then stop for PR review/checks | Goodhart guard=green auth tests do not prove deployed browser signup smoke, production email configuration, or public-beta readiness.

AutoLab: baseline=merged master public route used service-role admin auto-confirm | benchmark=anon signup boundary plus focused auth verifier/build/code review | iterations=3, best=2567709 | budget=3/3 | outcome=improved.