### PR TITLE
IMP-08: add typecheck script + re-enable build-time type errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Deployed on Vercel. Set the environment variables from the table above in your V
 ```bash
 # Validate before pushing
 npm run lint
+npm run typecheck
 npm run build
 npm test
 npm run security:secrets

--- a/next.config.ts
+++ b/next.config.ts
@@ -51,12 +51,6 @@ export function buildSecurityHeaders(
 const nextConfig: NextConfig = {
   // Exclude Node.js-only packages from bundling
   serverExternalPackages: ["pg", "pg-native", "pg-pool", "pg-protocol"],
-  // Skip type-checking during build — handled separately by CI `tsc --noEmit`.
-  // Needed because symptom-chat/route.ts exports a helper that triggers
-  // Next.js route-export validation (we must not modify clinical files).
-  typescript: {
-    ignoreBuildErrors: true,
-  },
   async headers() {
     return [
       {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "node scripts/build.js",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "test": "jest --verbose",
     "test:watch": "jest --watch",
     "smoke:private-tester": "node scripts/private-tester-smoke.mjs production",


### PR DESCRIPTION
## IMP-08 — typecheck script + re-enable build-time type errors

Plan: `plans/improve/08-typecheck-script-and-build-gate.md`

### What & why
- `package.json` had **no `typecheck` script** even though CI runs `npx tsc --noEmit` — no one-command local reproduction of the CI gate.
- `next.config.ts` set `typescript.ignoreBuildErrors: true` behind a **stale comment** claiming `symptom-chat/route.ts` exports a helper that breaks Next.js route-export validation. Verified the file's only exports are the valid `maxDuration` route-segment config and `POST` — the justification is gone. `ignoreBuildErrors: true` is a standing safety hole: build-time type errors were silently ignored.

### Changes (3 files)
- `package.json` — add `"typecheck": "tsc --noEmit"` (mirrors CI exactly)
- `next.config.ts` — remove the `typescript.ignoreBuildErrors` block + stale comment
- `README.md` — add `npm run typecheck` to the pre-push checklist

### The build gate decision (plan step 3)
Removed `ignoreBuildErrors` and ran the full `npm run build` — **it passed** with type-checking re-enabled (full route tree compiled, no type errors). Per the plan, the removal is kept. Build-time type errors now fail the build again.

### Verification
- `npm run typecheck` → clean (exit 0)
- `npm run build` → green with type-checking enforced
- `npx eslint next.config.ts` → 0 errors
- README: exactly one `npm run typecheck` line in the checklist
- Thermo-review (maintainability): PASS — removes stale config, adds reproducible script, fully reversible, no clinical files

### Out of scope
Fixing type errors the build might reveal (none did), `scripts/build.js`, CI workflow (already typechecks). Independent of all other plans (the README pre-push edit doesn't overlap Plan 10's sections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)