### PR TITLE
IMP-06: usage limit gate fails closed (503) on database errors

### DIFF
--- a/src/lib/symptom-chat/usage-limit-gate.ts
+++ b/src/lib/symptom-chat/usage-limit-gate.ts
@@ -141,6 +141,23 @@ function buildUsageLimitResponse(
   );
 }
 
+function buildUsageGateUnavailableResponse(session: TriageSession) {
+  return NextResponse.json(
+    {
+      type: "usage_limit",
+      code: "USAGE_GATE_UNAVAILABLE",
+      error: "We couldn't verify your plan usage",
+      message:
+        "We couldn't verify your plan usage just now. Please try starting your symptom check again in a moment.",
+      requires_upgrade: false,
+      ready_for_report: false,
+      conversationState: "idle",
+      session: sanitizeSessionForClient(session),
+    },
+    { status: 503 }
+  );
+}
+
 export async function maybeBuildUsageLimitResponse(input: {
   action: SymptomChatAction;
   messages: SymptomChatMessage[];
@@ -191,7 +208,18 @@ export async function maybeBuildUsageLimitResponse(input: {
       ? null
       : buildUsageLimitResponse(input.session, usageGate);
   } catch (error) {
-    console.error("[Billing] Usage gate failed open:", error);
-    return null;
+    // Demo mode (Supabase unconfigured) is a deliberate permissive pass —
+    // createServerSupabaseClient throws "DEMO_MODE" with no backend to gate on.
+    if (error instanceof Error && error.message === "DEMO_MODE") {
+      return null;
+    }
+    // Real lookup/database failures must fail CLOSED for a NEW chat start: an
+    // outage should not silently grant unlimited free checks. In-progress
+    // conversations and emergencies were already exempted before the try block.
+    console.error(
+      "[Billing] Usage gate unavailable, failing closed for new chat:",
+      error
+    );
+    return buildUsageGateUnavailableResponse(input.session);
   }
 }

--- a/tests/symptom-chat.route.test.ts
+++ b/tests/symptom-chat.route.test.ts
@@ -7375,7 +7375,7 @@ describe("VET-900 comprehensive scenarios", () => {
       expect(mockExtractWithQwen).not.toHaveBeenCalled();
     });
 
-    it("fails open when the billing gate check throws", async () => {
+    it("fails closed with 503 when the billing gate check throws", async () => {
       const consoleErrorSpy = jest
         .spyOn(console, "error")
         .mockImplementation(() => undefined);
@@ -7389,16 +7389,35 @@ describe("VET-900 comprehensive scenarios", () => {
       );
       const payload = await response.json();
 
-      expect(response.status).toBe(200);
-      expect(payload.type).toBe("question");
-      expect(mockExtractWithQwen).toHaveBeenCalled();
+      expect(response.status).toBe(503);
+      expect(payload.type).toBe("usage_limit");
+      expect(payload.code).toBe("USAGE_GATE_UNAVAILABLE");
+      expect(mockExtractWithQwen).not.toHaveBeenCalled();
       expect(
         consoleErrorSpy.mock.calls.some((call) =>
-          String(call[0]).includes("[Billing] Usage gate failed open:")
+          String(call[0]).includes(
+            "[Billing] Usage gate unavailable, failing closed for new chat:"
+          )
         )
       ).toBe(true);
 
       consoleErrorSpy.mockRestore();
+    });
+
+    it("still passes (demo mode) when the billing client throws DEMO_MODE", async () => {
+      mockCreateServerSupabaseClient.mockRejectedValueOnce(
+        new Error("DEMO_MODE")
+      );
+
+      const { POST } = await import("@/app/api/ai/symptom-chat/route");
+      const response = await POST(
+        makeTextOnlyRequest(createSession(), "my dog is limping")
+      );
+      const payload = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(payload.type).toBe("question");
+      expect(mockExtractWithQwen).toHaveBeenCalled();
     });
 
     it("bypasses the usage gate for emergency-start conversations", async () => {

--- a/tests/usage-limit-gate.test.ts
+++ b/tests/usage-limit-gate.test.ts
@@ -2,7 +2,71 @@ import { createSession, recordAnswer } from "@/lib/triage-engine";
 import {
   hasConversationStarted,
   hasEmergencyUsageGateBypassSignal,
+  maybeBuildUsageLimitResponse,
 } from "@/lib/symptom-chat/usage-limit-gate";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+
+jest.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: jest.fn(),
+}));
+
+jest.mock("@/lib/private-tester-access", () => ({
+  shouldBypassUsageLimitForPrivateTester: jest.fn(() => false),
+}));
+
+const mockCreateServerSupabaseClient =
+  createServerSupabaseClient as jest.MockedFunction<
+    typeof createServerSupabaseClient
+  >;
+
+type QueryResult = { data?: unknown; error?: unknown; count?: number | null };
+
+// Minimal chainable Supabase query stub: every builder method returns the
+// builder, and awaiting it (or calling maybeSingle) resolves the configured
+// result — covering the .select().eq() / .in().gte() / .maybeSingle() chains.
+function makeQuery(result: QueryResult) {
+  const builder = {
+    select: () => builder,
+    eq: () => builder,
+    order: () => builder,
+    limit: () => builder,
+    in: () => builder,
+    gte: () => builder,
+    maybeSingle: () => Promise.resolve(result),
+    then: (
+      onFulfilled: (value: QueryResult) => unknown,
+      onRejected?: (reason: unknown) => unknown
+    ) => Promise.resolve(result).then(onFulfilled, onRejected),
+  };
+  return builder;
+}
+
+function buildSupabaseMock(opts: {
+  user?: { id: string; email?: string } | null;
+  subscriptions?: QueryResult;
+  pets?: QueryResult;
+  symptomChecks?: QueryResult;
+}) {
+  return {
+    auth: {
+      getUser: jest
+        .fn()
+        .mockResolvedValue({ data: { user: opts.user ?? null }, error: null }),
+    },
+    from: jest.fn((table: string) => {
+      if (table === "subscriptions") {
+        return makeQuery(opts.subscriptions ?? { data: null, error: null });
+      }
+      if (table === "pets") {
+        return makeQuery(opts.pets ?? { data: [], error: null });
+      }
+      if (table === "symptom_checks") {
+        return makeQuery(opts.symptomChecks ?? { count: 0, error: null });
+      }
+      return makeQuery({ data: null, error: null });
+    }),
+  };
+}
 
 describe("usage-limit-gate helpers", () => {
   it("detects when a conversation is already in progress", () => {
@@ -37,5 +101,79 @@ describe("usage-limit-gate helpers", () => {
         },
       ])
     ).toBe(true);
+  });
+});
+
+describe("maybeBuildUsageLimitResponse fail-closed behavior", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function chatInput() {
+    return {
+      action: "chat" as const,
+      messages: [
+        { role: "user" as const, content: "My dog seems a bit off today." },
+      ],
+      session: createSession(),
+    };
+  }
+
+  it("passes (null) in demo mode when the Supabase client throws DEMO_MODE", async () => {
+    mockCreateServerSupabaseClient.mockRejectedValueOnce(new Error("DEMO_MODE"));
+
+    await expect(maybeBuildUsageLimitResponse(chatInput())).resolves.toBeNull();
+  });
+
+  it("passes (null) for an unauthenticated user by design", async () => {
+    mockCreateServerSupabaseClient.mockResolvedValueOnce(
+      buildSupabaseMock({ user: null }) as never
+    );
+
+    await expect(maybeBuildUsageLimitResponse(chatInput())).resolves.toBeNull();
+  });
+
+  it("fails closed with 503 USAGE_GATE_UNAVAILABLE when the usage count query errors", async () => {
+    mockCreateServerSupabaseClient.mockResolvedValueOnce(
+      buildSupabaseMock({
+        user: { id: "user-1", email: "owner@example.com" },
+        subscriptions: { data: null, error: null },
+        pets: { data: [{ id: "pet-1" }], error: null },
+        symptomChecks: { count: null, error: { message: "db unavailable" } },
+      }) as never
+    );
+
+    const response = await maybeBuildUsageLimitResponse(chatInput());
+    expect(response).not.toBeNull();
+    expect(response?.status).toBe(503);
+    await expect(response?.json()).resolves.toMatchObject({
+      type: "usage_limit",
+      code: "USAGE_GATE_UNAVAILABLE",
+      ready_for_report: false,
+      conversationState: "idle",
+    });
+  });
+
+  it("fails closed with 503 when the Supabase client throws a generic error", async () => {
+    mockCreateServerSupabaseClient.mockRejectedValueOnce(
+      new Error("network unreachable")
+    );
+
+    const response = await maybeBuildUsageLimitResponse(chatInput());
+    expect(response?.status).toBe(503);
+    await expect(response?.json()).resolves.toMatchObject({
+      code: "USAGE_GATE_UNAVAILABLE",
+    });
+  });
+
+  it("returns null for generate_report without touching Supabase", async () => {
+    const response = await maybeBuildUsageLimitResponse({
+      action: "generate_report",
+      messages: [{ role: "user", content: "done" }],
+      session: createSession(),
+    });
+
+    expect(response).toBeNull();
+    expect(mockCreateServerSupabaseClient).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## IMP-06 — usage limit gate must fail closed on DB errors

Plan: `plans/improve/06-usage-gate-fail-closed.md`

### Problem
`maybeBuildUsageLimitResponse` wrapped its whole Supabase path in a catch-all that logged once and returned `null` — i.e. "gate passes". A Supabase outage therefore **silently granted unlimited free new symptom-chat conversations**, invisibly converting every outage into a free-usage window.

### Fix
Split the catch:
- **Demo mode** (`createServerSupabaseClient` throws `"DEMO_MODE"`) still returns `null` — a deliberate permissive pass when there's no backend to gate on.
- **Real lookup/database failures** on a *new* chat start now return a **503** `{ type: "usage_limit", code: "USAGE_GATE_UNAVAILABLE", ... }` "try again shortly" envelope instead of granting.

Failing closed is safe here because in-progress conversations and emergencies are exempted **before** the `try` block (unchanged). The 503 reuses `type: "usage_limit"` so the client envelope handling degrades gracefully.

### STOP check (cleared)
The symptom-checker UI never reads `code` or `usage_gate` (grep: those appear only in `usage-limit-gate.ts`). An unrecognized `data.type` falls through the page's `if/else-if` chain to the generic `else` (page.tsx:685) that renders `data.message`; `conversationState: "idle"` is honored at page.tsx:609. No crash — graceful degradation.

### Files changed (3)
- `src/lib/symptom-chat/usage-limit-gate.ts` — `buildUsageGateUnavailableResponse()` + split catch
- `tests/usage-limit-gate.test.ts` — 5 new cases (DEMO_MODE→null, unauth→null, `USAGE_COUNT_FAILED`→503, generic throw→503, generate_report→null without Supabase)
- `tests/symptom-chat.route.test.ts` — the VET-900 test that asserted the **old fail-open** contract now asserts fail-closed 503; added a demo-mode-passes route test to protect the preserved permissive path

### Verification
- `npm test` usage-limit-gate: **7/7** (2 existing + 5 new)
- `npm test --testPathPatterns=symptom-chat`: **12 failures = unchanged pre-existing baseline, 0 new**; the 2 updated/added billing tests pass
- `npx tsc --noEmit`: clean · `npx eslint`: 0 errors
- Thermo-review (maintainability): PASS — new builder mirrors the existing envelope, permissive paths preserved, no clinical files

### Out of scope
Quotas, `evaluateSymptomCheckUsageGate`, private-tester bypass, the unauthenticated permissive path, UI handling of the new code. Independent of the route.ts stack (IMP-01A/B, Plans 02/05).

🤖 Generated with [Claude Code](https://claude.com/claude-code)