### PR TITLE
IMP-07: localize the 3 per-turn translator strings in parallel

### DIFF
--- a/src/app/(dashboard)/symptom-checker/page.tsx
+++ b/src/app/(dashboard)/symptom-checker/page.tsx
@@ -627,18 +627,23 @@ export default function SymptomCheckerPage() {
         setConversationState(inferred);
       }
 
-      const assistantText =
-        typeof data.message === "string"
-          ? await localizeAssistantText(data.message)
-          : null;
-      const terminalOwnerText =
-        typeof data.owner_message === "string"
-          ? await localizeAssistantText(data.owner_message)
-          : null;
-      const terminalNextStepText =
-        typeof data.recommended_next_step === "string"
-          ? await localizeAssistantText(data.recommended_next_step)
-          : null;
+      // Localize the assistant, terminal-owner, and next-step strings in
+      // parallel instead of three serial round-trips — one round-trip of
+      // latency per turn for non-English owners. Each entry is produced by the
+      // same localizeAssistantText call as before (the inputs are independent),
+      // so translation/fallback behavior is unchanged; only the ordering is.
+      const [assistantText, terminalOwnerText, terminalNextStepText] =
+        await Promise.all([
+          typeof data.message === "string"
+            ? localizeAssistantText(data.message)
+            : Promise.resolve(null),
+          typeof data.owner_message === "string"
+            ? localizeAssistantText(data.owner_message)
+            : Promise.resolve(null),
+          typeof data.recommended_next_step === "string"
+            ? localizeAssistantText(data.recommended_next_step)
+            : Promise.resolve(null),
+        ]);
 
       if (data.type === "emergency") {
         setMessages((prev) => [


### PR DESCRIPTION
## IMP-07 — parallelize per-turn translator calls

Plan: `plans/improve/07-batch-translator-calls.md`

### Problem
Every chat turn localized three strings — assistant message, terminal owner message, next-step — with **three sequential** `await localizeAssistantText(...)` calls. For non-English owners that's three serial translator round-trips of added latency per turn (and 3× the 20/min per-user translator budget).

### Fix
The three inputs are independent, so they now run with `Promise.all` — one round-trip of latency instead of three. (Single-file change to `symptom-checker/page.tsx`.)

### Design choice
Took the plan's accepted **parallel** design over the fully-batched single-request variant. Each result is still produced by the **same** `localizeAssistantText` call as before, so translation/fallback behavior is **provably byte-identical** — only the ordering changes from serial to concurrent. The batched variant would touch the shared `translator-client.ts` + the hook and add positional result-mapping, which risks rendering *mismatched* translated text in a clinical UI for no practical gain (3 concurrent calls are far under the 20/min limit at user-paced turns). Noted as a possible follow-up.

### Files changed (1)
- `src/app/(dashboard)/symptom-checker/page.tsx` — three serial awaits → one `Promise.all`. Variable names/types unchanged; no downstream lines touched.

### Verification
- `npx tsc --noEmit`: clean
- `npm test --testPathPatterns=translator`: 28/28
- `npm test` symptom-checker-state-ui + conversation-state-ui: 19/19 (exercise the page's turn handling)
- `npx eslint`: **0 errors** (3 pre-existing `<img>` warnings on untouched lines)
- Preview note: latency-only change, no visual delta, gated behind a non-English session + translator config — the UI-state suites are the appropriate verifier
- Thermo-review (maintainability): PASS — behavior-preserving, single file, no shared-module/clinical changes

### Out of scope
The translator API route + rate limiter, report-localization paths in `translator-client.ts`, clinical files. Independent of the route.ts stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)