### PR TITLE
IMP-01A: server-side readiness gate on generate_report

### DIFF
--- a/src/app/api/ai/symptom-chat/route.ts
+++ b/src/app/api/ai/symptom-chat/route.ts
@@ -1357,6 +1357,20 @@ export async function POST(request: Request) {
         });
       }
 
+      if (!isReadyForDiagnosis(session)) {
+        statusCode = 409;
+        return NextResponse.json(
+          {
+            type: "error",
+            message:
+              "This session does not yet have enough information to generate a report.",
+            code: "SESSION_NOT_READY",
+            ready_for_report: false,
+          },
+          { status: 409 }
+        );
+      }
+
       return await generateReport({
         session,
         pet: effectivePet,

--- a/tests/symptom-chat.payload-safety.test.ts
+++ b/tests/symptom-chat.payload-safety.test.ts
@@ -1,6 +1,7 @@
 import {
   addSymptoms,
   createSession,
+  recordAnswer,
   type PetProfile,
   type TriageSession,
 } from "@/lib/triage-engine";
@@ -603,7 +604,11 @@ describe("VET-1014 terminal payload safety pack", () => {
       "timeoutCount",
     ];
 
-    const session = addSymptoms(createSession(), ["vomiting"]);
+    let session = addSymptoms(createSession(), ["vomiting"]);
+    session = recordAnswer(session, "vomit_duration", "2 days");
+    session = recordAnswer(session, "vomit_frequency", "3 times");
+    session = recordAnswer(session, "vomit_blood", false);
+    session = recordAnswer(session, "toxin_exposure", "none");
     session.case_memory = {
       ...session.case_memory!,
       service_timeouts: [
@@ -754,10 +759,12 @@ describe("VET-1014 terminal payload safety pack", () => {
     let session = addSymptoms(createSession(), ["coughing"]);
     session = {
       ...session,
-      answered_questions: ["cough_type"],
+      answered_questions: ["cough_type", "cough_duration", "cough_timing"],
       extracted_answers: {
         ...session.extracted_answers,
         cough_type: "dry_honking",
+        cough_duration: "3 days",
+        cough_timing: "at rest",
       },
       last_question_asked: "cough_duration",
       case_memory: {
@@ -865,6 +872,7 @@ describe("VET-1014 terminal payload safety pack", () => {
         ...session.extracted_answers,
         limping_onset: "sudden_today",
       },
+      red_flags_triggered: ["non_weight_bearing"],
       last_question_asked: "limping_onset",
       case_memory: {
         ...session.case_memory!,

--- a/tests/symptom-chat.route.test.ts
+++ b/tests/symptom-chat.route.test.ts
@@ -446,6 +446,8 @@ function buildModerateReportSession() {
   let session = createSession();
   session = addSymptoms(session, ["excessive_scratching"]);
   session = recordAnswer(session, "scratch_location", "ears");
+  session = recordAnswer(session, "scratch_duration", "about 2 weeks");
+  session = recordAnswer(session, "flea_prevention", true);
   session.case_memory = {
     ...session.case_memory!,
     latest_owner_turn: "He keeps scratching around his ears.",
@@ -1440,7 +1442,15 @@ describe("symptom-chat mixed text + image routing", () => {
 
     const session = createSession();
     session.known_symptoms = ["wound_skin_issue"];
-    session.extracted_answers = { wound_location: "left hind leg" };
+    session.answered_questions = ["wound_location", "wound_size", "wound_duration", "wound_discharge", "wound_licking", "trauma_history"];
+    session.extracted_answers = {
+      wound_location: "left hind leg",
+      wound_size: "quarter-sized",
+      wound_duration: "2 days",
+      wound_discharge: "none",
+      wound_licking: false,
+      trauma_history: "no_trauma",
+    };
     session.vision_analysis = "Superficial moist lesion on the left hind leg.";
     session.vision_severity = "needs_review";
     session.latest_image_domain = "skin_wound";
@@ -1750,7 +1760,15 @@ describe("symptom-chat mixed text + image routing", () => {
 
       const session = createSession();
       session.known_symptoms = ["wound_skin_issue"];
-      session.extracted_answers = { wound_location: "left hind leg" };
+      session.answered_questions = ["wound_location", "wound_size", "wound_duration", "wound_discharge", "wound_licking", "trauma_history"];
+      session.extracted_answers = {
+        wound_location: "left hind leg",
+        wound_size: "small",
+        wound_duration: "1 day",
+        wound_discharge: "none",
+        wound_licking: false,
+        trauma_history: "no_trauma",
+      };
       session.vision_analysis = "Superficial moist lesion on the left hind leg.";
       session.vision_severity = "needs_review";
       session.latest_image_domain = "skin_wound";
@@ -8282,6 +8300,59 @@ describe("VET-900: world-class symptom checker regression pack", () => {
       expect(payload.owner_message).toContain(
         "How long did the seizure or collapse episode last?"
       );
+      expect(mockDiagnoseWithDeepSeek).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("IMP-01A: server-side readiness gate on generate_report", () => {
+    it("IMP-01A: forged not-ready session is rejected with 409 SESSION_NOT_READY", async () => {
+      const session = createSession();
+      // Empty session: no symptoms, no answers, no red flags — classic forgery
+
+      const { POST } = await import("@/app/api/ai/symptom-chat/route");
+      const response = await POST(makeReportRequest(session));
+      const payload = await response.json();
+
+      expect(response.status).toBe(409);
+      expect(payload.code).toBe("SESSION_NOT_READY");
+      expect(payload.ready_for_report).toBe(false);
+      expect(mockDiagnoseWithDeepSeek).not.toHaveBeenCalled();
+    });
+
+    it("IMP-01A: ready session still generates report (no regression)", async () => {
+      const session = buildModerateReportSession();
+
+      const { POST } = await import("@/app/api/ai/symptom-chat/route");
+      const response = await POST(makeReportRequest(session));
+      const payload = await response.json();
+
+      // Guard must NOT fire — status 409 / SESSION_NOT_READY is the only wrong outcome to prevent
+      expect(response.status).not.toBe(409);
+      expect(payload.code).not.toBe("SESSION_NOT_READY");
+      // The route proceeds to report generation (may be report or fail-safe depending on mock setup)
+      expect(payload.type).toBe("report");
+    });
+
+    it("IMP-01A: blocking-critical-info terminal outcome unchanged by readiness gate", async () => {
+      let session = createSession();
+      session = addSymptoms(session, ["difficulty_breathing"]);
+      session = recordAnswer(session, "breathing_rate", 40);
+      session = recordAnswer(session, "gum_color", "pink_normal");
+      session = recordAnswer(session, "position_preference", "standing");
+      // breathing_onset is still unanswered — triggers findReportBlockingCriticalInfo
+      session.case_memory = {
+        ...session.case_memory!,
+        latest_owner_turn: "He is breathing hard and his gums still look pink.",
+      };
+
+      const { POST } = await import("@/app/api/ai/symptom-chat/route");
+      const response = await POST(makeReportRequest(session));
+      const payload = await response.json();
+
+      // findReportBlockingCriticalInfo fires FIRST — readiness guard must not interfere
+      expect(response.status).toBe(200);
+      expect(payload.type).toBe("cannot_assess");
+      expect(payload.reason_code).toBe("owner_cannot_assess_breathing_onset");
       expect(mockDiagnoseWithDeepSeek).not.toHaveBeenCalled();
     });
   });

--- a/tests/symptom-chat.telemetry-gate.test.ts
+++ b/tests/symptom-chat.telemetry-gate.test.ts
@@ -265,6 +265,8 @@ function buildModerateReportSession() {
   let session = createSession();
   session = addSymptoms(session, ["excessive_scratching"]);
   session = recordAnswer(session, "scratch_location", "ears");
+  session = recordAnswer(session, "scratch_duration", "about 2 weeks");
+  session = recordAnswer(session, "flea_prevention", true);
   session.case_memory = {
     ...session.case_memory!,
     latest_owner_turn: "He keeps scratching around his ears.",
@@ -1393,6 +1395,10 @@ describe("VET-1428 repeat-loop + hallucination telemetry gate", () => {
       // Later question that required a clarification round (re-asked).
       session = recordAnswer(session, "cough_type", "dry");
 
+      // Bypass the ≥3 answered-questions readiness gate without altering the
+      // question_asked_counts / clarification_attempts that VET-1546C-R3 tests.
+      session.red_flags_triggered = ["breathing_difficulty"];
+
       const memory = session.case_memory!;
       session.case_memory = {
         ...memory,
@@ -1602,6 +1608,9 @@ describe("VET-1428 repeat-loop + hallucination telemetry gate", () => {
       let session = createSession();
       session = addSymptoms(session, ["regurgitation"]);
       session = recordAnswer(session, "coughing_present", true);
+      // Bypass the readiness gate; red flag does not affect the second-opinion
+      // trace reconstruction that this test validates.
+      session.red_flags_triggered = ["coughing_after_regurgitation"];
       const memory = session.case_memory!;
       session.case_memory = {
         ...memory,
@@ -1743,6 +1752,7 @@ describe("VET-1428 repeat-loop + hallucination telemetry gate", () => {
       let session = createSession();
       session = addSymptoms(session, ["coughing"]);
       session = recordAnswer(session, "cough_type", "dry");
+      session.red_flags_triggered = ["breathing_difficulty"];
       const memory = session.case_memory!;
       session.case_memory = {
         ...memory,
@@ -1773,6 +1783,7 @@ describe("VET-1428 repeat-loop + hallucination telemetry gate", () => {
       let session = createSession();
       session = addSymptoms(session, ["coughing"]);
       session = recordAnswer(session, "cough_duration", "2 days");
+      session.red_flags_triggered = ["breathing_difficulty"];
       const memory = session.case_memory!;
       session.case_memory = {
         ...memory,


### PR DESCRIPTION
## IMP-01A — server-side readiness gate on `generate_report`

Adds an `isReadyForDiagnosis()` guard between the `findReportBlockingCriticalInfo` check and the `generateReport` call in the symptom-chat route. A client that forges a not-ready session (no symptoms, fewer than 3 answered questions, or unanswered critical questions) now receives **409 `SESSION_NOT_READY`** instead of being escalated straight to AI diagnosis.

### Files changed (4)
- `src/app/api/ai/symptom-chat/route.ts` — 409 early return when `!isReadyForDiagnosis(session)`
- `tests/symptom-chat.route.test.ts` — 3 new regression tests (forged → 409, ready → report, blocking-critical → 200 cannot_assess) + report-session fixtures updated to cover all critical questions
- `tests/symptom-chat.payload-safety.test.ts` — report-session fixtures updated for the gate
- `tests/symptom-chat.telemetry-gate.test.ts` — `buildModerateReportSession` + VET-1546C-R3 fixtures updated for the gate

The extra two test files were required because the gate affects shared report-session helpers; trace-sensitive sessions use the `red_flags_triggered` bypass so their second-opinion assertions are unchanged.

### Verification
- `npm test`: 12 pre-existing failures only (MiniMax compression + behavior regressions), **0 new failures**
- `npx tsc --noEmit`: 0 errors
- `npm run build`: clean
- `npx eslint` (changed files): 0 errors

### Notes
- Reuses existing `isReadyForDiagnosis` — no clinical logic invented, no clinical file modified.
- UI only calls `generate_report` after the server returns `ready_for_report: true`, so the guard is safe in production.
- Paired with IMP-01B to close the empty-forged-session attack surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)