### PR TITLE
Recover post-merge symptom-chat route gate

### DIFF
--- a/tests/symptom-chat.route.test.ts
+++ b/tests/symptom-chat.route.test.ts
@@ -64,6 +64,19 @@ const mockEventType = {
   SUBSCRIPTION_CHANGED: "SUBSCRIPTION_CHANGED",
   PET_ADDED: "PET_ADDED",
 } as const;
+const originalSymptomChatTurnDepth = process.env.SYMPTOM_CHAT_TURN_DEPTH;
+
+beforeEach(() => {
+  process.env.SYMPTOM_CHAT_TURN_DEPTH = "deep";
+});
+
+afterAll(() => {
+  if (originalSymptomChatTurnDepth === undefined) {
+    delete process.env.SYMPTOM_CHAT_TURN_DEPTH;
+  } else {
+    process.env.SYMPTOM_CHAT_TURN_DEPTH = originalSymptomChatTurnDepth;
+  }
+});
 
 jest.mock("@/lib/rate-limit", () => ({
   symptomChatLimiter: {},
@@ -1154,7 +1167,7 @@ describe("symptom-chat mixed text + image routing", () => {
       "EXPLICITLY REFERENCE PHOTO IN WORDING: NO"
     );
     expect(payload.message).toBe(
-      "I'm keeping track of what you've shared so far about Bruno's limping. How big is the affected area? Compare to a coin, golf ball, or your palm."
+      "Got it — left leg. How big is the affected area? Compare to a coin, golf ball, or your palm."
     );
     expect(payload.message).not.toContain("photo");
   });
@@ -1179,7 +1192,7 @@ describe("symptom-chat mixed text + image routing", () => {
     expect(response.status).toBe(200);
     expect(payload.type).toBe("question");
     expect(payload.message).toBe(
-      "I'm keeping track of what you've shared so far about Bruno's limping. How big is the affected area? Compare to a coin, golf ball, or your palm."
+      "Got it — left leg. How big is the affected area? Compare to a coin, golf ball, or your palm."
     );
     expect(mockPhraseWithLlama).not.toHaveBeenCalled();
     expect(mockVerifyQuestionWithNemotron).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- force the symptom-chat route test file into `SYMPTOM_CHAT_TURN_DEPTH=deep` so the route-suite verifier keeps exercising deep clinical orchestration after #607 made plain text production turns default to standard
- update two stale deterministic fallback wording assertions to the current answer-specific copy while preserving the no-photo-wording assertion

## Verification
- `NODE_PATH=G:\MY Website\pawvital-ai\node_modules node G:\MY Website\pawvital-ai\node_modules\jest\bin\jest.js --config G:\MY Website\pawvital-ai-vet1571-1573-gate\jest.config.ts --runInBand --testPathPatterns=symptom-chat --silent --json --outputFile G:\MY Website\.agents\autoscientists\runs\vet-1571-1573-gate-recover-post-merge-symptom-chat-route-gate\artifacts\iteration2-symptom-chat-results.json` -> 11 suites / 603 tests passed
- `NODE_PATH=G:\MY Website\pawvital-ai\node_modules node G:\MY Website\pawvital-ai\node_modules\jest\bin\jest.js --config G:\MY Website\pawvital-ai-vet1571-1573-gate\jest.config.ts --runInBand --runTestsByPath tests/turn-depth.test.ts tests/memory-compression.test.ts --silent` -> 2 suites / 7 tests passed
- `git diff --check` -> pass
- AutoScientists verifier -> pass

## Gates
Thermo-review verdict: pass
AutoScientists run: `G:\MY Website\.agents\autoscientists\runs\vet-1571-1573-gate-recover-post-merge-symptom-chat-route-gate`
SIA: verifier=symptom-chat route suite + turn-depth/memory-compression holdout | trajectory=12-failure baseline -> deep route harness -> stale wording update -> green suite | decision=harness/test update | Goodhart guard=standard-depth policy remains covered by dedicated tests
AutoLab: baseline=12 failures / 603 tests | benchmark=symptom-chat route failures remaining | iterations=2, best=603/603 passed | budget=2/3 | outcome=improved locally

## Known hold
The repository currently is not attaching required GitHub Actions checks; this PR should not merge until the required `Threshold Review Gate` context is present and passing.