### PR TITLE
IMP-02: cap symptom-chat request body at 10 MB (413)

### DIFF
--- a/src/app/api/ai/symptom-chat/route.ts
+++ b/src/app/api/ai/symptom-chat/route.ts
@@ -1220,6 +1220,109 @@ function buildDeterministicEmergencyMessage(
   return `Based on the symptoms you've shared${details}, ${petName} may be having a medical emergency. Please go to the nearest emergency veterinary hospital now. I have enough information to prepare an emergency summary for the vet while you're on the way.`;
 }
 
+// Cap the request body (which can carry a base64 image) so an oversized or
+// buggy client cannot force unbounded buffering/parsing on the busiest AI
+// route. 10 MB matches the image-bearing async-review route. Pattern mirrors
+// the capped reader in symptom-check/route.ts. Route-local (not exported) so
+// the file keeps exporting only POST + maxDuration.
+const MAX_REQUEST_BYTES = 10 * 1024 * 1024;
+
+type BodyParseResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; response: Response };
+
+function jsonError(error: string, status: number, code: string) {
+  return NextResponse.json({ error, code }, { status });
+}
+
+function decodeUtf8(chunks: Uint8Array[], totalBytes: number) {
+  const merged = new Uint8Array(totalBytes);
+  let offset = 0;
+
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return new TextDecoder().decode(merged);
+}
+
+async function readJsonBody<T>(
+  request: Request,
+  maxBytes: number
+): Promise<BodyParseResult<T>> {
+  const declaredLength = Number(request.headers.get("content-length") ?? "");
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    return {
+      ok: false,
+      response: jsonError("Request body too large", 413, "PAYLOAD_TOO_LARGE"),
+    };
+  }
+
+  const reader = request.body?.getReader();
+  if (!reader) {
+    return {
+      ok: false,
+      response: jsonError("Request body is required", 400, "INVALID_JSON"),
+    };
+  }
+
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (!value) {
+        continue;
+      }
+
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBytes) {
+        try {
+          await reader.cancel();
+        } catch {}
+
+        return {
+          ok: false,
+          response: jsonError(
+            "Request body too large",
+            413,
+            "PAYLOAD_TOO_LARGE"
+          ),
+        };
+      }
+
+      chunks.push(value);
+    }
+  } catch {
+    return {
+      ok: false,
+      response: jsonError("Malformed JSON body", 400, "INVALID_JSON"),
+    };
+  }
+
+  const rawBody = decodeUtf8(chunks, totalBytes).trim();
+  if (!rawBody) {
+    return {
+      ok: false,
+      response: jsonError("Request body is required", 400, "INVALID_JSON"),
+    };
+  }
+
+  try {
+    return { ok: true, value: JSON.parse(rawBody) as T };
+  } catch {
+    return {
+      ok: false,
+      response: jsonError("Malformed JSON body", 400, "INVALID_JSON"),
+    };
+  }
+}
+
 export async function POST(request: Request) {
   const startedAtMs = Date.now();
   const turnDeadline = createTurnDeadline(startedAtMs);
@@ -1282,7 +1385,15 @@ export async function POST(request: Request) {
       );
     }
 
-    const body: RequestBody = await request.json();
+    const parsedBody = await readJsonBody<RequestBody>(
+      request,
+      MAX_REQUEST_BYTES
+    );
+    if (!parsedBody.ok) {
+      statusCode = parsedBody.response.status;
+      return parsedBody.response;
+    }
+    const body = parsedBody.value;
     const {
       messages,
       pet,

--- a/tests/symptom-chat.route.test.ts
+++ b/tests/symptom-chat.route.test.ts
@@ -725,6 +725,69 @@ describe("symptom-chat mixed text + image routing", () => {
     });
   });
 
