### PR TITLE
IMP-09: wire the owner outcome-feedback loop in the report UI

### DIFF
--- a/src/components/symptom-report/outcome-feedback.tsx
+++ b/src/components/symptom-report/outcome-feedback.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { TesterFeedbackWidget } from "@/components/tester-feedback";
+import { OwnerOutcomeForm } from "./owner-outcome-form";
 import type { SymptomReport } from "./types";
 
 interface OutcomeFeedbackSectionProps {
@@ -15,11 +16,14 @@ export function OutcomeFeedbackSection({
   }
 
   return (
-    <TesterFeedbackWidget
-      symptomCheckId={report.report_storage_id}
-      reportTitle={report.title}
-      urgencyLabel={report.recommendation}
-      surface="result_page"
-    />
+    <div className="space-y-4">
+      <OwnerOutcomeForm symptomCheckId={report.report_storage_id} />
+      <TesterFeedbackWidget
+        symptomCheckId={report.report_storage_id}
+        reportTitle={report.title}
+        urgencyLabel={report.recommendation}
+        surface="result_page"
+      />
+    </div>
   );
 }

--- a/src/components/symptom-report/owner-outcome-form.tsx
+++ b/src/components/symptom-report/owner-outcome-form.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { useState } from "react";
+import { AlertTriangle, CheckCircle2, ClipboardCheck } from "lucide-react";
+import Card from "@/components/ui/card";
+
+type MatchedExpectation = "yes" | "partly" | "no";
+
+// Mirror the server zod limits in src/app/api/ai/outcome-feedback/route.ts.
+const CONFIRMED_DIAGNOSIS_MAX = 2000;
+const VET_OUTCOME_MAX = 2000;
+const OWNER_NOTES_MAX = 4000;
+
+interface OwnerOutcomeFormProps {
+  symptomCheckId?: string | null;
+}
+
+interface OutcomeFeedbackSubmitResponse {
+  ok?: boolean;
+  proposalCreated?: boolean;
+}
+
+function getSafeOutcomeErrorMessage(status: number) {
+  switch (status) {
+    case 400:
+      return "Please review your update and try again.";
+    case 401:
+      return "Please sign in again to share an outcome.";
+    case 403:
+    case 404:
+      return "We could not link this update to a saved report.";
+    case 429:
+      return "You're sending updates too quickly. Please try again shortly.";
+    default:
+      return "Outcome updates are temporarily unavailable. Please try again shortly.";
+  }
+}
+
+function ChoiceButton({
+  active,
+  label,
+  onClick,
+}: {
+  active: boolean;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded-full border px-3 py-1.5 text-sm font-medium transition-colors ${
+        active
+          ? "border-emerald-500 bg-emerald-50 text-emerald-700"
+          : "border-gray-200 bg-white text-gray-700 hover:bg-gray-50"
+      }`}
+    >
+      {label}
+    </button>
+  );
+}
+
+export function OwnerOutcomeForm({ symptomCheckId }: OwnerOutcomeFormProps) {
+  const [matchedExpectation, setMatchedExpectation] =
+    useState<MatchedExpectation | null>(null);
+  const [confirmedDiagnosis, setConfirmedDiagnosis] = useState("");
+  const [vetOutcome, setVetOutcome] = useState("");
+  const [ownerNotes, setOwnerNotes] = useState("");
+  const [saveState, setSaveState] = useState<
+    "idle" | "saving" | "saved" | "error"
+  >("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [proposalCreated, setProposalCreated] = useState(false);
+
+  if (!symptomCheckId) {
+    return null;
+  }
+
+  const submit = async () => {
+    if (saveState === "saving") {
+      return;
+    }
+    if (!matchedExpectation) {
+      setErrorMessage("Please choose whether this matched what happened.");
+      setSaveState("error");
+      return;
+    }
+
+    setSaveState("saving");
+    setErrorMessage(null);
+
+    try {
+      const trimmedDiagnosis = confirmedDiagnosis.trim();
+      const trimmedVetOutcome = vetOutcome.trim();
+      const trimmedNotes = ownerNotes.trim();
+
+      const response = await fetch("/api/ai/outcome-feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          symptomCheckId,
+          matchedExpectation,
+          ...(trimmedDiagnosis ? { confirmedDiagnosis: trimmedDiagnosis } : {}),
+          ...(trimmedVetOutcome ? { vetOutcome: trimmedVetOutcome } : {}),
+          ...(trimmedNotes ? { ownerNotes: trimmedNotes } : {}),
+        }),
+      });
+
+      const payload = (await response
+        .json()
+        .catch(() => ({}))) as OutcomeFeedbackSubmitResponse;
+
+      if (!response.ok || !payload.ok) {
+        throw new Error(getSafeOutcomeErrorMessage(response.status));
+      }
+
+      setProposalCreated(Boolean(payload.proposalCreated));
+      setSaveState("saved");
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "Unable to save this update right now"
+      );
+      setSaveState("error");
+    }
+  };
+
+  return (
+    <Card className="border border-emerald-100 bg-emerald-50/50 p-4 sm:p-5">
+      <div className="flex items-start gap-3">
+        <div className="rounded-full bg-emerald-100 p-2 text-emerald-700">
+          <ClipboardCheck className="h-5 w-5" />
+        </div>
+        <div className="min-w-0 flex-1 space-y-4">
+          <div>
+            <h3 className="text-base font-semibold text-gray-900">
+              Did this match what happened?
+            </h3>
+            <p className="mt-1 text-sm text-gray-600">
+              If you&apos;ve since seen a vet or learned what was going on, let us
+              know. Your update helps calibrate future triage and is reviewed by
+              our clinical team.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <p className="text-sm font-medium text-gray-900">
+              Did the outcome match this assessment?
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <ChoiceButton
+                active={matchedExpectation === "yes"}
+                label="Yes, it matched"
+                onClick={() => setMatchedExpectation("yes")}
+              />
+              <ChoiceButton
+                active={matchedExpectation === "partly"}
+                label="Partly"
+                onClick={() => setMatchedExpectation("partly")}
+              />
+              <ChoiceButton
+                active={matchedExpectation === "no"}
+                label="No, it was different"
+                onClick={() => setMatchedExpectation("no")}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <label
+              htmlFor={`owner-outcome-diagnosis-${symptomCheckId}`}
+              className="text-sm font-medium text-gray-900"
+            >
+              Confirmed diagnosis (optional)
+            </label>
+            <input
+              id={`owner-outcome-diagnosis-${symptomCheckId}`}
+              type="text"
+              value={confirmedDiagnosis}
+              maxLength={CONFIRMED_DIAGNOSIS_MAX}
+              onChange={(event) => setConfirmedDiagnosis(event.target.value)}
+              placeholder="What did the vet diagnose?"
+              className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label
+              htmlFor={`owner-outcome-vet-${symptomCheckId}`}
+              className="text-sm font-medium text-gray-900"
+            >
+              What did the vet do? (optional)
+            </label>
+            <input
+              id={`owner-outcome-vet-${symptomCheckId}`}
+              type="text"
+              value={vetOutcome}
+              maxLength={VET_OUTCOME_MAX}
+              onChange={(event) => setVetOutcome(event.target.value)}
+              placeholder="Treatment, tests, or next steps"
+              className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label
+              htmlFor={`owner-outcome-notes-${symptomCheckId}`}
+              className="text-sm font-medium text-gray-900"
+            >
+              Anything else? (optional)
+            </label>
+            <textarea
+              id={`owner-outcome-notes-${symptomCheckId}`}
+              value={ownerNotes}
+              maxLength={OWNER_NOTES_MAX}
+              onChange={(event) => setOwnerNotes(event.target.value)}
+              rows={3}
+              placeholder="How is your dog doing now?"
+              className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+            />
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              onClick={submit}
+              disabled={saveState === "saving" || saveState === "saved"}
+              className="rounded-full bg-emerald-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {saveState === "saving"
+                ? "Sharing..."
+                : saveState === "saved"
+                  ? "Update shared"
+                  : "Share outcome"}
+            </button>
+
+            {saveState === "saved" ? (
+              <span className="inline-flex items-center gap-2 text-sm text-emerald-700">
+                <CheckCircle2 className="h-4 w-4" />
+                {proposalCreated
+                  ? "Thank you — your report was flagged for clinical review."
+                  : "Thank you — your update was saved."}
+              </span>
+            ) : null}
+
+            {saveState === "error" && errorMessage ? (
+              <span className="inline-flex items-center gap-2 text-sm text-red-700">
+                <AlertTriangle className="h-4 w-4" />
+                {errorMessage}
+              </span>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/tests/owner-outcome-form.test.tsx
+++ b/tests/owner-outcome-form.test.tsx
@@ -1,0 +1,86 @@
+/** @jest-environment jsdom */
+
+import * as React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { OwnerOutcomeForm } from "@/components/symptom-report/owner-outcome-form";
+
+const SYMPTOM_CHECK_ID = "11111111-1111-1111-1111-111111111111";
+
+describe("OwnerOutcomeForm", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it("posts the selected outcome and confirmed diagnosis to the feedback API", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true, proposalCreated: false }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<OwnerOutcomeForm symptomCheckId={SYMPTOM_CHECK_ID} />);
+
+    // All three outcome choices are rendered.
+    expect(screen.getByText("Yes, it matched")).toBeTruthy();
+    expect(screen.getByText("Partly")).toBeTruthy();
+    expect(screen.getByText("No, it was different")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("No, it was different"));
+    fireEvent.change(screen.getByPlaceholderText("What did the vet diagnose?"), {
+      target: { value: "otitis externa" },
+    });
+    fireEvent.click(screen.getByText("Share outcome"));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/ai/outcome-feedback");
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body).toEqual({
+      symptomCheckId: SYMPTOM_CHECK_ID,
+      matchedExpectation: "no",
+      confirmedDiagnosis: "otitis externa",
+    });
+
+    await screen.findByText("Thank you — your update was saved.");
+  });
+
+  it("shows the clinical-review message when the API reports a proposal was created", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true, proposalCreated: true }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<OwnerOutcomeForm symptomCheckId={SYMPTOM_CHECK_ID} />);
+
+    fireEvent.click(screen.getByText("Partly"));
+    fireEvent.click(screen.getByText("Share outcome"));
+
+    await screen.findByText(
+      "Thank you — your report was flagged for clinical review."
+    );
+  });
+
+  it("blocks submission until an outcome choice is made", async () => {
+    const fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<OwnerOutcomeForm symptomCheckId={SYMPTOM_CHECK_ID} />);
+
+    fireEvent.click(screen.getByText("Share outcome"));
+
+    await screen.findByText(
+      "Please choose whether this matched what happened."
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("renders nothing without a symptomCheckId", () => {
+    const { container } = render(<OwnerOutcomeForm symptomCheckId={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
## IMP-09 — wire the owner outcome-feedback loop

Plan: `plans/improve/09-owner-outcome-feedback-loop.md`

### Problem
The calibration loop (owner outcome → threshold proposal → admin review) is fully built server-side and admin-side, but **dead-ended at the owner UI**. `POST /api/ai/outcome-feedback` accepts `matchedExpectation`/`confirmedDiagnosis`/`vetOutcome`/`ownerNotes`, persists them, and auto-drafts a proposal for non-`yes` outcomes — yet `FullReport`'s `onOutcomeFeedback` prop had no caller, and the rendered section only collected tester *helpfulness*.

### STOP checks (cleared)
- The dirty-tree zod schema matches the plan excerpt exactly.
- The proposal-created field is real: route returns `{ ok, proposalCreated, structuredStored, warnings }` (route.ts:194), and `saveOutcomeFeedbackToDB` returns `proposalCreated: boolean`.
- `tests/outcome-feedback.route.test.ts` baseline 9/9; it **already** covers full-outcome posting + proposal behavior, so step 5 needs no route-test change.

### Changes (3 files, UI only)
- **NEW** `owner-outcome-form.tsx` — `"Did this match what happened?"` with a yes/partly/no choice + optional confirmed-diagnosis / vet-outcome / notes (`maxLength` mirrors the server zod limits). POSTs the existing schema (empty optionals omitted); on success shows a thank-you, plus a **"flagged for clinical review"** line when `proposalCreated` is true. Mirrors the `TesterFeedbackWidget` save-state/error patterns.
- `outcome-feedback.tsx` — renders `OwnerOutcomeForm` alongside the tester widget. Both report callers (symptom-checker + history) are covered with **no caller edits**; `readOnlyShared` still hides the whole section.
- **NEW** `tests/owner-outcome-form.test.tsx` — 4 jsdom/Testing-Library tests: three choices render; submitting "no" + diagnosis posts the exact payload; `proposalCreated:true` shows the review message; submit blocked until a choice is made; null `symptomCheckId` renders nothing.

### Verification
- `npm test` owner-outcome-form + outcome-feedback + tester-feedback: **29/29** across 8 suites (4 new)
- `npx tsc --noEmit`: clean · `npx eslint`: 0 errors
- Preview note: the form only renders for a Supabase-stored report behind auth, so it can't be exercised in demo/local — the jsdom component test is the appropriate verifier (mounts it in isolation, asserts payload + messages).
- Thermo-review (maintainability): PASS — reuses existing API + widget patterns, no caller plumbing, no clinical/route/storage changes

### Out of scope
`threshold-proposals.ts`, `report-storage.ts`, the admin panel, the route handler — all read-only. Independent of the route.ts stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)