### PR TITLE
IMP-10: sync README/AGENTS docs with verified reality

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This version has breaking changes — APIs, conventions, and file structure may 
 
 ### Overview
 
-PawVital AI is a single Next.js 16.2.1 app (React 19, Tailwind 4, TypeScript 5) with optional Python sidecar microservices under `services/`. Package manager is **npm** (lockfile: `package-lock.json`).
+PawVital AI is a single Next.js 16.x app (React 19, Tailwind 4, TypeScript 5; exact pin in `package.json`) with optional Python sidecar microservices under `services/`. Package manager is **npm** (lockfile: `package-lock.json`).
 
 ### Key commands
 
@@ -66,7 +66,7 @@ The app runs in **demo mode** when Supabase environment variables are not set (`
 
 ### Gotchas
 
-- The ESLint config uses `eslint/config` with `defineConfig` and `globalIgnores` (ESLint 9 flat config). Pre-existing lint errors exist in test files (`@typescript-eslint/no-explicit-any`) and one `prefer-const` in `symptom-chat/route.ts`.
+- The ESLint config uses `eslint/config` with `defineConfig` and `globalIgnores` (ESLint 9 flat config). The repo currently lints with 0 errors and ~90 pre-existing warnings (mostly `@typescript-eslint/no-unused-vars`, a few `@next/next/no-img-element`); do not introduce new errors.
 - Jest config uses `ts-jest` with `useESM: false` and maps `@/` to `./src/`. Test environment is `node` (not jsdom).
 - `next.config.ts` externalizes `pg`, `pg-native`, `pg-pool`, `pg-protocol` from Turbopack bundling.
 - The dev server starts very fast (~265ms with Turbopack). Hot reload works without needing restart after dependency changes.

--- a/README.md
+++ b/README.md
@@ -74,11 +74,12 @@ Browser
     ├── POST /api/ai/async-review      → background session review
     ├── GET  /api/ai/shadow-rollout    → shadow comparison admin
     ├── POST /api/pets/[id]            → pet profile management
-    ├── POST /api/reports              → report generation + sharing
-    └── POST /api/triage               → triage session persistence
+    ├── POST /api/reports/pdf          → report PDF rendering
+    ├── POST /api/reports/share        → shareable report links
+    └── POST /api/triage/next          → deterministic next-question step
         │
         ├── Supabase Auth    — session validation on every request
-        ├── Upstash Redis    — usage_log rate limiting (per user, per day)
+        ├── Upstash Redis    — sliding-window rate limiting (per user, per minute; in-process fallback)
         ├── Supabase Postgres — chat history, pet profiles, health scores
         └── NVIDIA NIM API   — multi-model calls with Anthropic fallback
 ```
@@ -89,7 +90,7 @@ Browser
 - **Deterministic answer coercion before LLM extraction.** When a user says "yes" or "about two days", the system coerces the answer deterministically using the pending question as an anchor before falling back to the model.
 - **Structured state cannot be mutated by model output.** `answered_questions`, `extracted_answers`, and `unresolved_question_ids` are protected from compression side effects and LLM hallucination.
 - **Multi-model fallback.** If NVIDIA NIM is unavailable, `sideModel()` automatically switches to the next ranked model. Anthropic Claude handles second-opinion and final report paths.
-- **Rate limiting via Postgres.** A `usage_log` table with an indexed `(user_id, created_at)` compound key counts daily requests without an external counter. Falls back gracefully if Redis is unavailable.
+- **Rate limiting via Upstash Redis.** Sliding-window limiters per scope (symptom-chat, image analysis, general API, translator) defined in `src/lib/rate-limit.ts`. When Redis errors at call time, an in-process fallback limiter enforces the same per-scope limits.
 - **Row-Level Security on every table.** Supabase RLS policies ensure users can only read and write their own data, enforced at the database layer.
 - **Multimodal support.** Chat and photo routes accept base64-encoded images and route them to vision-capable models.
 - **AI-gated merges.** A GitHub Models review gate checks every PR for clinical correctness before the auto-merge step runs.
@@ -164,21 +165,26 @@ Open [http://localhost:3000](http://localhost:3000).
 
 ## Database Schema
 
-Seven tables, all with RLS enabled:
+Ten tables, all with RLS enabled (`supabase-schema.sql`):
 
 - **`profiles`** — synced from `auth.users` via trigger on signup; stores display name, subscription tier, and pet count
+- **`subscriptions`** — per-user subscription / billing state
 - **`pets`** — pet profiles with breed, age, weight, sex, and medical history; foreign-keyed to `profiles`
-- **`triage_sessions`** — one row per symptom-checker session; stores structured state (`answered_questions`, `extracted_answers`, `urgency_level`)
-- **`chat_messages`** — per-turn message log for every triage session; used for report generation and async review
 - **`health_scores`** — AI-generated health score history per pet; indexed by `(pet_id, created_at)`
-- **`usage_log`** — per-user daily AI request counter; `(user_id, created_at)` compound index; rate-limit fallback if Redis is unavailable
-- **`outcome_feedback`** — owner-reported triage outcome (resolved / vet visit / emergency); feeds back into shadow evaluation benchmarks
+- **`symptom_checks`** — one row per symptom check; stores symptoms text, AI response, severity, and recommendation
+- **`supplements`** — AI supplement recommendations per pet
+- **`reminders`** — scheduled care reminders per pet
+- **`journal_entries`** — owner health-journal entries per pet
+- **`community_posts`** — community forum posts
+- **`community_comments`** — comments on community forum posts
 
 ---
 
 ## Python Sidecars
 
 Five optional microservices under `services/`. Run locally via `docker-compose.sidecars.yml` or deploy to HuggingFace Spaces / RunPod.
+
+Hosting note: `vision-preprocess-service` also runs as a standalone Vercel FastAPI deployment. The four heavier model-backed sidecars exceed Vercel's Lambda size limits and deploy via the Docker GPU-host bundle in `deploy/sidecars-gpu-host/` (see `plans/SIDECAR_DEPLOYMENT_RUNBOOK.md`).
 
 | Service | Port | Purpose |
 |---|---|---|


### PR DESCRIPTION
## IMP-10 — documentation sync (README.md + AGENTS.md)

Plan: `plans/improve/10-docs-sync-readme-agents.md`

These docs are read by every agent at session start, so wrong infrastructure claims (e.g. "Postgres `usage_log` rate limiting") actively mislead security/billing work. All items below were verified against the real tree before editing.

### README.md
- **(A) Endpoints** — `/api/reports` and `/api/triage` don't exist. Real routes: `POST /api/reports/pdf`, `POST /api/reports/share`, `POST /api/triage/next` (verified exports).
- **(B/C) Rate limiting** — there is no Postgres `usage_log` table. It's Upstash **sliding-window per-minute** with an in-process fallback (`src/lib/rate-limit.ts`). Fixed both the architecture diagram and the key-decisions bullet.
- **(D) Schema** — the "**Seven tables**" list named three phantom tables (`triage_sessions`, `chat_messages`, `usage_log`) + `outcome_feedback` (none in `supabase-schema.sql`). Replaced with the **real ten** tables from `supabase-schema.sql` (profiles, subscriptions, pets, health_scores, symptom_checks, supplements, reminders, journal_entries, community_posts, community_comments).
- **(G) Sidecars** — added the GPU-host deploy path (`deploy/sidecars-gpu-host/`, `plans/SIDECAR_DEPLOYMENT_RUNBOOK.md`) the intro omitted.

### AGENTS.md
- **(E)** `Next.js 16.2.1` → durable `16.x (exact pin in package.json)` (actual is 16.2.6; phrased to resist re-drift).
- **(F)** Stale lint claim (nonexistent errors + a `prefer-const`) → verified **0 errors / ~90 pre-existing warnings** (mostly `no-unused-vars`).

### Verification (all gates pass)
- `usage_log`, `triage_sessions|chat_messages`, bare `POST /api/reports `/`POST /api/triage `, `16.2.1`, `prefer-const` → **0 matches**
- `sidecars-gpu-host` → 1 match
- `git status` → **only README.md + AGENTS.md** changed (no code touched; eslint baseline 92/0-errors unaffected)

### Deferred (per plan)
The marketing-overclaim reconciliation (`plans/DEVELOPMENT_ROADMAP.md:19`) — judgment-heavy, explicitly out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)