+  describe("IMP-02: request body size cap", () => {
+    it("rejects an oversized body (large content-length) with 413 PAYLOAD_TOO_LARGE", async () => {
+      const oversizedImage = "a".repeat(10 * 1024 * 1024 + 1024);
+      const request = new Request("http://localhost/api/ai/symptom-chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "chat",
+          pet: PET,
+          session: createSession(),
+          image: oversizedImage,
+          messages: [{ role: "user", content: "my dog is limping" }],
+        }),
+      });
+
+      const { POST } = await import("@/app/api/ai/symptom-chat/route");
+      const response = await POST(request);
+      const payload = await response.json();
+
+      expect(response.status).toBe(413);
+      expect(payload.code).toBe("PAYLOAD_TOO_LARGE");
+      expect(mockExtractWithQwen).not.toHaveBeenCalled();
+    });
+
+    it("rejects an oversized streamed body with no content-length via the streaming cap", async () => {
+      const oneMb = new TextEncoder().encode("a".repeat(1024 * 1024));
+      let emitted = 0;
+      const body = new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (emitted >= 11) {
+            controller.close();
+            return;
+          }
+          controller.enqueue(oneMb);
+          emitted += 1;
+        },
+      });
+      const request = new Request("http://localhost/api/ai/symptom-chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+        // Stream bodies require duplex; not yet in the lib RequestInit type.
+        duplex: "half",
+      } as RequestInit & { duplex: "half" });
+
+      const { POST } = await import("@/app/api/ai/symptom-chat/route");
+      const response = await POST(request);
+      const payload = await response.json();
+
+      expect(response.status).toBe(413);
+      expect(payload.code).toBe("PAYLOAD_TOO_LARGE");
+    });
+
+    it("still parses a normal-sized chat request (not 413)", async () => {
+      const { POST } = await import("@/app/api/ai/symptom-chat/route");
+      const response = await POST(
+        makeTextOnlyRequest(createSession(), "my dog is limping")
+      );
+
+      expect(response.status).not.toBe(413);
+    });
+  });
+
   it("records sanitized route telemetry for rate-limited symptom-chat requests", async () => {
     mockCheckRateLimit.mockResolvedValue({
       success: false,


### PR DESCRIPTION
## IMP-02 — request body size cap for symptom-chat

Plan: `plans/improve/02-body-size-cap-symptom-chat.md`

### Problem
`POST /api/ai/symptom-chat` read its body with a bare `await request.json()`, and the payload carries an optional base64 `image` — so an oversized or buggy client could force unbounded buffering/parsing on the **busiest AI route** (memory-exhaustion / DoS). Sibling routes already solve this: `symptom-check` caps at 32 KB, `async-review` at 10 MB.

### Fix
A capped streaming JSON reader at the top of `POST`, returning **413 `PAYLOAD_TOO_LARGE`** — copied verbatim from the proven `symptom-check/route.ts` pattern, sized to **10 MB** to match the image-bearing `async-review` route.
- Route-local (non-exported) `readJsonBody` / `decodeUtf8` / `jsonError` / `BodyParseResult` + `MAX_REQUEST_BYTES`. The route keeps exporting only `POST` + `maxDuration`.
- Replaces the bare parse; preserves the `statusCode` telemetry assignment.

### Files changed (2)
- `src/app/api/ai/symptom-chat/route.ts` — capped reader helpers + swapped parse (+113)
- `tests/symptom-chat.route.test.ts` — `IMP-02` describe block (3 tests)

### Tests
1. Oversized body → undici sets a >10 MB `content-length` → early check → **413** (`mockExtractWithQwen` never called)
2. Oversized **`ReadableStream`** body with **no** content-length → the **streaming** cap trips → **413**
3. A normal-sized chat request → **not** 413 (parity)

### Verification
- `npx tsc --noEmit`: clean
- `npm test --testPathPatterns=symptom-chat`: **12 failures = unchanged pre-existing baseline, 0 new** (606 total: +3 IMP-02 tests, all pass). Every existing test builds stream-readable request bodies, which the reader handles.
- `npx eslint`: **0 errors** (3 pre-existing `<img>` warnings on untouched lines)
- Thermo-review (maintainability): PASS — reuses the existing reader, no new exports, no clinical files

### Out of scope
The optional shared-helper extraction (the three duplicate readers have diverged), the 32 KB/10 MB caps of the siblings, per-field image validation. Edits only the body-parsing layer. Serial with Plan 05 (image-gate) on this file — 05 stacks on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)