### PR TITLE
IMP-04: auth + rate limit on /api/azure/maps/nearest-vets

### DIFF
--- a/src/app/api/azure/maps/nearest-vets/route.ts
+++ b/src/app/api/azure/maps/nearest-vets/route.ts
@@ -1,5 +1,11 @@
 import { NextResponse } from "next/server";
 import { findNearestEmergencyVets } from "@/lib/azure/maps";
+import { requireAuthenticatedApiUser } from "@/lib/api-auth";
+import {
+  checkRateLimit,
+  generalApiLimiter,
+  getRateLimitId,
+} from "@/lib/rate-limit";
 
 export const runtime = "nodejs";
 
@@ -15,6 +21,41 @@ function jsonNoStore(body: unknown, status: number) {
 }
 
 export async function POST(request: Request) {
+  const auth = await requireAuthenticatedApiUser({
+    demoMessage: "Nearby vet lookup is unavailable in demo mode",
+  });
+  if ("response" in auth) {
+    // Demo mode (Supabase unconfigured) returns 503 — preserve the client's
+    // graceful hide-on-unavailable contract instead of surfacing an error.
+    if (auth.response?.status === 503) {
+      return jsonNoStore(
+        { clinics: [], enabled: false, reason: "not_configured" },
+        200
+      );
+    }
+    // Unauthenticated (401) or server-config error (500): return as-is.
+    return auth.response;
+  }
+
+  const rateLimitResult = await checkRateLimit(
+    generalApiLimiter,
+    getRateLimitId(request, auth.user.id)
+  );
+  if (!rateLimitResult.success) {
+    return NextResponse.json(
+      { clinics: [], enabled: false, reason: "rate_limited" },
+      {
+        headers: {
+          "Cache-Control": "no-store",
+          "Retry-After": String(
+            Math.max(1, Math.ceil((rateLimitResult.reset - Date.now()) / 1000))
+          ),
+        },
+        status: 429,
+      }
+    );
+  }
+
   let body: unknown;
   try {
     body = await request.json();

--- a/tests/azure-maps-route.test.ts
+++ b/tests/azure-maps-route.test.ts
@@ -1,30 +1,53 @@
-import { findNearestEmergencyVets } from "@/lib/azure/maps";
+import { NextResponse } from "next/server";
+
+const mockFindNearestEmergencyVets = jest.fn();
+const mockRequireAuthenticatedApiUser = jest.fn();
+const mockCheckRateLimit = jest.fn();
+const mockGetRateLimitId = jest.fn();
 
 jest.mock("@/lib/azure/maps", () => ({
-  findNearestEmergencyVets: jest.fn(),
+  findNearestEmergencyVets: (...args: unknown[]) =>
+    mockFindNearestEmergencyVets(...args),
 }));
 
-const mockedFindNearestEmergencyVets =
-  findNearestEmergencyVets as jest.MockedFunction<
-    typeof findNearestEmergencyVets
-  >;
+jest.mock("@/lib/api-auth", () => ({
+  requireAuthenticatedApiUser: (...args: unknown[]) =>
+    mockRequireAuthenticatedApiUser(...args),
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  generalApiLimiter: {},
+  checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
+  getRateLimitId: (...args: unknown[]) => mockGetRateLimitId(...args),
+}));
+
+function makeRequest(body: string) {
+  return new Request("http://localhost/api/azure/maps/nearest-vets", {
+    body,
+    headers: { "Content-Type": "application/json" },
+    method: "POST",
+  });
+}
 
 describe("POST /api/azure/maps/nearest-vets", () => {
   beforeEach(() => {
-    jest.resetAllMocks();
+    jest.resetModules();
+    jest.clearAllMocks();
+    mockRequireAuthenticatedApiUser.mockResolvedValue({
+      supabase: {},
+      user: { id: "user-1" },
+    });
+    mockCheckRateLimit.mockResolvedValue({
+      success: true,
+      reset: Date.now() + 30_000,
+    });
+    mockGetRateLimitId.mockReturnValue("user:user-1");
   });
 
   it("returns no-store invalid_location for malformed JSON", async () => {
-    const { POST } = await import(
-      "@/app/api/azure/maps/nearest-vets/route"
-    );
+    const { POST } = await import("@/app/api/azure/maps/nearest-vets/route");
 
-    const response = await POST(
-      new Request("http://localhost/api/azure/maps/nearest-vets", {
-        body: "{",
-        method: "POST",
-      })
-    );
+    const response = await POST(makeRequest("{"));
 
     await expect(response.json()).resolves.toEqual({
       clinics: [],
@@ -33,24 +56,18 @@ describe("POST /api/azure/maps/nearest-vets", () => {
     });
     expect(response.status).toBe(400);
     expect(response.headers.get("Cache-Control")).toBe("no-store");
-    expect(mockedFindNearestEmergencyVets).not.toHaveBeenCalled();
+    expect(mockFindNearestEmergencyVets).not.toHaveBeenCalled();
   });
 
   it("passes coordinates to the Azure Maps helper without caching the response", async () => {
-    mockedFindNearestEmergencyVets.mockResolvedValue({
+    mockFindNearestEmergencyVets.mockResolvedValue({
       clinics: [],
       enabled: true,
     });
-    const { POST } = await import(
-      "@/app/api/azure/maps/nearest-vets/route"
-    );
+    const { POST } = await import("@/app/api/azure/maps/nearest-vets/route");
 
     const response = await POST(
-      new Request("http://localhost/api/azure/maps/nearest-vets", {
-        body: JSON.stringify({ latitude: 41.149, longitude: -81.358 }),
-        headers: { "Content-Type": "application/json" },
-        method: "POST",
-      })
+      makeRequest(JSON.stringify({ latitude: 41.149, longitude: -81.358 }))
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -58,9 +75,85 @@ describe("POST /api/azure/maps/nearest-vets", () => {
       enabled: true,
     });
     expect(response.headers.get("Cache-Control")).toBe("no-store");
-    expect(mockedFindNearestEmergencyVets).toHaveBeenCalledWith({
+    expect(mockFindNearestEmergencyVets).toHaveBeenCalledWith({
       latitude: 41.149,
       longitude: -81.358,
     });
+    expect(mockGetRateLimitId).toHaveBeenCalledWith(
+      expect.any(Request),
+      "user-1"
+    );
+  });
+
+  it("rejects unauthenticated callers with 401 and never calls Azure Maps", async () => {
+    mockRequireAuthenticatedApiUser.mockResolvedValueOnce({
+      response: NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 }
+      ),
+    });
+    const { POST } = await import("@/app/api/azure/maps/nearest-vets/route");
+
+    const response = await POST(
+      makeRequest(JSON.stringify({ latitude: 41.1, longitude: -81.3 }))
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: "Authentication required",
+    });
+    expect(mockFindNearestEmergencyVets).not.toHaveBeenCalled();
+  });
+
+  it("maps demo mode (503) to the graceful not_configured envelope (200)", async () => {
+    mockRequireAuthenticatedApiUser.mockResolvedValueOnce({
+      response: NextResponse.json(
+        {
+          error: "Nearby vet lookup is unavailable in demo mode",
+          code: "DEMO_MODE",
+        },
+        { status: 503 }
+      ),
+    });
+    const { POST } = await import("@/app/api/azure/maps/nearest-vets/route");
+
+    const response = await POST(
+      makeRequest(JSON.stringify({ latitude: 41.1, longitude: -81.3 }))
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      clinics: [],
+      enabled: false,
+      reason: "not_configured",
+    });
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(mockFindNearestEmergencyVets).not.toHaveBeenCalled();
+  });
+
+  it("rate limits by authenticated user id with a 429 and Retry-After header", async () => {
+    mockCheckRateLimit.mockResolvedValueOnce({
+      success: false,
+      remaining: 0,
+      reset: Date.now() + 10_000,
+    });
+    const { POST } = await import("@/app/api/azure/maps/nearest-vets/route");
+
+    const response = await POST(
+      makeRequest(JSON.stringify({ latitude: 41.1, longitude: -81.3 }))
+    );
+
+    expect(response.status).toBe(429);
+    await expect(response.json()).resolves.toEqual({
+      clinics: [],
+      enabled: false,
+      reason: "rate_limited",
+    });
+    expect(response.headers.get("Retry-After")).toBeTruthy();
+    expect(mockGetRateLimitId).toHaveBeenCalledWith(
+      expect.any(Request),
+      "user-1"
+    );
+    expect(mockFindNearestEmergencyVets).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## IMP-04 — auth + rate limit on `nearest-vets`

Plan: `plans/improve/04-auth-ratelimit-nearest-vets.md`

### Problem
`POST /api/azure/maps/nearest-vets` was the **only** Azure-backed route with neither authentication nor rate limiting. Any anonymous caller could burn metered Azure Maps quota and use it as a free vet-clinic lookup proxy.

### Pre-flight STOP check (passed)
`<NearestVetFinder />` is gated behind **`!readOnlyShared`** (`full-report.tsx:241-243`), and the only public surface — `src/app/shared/[token]/page.tsx:133` — renders `<FullReport ... readOnlyShared />`, so the widget **never renders for unauthenticated viewers**. The component only fetches from authenticated dashboard contexts (symptom-checker, history). Adding 401 therefore changes no legitimate user-visible behavior.

### Fix
Applies the existing `speech-token` pattern at the top of `POST`, before body parsing:
- `requireAuthenticatedApiUser({ demoMessage: ... })` + per-user `generalApiLimiter`.
- **Demo mode** (503 `DEMO_MODE`) is mapped to the route's own graceful `{ clinics: [], enabled: false, reason: "not_configured" }` (200) envelope so `NearestVetFinder` hides itself exactly as before — preserving the client contract in demo deployments.
- **Unauthenticated** → 401 (helper's response as-is). **Rate-limited** → 429 with `Retry-After`.
- No client change: same-origin fetch already carries Supabase auth cookies.

### Files changed (2)
- `src/app/api/azure/maps/nearest-vets/route.ts` — auth + rate-limit blocks (+41)
- `tests/azure-maps-route.test.ts` — auth/rate-limit delegation mocks; existing 2 tests now run authenticated; 3 new (401, demo→not_configured 200, 429+Retry-After)

### Verification
- `npm test` azure-maps + speech-token + nearest-vet-finder: **12/12** (9 baseline + 3 new)
- `npx tsc --noEmit`: clean (the `auth.response?.status` optional-chain matches the auth union's `response?: never` modeling)
- `npx eslint`: 0 errors
- Thermo-review (maintainability): PASS — mirrors the established auth exemplar, no new patterns, no clinical files

### Out of scope
`findNearestEmergencyVets` lib, client component, other unauthenticated routes. Independent of the route.ts stack (IMP-01A/B, Plans 02/05).

🤖 Generated with [Claude Code](https://claude.com/claude-code)