### PR TITLE
IMP-01B: drop unsupported client red flags on empty sessions

### DIFF
--- a/src/app/api/ai/symptom-chat/route.ts
+++ b/src/app/api/ai/symptom-chat/route.ts
@@ -1220,6 +1220,45 @@ function buildDeterministicEmergencyMessage(
   return `Based on the symptoms you've shared${details}, ${petName} may be having a medical emergency. Please go to the nearest emergency veterinary hospital now. I have enough information to prepare an emergency summary for the vet while you're on the way.`;
 }
 
+function sanitizeUnsupportedClientRedFlags(
+  session: TriageSession,
+  messages: { role: "user" | "assistant"; content: string }[]
+): TriageSession {
+  if (session.red_flags_triggered.length === 0) return session;
+
+  // Only the blatant-forgery case is safe to validate from message text alone.
+  // If the session carries ANY other legitimate red-flag evidence source
+  // (recorded answers, known symptoms, or vision-derived flags), leave it
+  // untouched — those sources cannot be reproduced from messages and dropping
+  // them would risk discarding a real emergency. (See IMP-01B inventory.)
+  const hasOtherEvidence =
+    session.known_symptoms.length > 0 ||
+    Object.keys(session.extracted_answers).length > 0 ||
+    (session.vision_red_flags?.length ?? 0) > 0;
+  if (hasOtherEvidence) return session;
+
+  const supported = new Set<string>();
+  for (const m of messages) {
+    if (m.role !== "user") continue;
+    for (const flag of extractDeterministicEmergencyRedFlags(
+      m.content,
+      session.known_symptoms
+    )) {
+      supported.add(flag);
+    }
+  }
+
+  const validated = session.red_flags_triggered.filter((f) => supported.has(f));
+  if (validated.length === session.red_flags_triggered.length) return session;
+
+  console.warn(
+    `[session-integrity] Dropped ${
+      session.red_flags_triggered.length - validated.length
+    } client red flag(s) unsupported by an otherwise-empty session`
+  );
+  return { ...session, red_flags_triggered: validated };
+}
+
 export async function POST(request: Request) {
   const startedAtMs = Date.now();
   const turnDeadline = createTurnDeadline(startedAtMs);
@@ -1295,6 +1334,7 @@ export async function POST(request: Request) {
     } = body;
 
     let session = clientSession || createSession();
+    session = sanitizeUnsupportedClientRedFlags(session, messages);
     const usageLimitResponse = await maybeBuildUsageLimitResponse({
       action,
       messages,

--- a/tests/symptom-chat.route.test.ts
+++ b/tests/symptom-chat.route.test.ts
@@ -8357,6 +8357,93 @@ describe("VET-900: world-class symptom checker regression pack", () => {
     });
   });
 
+  describe("IMP-01B: sanitize forged client red flags on empty sessions", () => {
+    it("IMP-01B: drops forged red flag from an otherwise-empty session on a chat turn", async () => {
+      const session = createSession();
+      // Forge a real flag ID on an otherwise-empty session (no symptoms, no answers, no vision flags)
+      session.red_flags_triggered = ["blue_gums"];
+
+      const { POST } = await import("@/app/api/ai/symptom-chat/route");
+      const response = await POST(
+        makeTextOnlyRequest(session, "my dog seems a little tired")
+      );
+      const payload = await response.json();
+
+      // The forged flag must be dropped — tiredness message cannot support blue_gums
+      expect(response.status).toBe(200);
+      expect(payload.type).not.toBe("emergency");
+      expect(payload.session.red_flags_triggered).not.toContain("blue_gums");
+    });
+
+    it("IMP-01B: forged empty session + generate_report returns 409 after flag drop (pairs with IMP-01A)", async () => {
+      const session = createSession();
+      // Forge blue_gums to try to bypass IMP-01A readiness gate via red-flag bypass
+      session.red_flags_triggered = ["blue_gums"];
+
+      const { POST } = await import("@/app/api/ai/symptom-chat/route");
+      const response = await POST(makeReportRequest(session));
+      const payload = await response.json();
+
+      // After IMP-01B drops the forged flag, isReadyForDiagnosis returns false → 409
+      expect(response.status).toBe(409);
+      expect(payload.code).toBe("SESSION_NOT_READY");
+    });
+
+    it("IMP-01B: genuine first-turn emergency message still escalates (no regression)", async () => {
+      const session = createSession(); // no forged flags
+
+      const { POST } = await import("@/app/api/ai/symptom-chat/route");
+      const response = await POST(
+        makeTextOnlyRequest(
+          session,
+          "My dog collapsed and his gums look blue-gray."
+        )
+      );
+      const payload = await response.json();
+
+      // Real emergency extracted from message text — must still escalate
+      expect(response.status).toBe(200);
+      expect(payload.type).toBe("emergency");
+    });
+
+    it("IMP-01B: rich session with known_symptoms is left untouched by sanitizer (CRITICAL)", async () => {
+      let session = createSession();
+      session = addSymptoms(session, ["coughing"]);
+      session = recordAnswer(session, "cough_type", "dry");
+      // Known symptoms present → hasOtherEvidence = true → helper must skip sanitization
+      session.red_flags_triggered = ["blue_gums"];
+
+      const { POST } = await import("@/app/api/ai/symptom-chat/route");
+      const response = await POST(
+        makeTextOnlyRequest(session, "his gums are pale now")
+      );
+      const payload = await response.json();
+
+      // red_flags_triggered must survive — session escalates to emergency
+      expect(response.status).toBe(200);
+      expect(payload.type).toBe("emergency");
+      expect(payload.session.red_flags_triggered).toContain("blue_gums");
+    });
+
+    it("IMP-01B: session with vision_red_flags is left untouched by sanitizer (CRITICAL)", async () => {
+      const session = createSession();
+      // vision_red_flags present → hasOtherEvidence = true → helper must skip sanitization
+      session.vision_red_flags = ["wound_deep_bleeding"];
+      session.red_flags_triggered = ["wound_deep_bleeding"];
+
+      const { POST } = await import("@/app/api/ai/symptom-chat/route");
+      const response = await POST(
+        makeTextOnlyRequest(session, "there is a lot of blood from the wound")
+      );
+      const payload = await response.json();
+
+      // vision-derived flags must survive unchanged
+      expect(response.status).toBe(200);
+      expect(payload.type).toBe("emergency");
+      expect(payload.session.red_flags_triggered).toContain("wound_deep_bleeding");
+    });
+  });
+
   describe("VET-1029 critical info and alternate observable regression matrix", () => {
     it("blocks report readiness until respiratory critical info is answered", () => {
       let session = createSession();


### PR DESCRIPTION
## IMP-01B — drop unsupported client red flags on empty sessions

> **Base = the IMP-01A branch** (#610), not master. IMP-01B depends on IMP-01A's readiness gate (test #2 asserts 409 `SESSION_NOT_READY`). Retarget to master after #610 merges. The diff here is exactly the 2 intended files.

Adds `sanitizeUnsupportedClientRedFlags()` to the route, wired immediately after `let session = clientSession || createSession()`. When a session has `red_flags_triggered` populated **but no other evidence** (no `known_symptoms`, no `extracted_answers`, no `vision_red_flags`), any flag the actual conversation messages do not support is dropped (with a `console.warn`). Sessions carrying any other legitimate red-flag source are returned untouched — the guard only catches blatant forgery on otherwise-empty sessions.

### Files changed (2)
- `src/app/api/ai/symptom-chat/route.ts` — `sanitizeUnsupportedClientRedFlags` helper + one wired call
- `tests/symptom-chat.route.test.ts` — 5 regression tests

### Tests added
1. Forged empty session → flag dropped, no escalation
2. Forged empty + `generate_report` → 409 `SESSION_NOT_READY` (pairs with IMP-01A)
3. Genuine first-turn emergency message still escalates (no regression)
4. **CRITICAL** — rich session with `known_symptoms` left untouched, still escalates
5. **CRITICAL** — session with `vision_red_flags` left untouched, still escalates

### Verification
- `npm test`: 12 pre-existing failures only, **0 new failures**
- `npx tsc --noEmit`: 0 errors
- `npx eslint` (changed files): 0 errors
- `npm run build`: clean

### Clinical-reviewer gate (required before merge)
Per the ticket, a clinical-reviewer must confirm the `hasOtherEvidence` skip-rule is clinically acceptable and that no legitimate first-turn emergency is affected.

### Residual risk (out of scope)
A client that forges `answers`/`symptoms`/`vision_red_flags` escapes this guard — closing that needs server-side session integrity (signing/persistence), a separate epic. IMP-01B is a conservative strict improvement, not a complete fix. No clinical files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)