### PR TITLE
IMP-03: rate limiting fails closed (in-process fallback) when Upstash unset in production

### DIFF
--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -26,11 +26,24 @@ const RATE_LIMIT_ERROR_LOG_INTERVAL_MS = 60_000;
 const DEFAULT_FALLBACK_WINDOW_MS = 60_000;
 const DEFAULT_FALLBACK_LIMIT = 30;
 let lastRateLimitErrorLogAt = 0;
+let rateLimitUnconfiguredLogged = false;
 
 export type RateLimitFallbackConfig = {
   limit: number;
   scope: string;
   windowMs: number;
+};
+
+/**
+ * Config used by the in-process fallback limiter when no Upstash limiter
+ * object exists at all (production with Upstash env unset). Every scope shares
+ * one "default" bucket per identifier — coarser than the per-scope Redis
+ * limits, but strictly safer than the previous unlimited fail-open.
+ */
+const DEFAULT_FALLBACK_CONFIG: RateLimitFallbackConfig = {
+  limit: DEFAULT_FALLBACK_LIMIT,
+  scope: "default",
+  windowMs: DEFAULT_FALLBACK_WINDOW_MS,
 };
 
 type LocalFallbackState = {
@@ -151,6 +164,20 @@ function logRateLimitFailure(
   );
 }
 
+function logRateLimitUnconfiguredOnce(identifier: string) {
+  if (rateLimitUnconfiguredLogged) {
+    return;
+  }
+
+  rateLimitUnconfiguredLogged = true;
+  console.warn(
+    `[rate-limit] Upstash not configured in production; using in-process ` +
+      `fallback limiter (default scope, ${DEFAULT_FALLBACK_CONFIG.limit} per ` +
+      `${DEFAULT_FALLBACK_CONFIG.windowMs}ms). Set UPSTASH_REDIS_REST_URL and ` +
+      `UPSTASH_REDIS_REST_TOKEN to restore distributed limiting. First seen: ${identifier}.`
+  );
+}
+
 function pruneLocalFallbackState(now = Date.now()) {
   for (const [key, state] of localFallbackState.entries()) {
     if (now >= state.reset) {
@@ -159,18 +186,12 @@ function pruneLocalFallbackState(now = Date.now()) {
   }
 }
 
-function runLocalFallbackLimiter(
-  limiter: Ratelimit,
+function runLocalFallbackWithConfig(
+  config: RateLimitFallbackConfig,
   identifier: string,
   now = Date.now()
 ): RateLimitResult {
   pruneLocalFallbackState(now);
-  const config =
-    limiterFallbackConfigs.get(limiter as unknown as object) || {
-      limit: DEFAULT_FALLBACK_LIMIT,
-      scope: "default",
-      windowMs: DEFAULT_FALLBACK_WINDOW_MS,
-    };
   const key = `${config.scope}:${identifier}`;
   const existing = localFallbackState.get(key);
   const active =
@@ -199,11 +220,30 @@ function runLocalFallbackLimiter(
   };
 }
 
+function runLocalFallbackLimiter(
+  limiter: Ratelimit,
+  identifier: string,
+  now = Date.now()
+): RateLimitResult {
+  const config =
+    limiterFallbackConfigs.get(limiter as unknown as object) ||
+    DEFAULT_FALLBACK_CONFIG;
+  return runLocalFallbackWithConfig(config, identifier, now);
+}
+
 export async function checkRateLimit(
   limiter: Ratelimit | null,
   identifier: string
 ): Promise<RateLimitResult> {
-  if (!limiter) return { success: true }; // No-op in dev/demo
+  if (!limiter) {
+    // Production with no Upstash limiter must NOT run unlimited. Fall back to
+    // the in-process limiter instead of granting every request (fail-open).
+    if (process.env.NODE_ENV === "production") {
+      logRateLimitUnconfiguredOnce(identifier);
+      return runLocalFallbackWithConfig(DEFAULT_FALLBACK_CONFIG, identifier);
+    }
+    return { success: true }; // No-op in dev/demo
+  }
 
   try {
     const result = await limiter.limit(identifier);

--- a/tests/rate-limit.test.ts
+++ b/tests/rate-limit.test.ts
@@ -200,4 +200,59 @@ describe("rate-limit helper", () => {
 
     expect(getRateLimitId(spoofedHeaderRequest)).toBe("ip:203.0.113.7");
   });
+
+  it("falls closed to the in-process limiter in production when Upstash is unconfigured", async () => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-04-14T12:00:00.000Z"));
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+
+    try {
+      const { checkRateLimit } = await import("../src/lib/rate-limit");
+
+      for (let attempt = 0; attempt < 30; attempt += 1) {
+        await expect(
+          checkRateLimit(null, "ip:prod-unconfigured")
+        ).resolves.toEqual({
+          success: true,
+          degraded: true,
+          reason: "redis_unavailable",
+        });
+      }
+
+      await expect(
+        checkRateLimit(null, "ip:prod-unconfigured")
+      ).resolves.toEqual({
+        success: false,
+        reset: expect.any(Number),
+        remaining: 0,
+      });
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(String(warnSpy.mock.calls[0]?.[0] ?? "")).toContain(
+        "Upstash not configured in production"
+      );
+    } finally {
+      process.env.NODE_ENV = originalEnv;
+    }
+  });
+
+  it("stays a permissive no-op outside production when Upstash is unconfigured", async () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "development";
+
+    try {
+      const { checkRateLimit } = await import("../src/lib/rate-limit");
+
+      for (let attempt = 0; attempt < 50; attempt += 1) {
+        await expect(
+          checkRateLimit(null, "ip:dev-unconfigured")
+        ).resolves.toEqual({
+          success: true,
+        });
+      }
+    } finally {
+      process.env.NODE_ENV = originalEnv;
+    }
+  });
 });


### PR DESCRIPTION
## IMP-03 — rate limiting must not fail open in production

Plan: `plans/improve/03-rate-limit-fail-closed-production.md`

### Problem
`checkRateLimit` returned unconditional `{ success: true }` whenever the limiter was `null` — and every limiter is `null` when `UPSTASH_REDIS_REST_URL`/`UPSTASH_REDIS_REST_TOKEN` are unset, **including production**. A prod deploy that lost its Upstash env ran with **zero** rate limiting on every AI route, with no signal: pure cost + abuse exposure.

### Fix
The null-limiter path now engages the **existing** in-process fallback limiter (`runLocalFallbackLimiter`'s counting logic) when `NODE_ENV === "production"`, returning `{ success: false }` past the default cap (30/min per identifier) instead of granting unlimited. A one-time `console.warn` flags the misconfiguration. Dev/demo and test environments keep the exact permissive no-op they have today.

Design choice: unconfigured-prod uses a single shared `"default"` scope bucket (the `null` limiter carries no scope), coarser than the per-scope Redis limits but strictly safer than fail-open — and it does **not** brick a misconfigured deploy (no hard 429). Documented in `DEFAULT_FALLBACK_CONFIG`.

### Files changed (2)
- `src/lib/rate-limit.ts` — extract `runLocalFallbackWithConfig()` shared core; `runLocalFallbackLimiter()` delegates to it (no behavior change on the Redis-error path); add prod null-limiter branch + one-time warn. **`checkRateLimit` public signature unchanged** (15+ callers safe).
- `tests/rate-limit.test.ts` — 2 new tests: prod-unset enforces the cap (30 ok, 31st blocked, warns once); non-prod stays permissive (50 calls all succeed).

### Verification
- `npm test` rate-limit + failover-harness: **12/12** (10 existing + 2 new)
- `npx tsc --noEmit`: clean
- `npx eslint src/lib/rate-limit.ts tests/rate-limit.test.ts`: 0 errors
- `npm test --testPathPatterns=symptom-chat`: 12 failures = unchanged pre-existing master baseline (compression/second-opinion), **0 new, 0 rate-limit-related** — change is a proven no-op in the test env (`NODE_ENV=test`)
- Thermo-review (maintainability): PASS — minimal, no duplication, signature stable, no clinical files touched

### Out of scope
Limiter quotas, Upstash config, hard 429 fail-closed, the billing usage-gate (Plan 06), clinical files. Independent of the route.ts stack (IMP-01A/B, Plans 02/05).

🤖 Generated with [Claude Code](https://claude.com/claude-code)