### PR TITLE
IMP-05: server-bind the image-gate override (HMAC token)

### DIFF
--- a/src/app/(dashboard)/symptom-checker/page.tsx
+++ b/src/app/(dashboard)/symptom-checker/page.tsx
@@ -96,6 +96,7 @@ interface SendMessageOptions {
   imageOverride?: string | null;
   imageMetaOverride?: ImageMeta | null;
   gateOverride?: boolean;
+  gateOverrideTokenOverride?: string | null;
   appendUserMessage?: boolean;
 }
 
@@ -266,6 +267,9 @@ export default function SymptomCheckerPage() {
   const [pendingGateImage, setPendingGateImage] = useState<string | null>(null);
   const [pendingGateImageMeta, setPendingGateImageMeta] =
     useState<ImageMeta | null>(null);
+  const [pendingGateToken, setPendingGateToken] = useState<string | null>(
+    null,
+  );
   const [promptVetRecord, setPromptVetRecord] = useState(false);
   const [loading, setLoading] = useState(false);
   const [report, setReport] = useState<SymptomReport | null>(null);
@@ -357,6 +361,7 @@ export default function SymptomCheckerPage() {
   const clearPendingGateImage = () => {
     setPendingGateImage(null);
     setPendingGateImageMeta(null);
+    setPendingGateToken(null);
   };
 
   const appendTranscriptToInput = (transcript: string) => {
@@ -524,6 +529,7 @@ export default function SymptomCheckerPage() {
       imageOverride,
       imageMetaOverride,
       gateOverride = false,
+      gateOverrideTokenOverride,
       appendUserMessage = true,
     } = options;
     const messageText = text ?? input.trim();
@@ -592,6 +598,7 @@ export default function SymptomCheckerPage() {
           image: imageToSend, // Send the base64 image here
           imageMeta: imageMetaToSend,
           gateOverride,
+          gateOverrideToken: gateOverrideTokenOverride ?? undefined,
         }),
         signal: controller.signal,
       });
@@ -665,6 +672,11 @@ export default function SymptomCheckerPage() {
             timestamp: new Date(),
           },
         ]);
+        setPendingGateToken(
+          typeof data.gate_override_token === "string"
+            ? data.gate_override_token
+            : null,
+        );
       } else if (data.type === "ready") {
         setMessages((prev) => [
           ...prev,
@@ -855,6 +867,7 @@ export default function SymptomCheckerPage() {
       imageOverride: pendingGateImage,
       imageMetaOverride: pendingGateImageMeta,
       gateOverride: true,
+      gateOverrideTokenOverride: pendingGateToken,
       appendUserMessage: false,
     });
   };

--- a/src/app/api/ai/symptom-chat/route.ts
+++ b/src/app/api/ai/symptom-chat/route.ts
@@ -167,6 +167,10 @@ import { buildQuestionResponseFlow } from "@/lib/symptom-chat/question-response-
 import { resolveVerifiedUserId } from "@/lib/symptom-chat/server-identity";
 import { maybeBuildUsageLimitResponse } from "@/lib/symptom-chat/usage-limit-gate";
 import {
+  issueGateOverrideToken,
+  verifyGateOverrideToken,
+} from "@/lib/symptom-chat/gate-override-token";
+import {
   generateReport,
   generateTerminalOutcomeReport,
 } from "@/lib/symptom-chat/report-pipeline";
@@ -211,6 +215,7 @@ interface RequestBody {
   image?: string; // base64 image data (with or without data URL prefix)
   imageMeta?: ImageMeta;
   gateOverride?: boolean;
+  gateOverrideToken?: string;
 }
 
 type LiveUpdateTarget = {
@@ -1403,6 +1408,7 @@ export async function POST(request: Request) {
       image,
       imageMeta,
       gateOverride,
+      gateOverrideToken,
     } = body;
 
     let session = clientSession || createSession();
@@ -1660,7 +1666,15 @@ export async function POST(request: Request) {
           session.known_symptoms.includes("wound_skin_issue"))
       : false;
 
-    if (image && shouldRunWoundVision && gateOverride !== true) {
+    // Server-bind the gate override: an override is honored only when the
+    // client echoes a valid, unexpired HMAC token that THIS server issued for
+    // THIS image hash. A bare gateOverride:true (forged or stale) no longer
+    // bypasses the gate — it re-runs and, if it warns, re-issues a fresh token.
+    const gateOverrideAccepted =
+      gateOverride === true &&
+      verifyGateOverrideToken(gateOverrideToken, imageHash || "");
+
+    if (image && shouldRunWoundVision && !gateOverrideAccepted) {
       const gateCacheKey = buildGateCacheKey(imageHash || "", imageMeta);
       const gateWarning =
         session.gate_cache_key === gateCacheKey
@@ -1676,12 +1690,13 @@ export async function POST(request: Request) {
           session,
           gate: gateWarning,
           ready_for_report: false,
+          gate_override_token: issueGateOverrideToken(imageHash || ""),
         });
       }
     }
 
     if (image && shouldRunWoundVision) {
-      if (gateOverride === true) {
+      if (gateOverrideAccepted) {
         console.log("[Image Gate] Override accepted, continuing to vision pipeline");
       }
       try {

--- a/src/lib/symptom-chat/gate-override-token.ts
+++ b/src/lib/symptom-chat/gate-override-token.ts
@@ -1,0 +1,60 @@
+import { createHmac, timingSafeEqual } from "crypto";
+
+/**
+ * Server-bound image-gate override tokens.
+ *
+ * When the symptom-chat route returns an `image_gate` warning it issues a
+ * short-lived HMAC token over the image hash. A client `gateOverride` is only
+ * honored when it echoes a valid, unexpired token for the SAME image — so a
+ * forged `gateOverride: true` can no longer bypass the quality/safety gate.
+ *
+ * Stateless (no storage). The dev fallback secret keeps demo mode working with
+ * zero env config, matching the repo's demo-mode philosophy; production should
+ * set IMAGE_GATE_OVERRIDE_SECRET (or reuse ASYNC_REVIEW_WEBHOOK_SECRET).
+ */
+
+const TOKEN_TTL_MS = 15 * 60 * 1000; // 15 minutes
+
+function getSecret(): string {
+  return (
+    process.env.IMAGE_GATE_OVERRIDE_SECRET?.trim() ||
+    process.env.ASYNC_REVIEW_WEBHOOK_SECRET?.trim() ||
+    "dev-only-gate-override-secret"
+  );
+}
+
+export function issueGateOverrideToken(
+  imageHash: string,
+  now = Date.now()
+): string {
+  const expiresAt = now + TOKEN_TTL_MS;
+  const sig = createHmac("sha256", getSecret())
+    .update(`${imageHash}.${expiresAt}`)
+    .digest("hex");
+  return `${expiresAt}.${sig}`;
+}
+
+export function verifyGateOverrideToken(
+  token: string | undefined,
+  imageHash: string,
+  now = Date.now()
+): boolean {
+  if (!token) return false;
+
+  const dot = token.indexOf(".");
+  if (dot <= 0) return false;
+
+  const expiresAt = Number(token.slice(0, dot));
+  if (!Number.isFinite(expiresAt) || now > expiresAt) return false;
+
+  const expected = createHmac("sha256", getSecret())
+    .update(`${imageHash}.${expiresAt}`)
+    .digest();
+  // Decode the given signature to bytes; invalid hex yields a shorter buffer
+  // (Buffer.from stops at the first non-hex char) which the length guard below
+  // rejects, so timingSafeEqual never sees mismatched lengths.
+  const given = Buffer.from(token.slice(dot + 1), "hex");
+  if (given.length !== expected.length) return false;
+
+  return timingSafeEqual(given, expected);
+}

--- a/tests/gate-override-token.test.ts
+++ b/tests/gate-override-token.test.ts
@@ -1,0 +1,54 @@
+import {
+  issueGateOverrideToken,
+  verifyGateOverrideToken,
+} from "@/lib/symptom-chat/gate-override-token";
+
+const TTL_MS = 15 * 60 * 1000;
+const HASH = "abc123imagehash";
+
+describe("gate-override-token", () => {
+  it("verifies a freshly issued token for the same image hash", () => {
+    const token = issueGateOverrideToken(HASH);
+    expect(verifyGateOverrideToken(token, HASH)).toBe(true);
+  });
+
+  it("rejects a missing or empty token", () => {
+    expect(verifyGateOverrideToken(undefined, HASH)).toBe(false);
+    expect(verifyGateOverrideToken("", HASH)).toBe(false);
+  });
+
+  it("rejects a token bound to a different image hash (binding holds)", () => {
+    const token = issueGateOverrideToken(HASH);
+    expect(verifyGateOverrideToken(token, "a-different-image-hash")).toBe(false);
+  });
+
+  it("rejects an expired token but accepts it just before expiry (TTL holds)", () => {
+    const issuedAt = 1_700_000_000_000;
+    const token = issueGateOverrideToken(HASH, issuedAt);
+    expect(verifyGateOverrideToken(token, HASH, issuedAt + TTL_MS - 1)).toBe(
+      true
+    );
+    expect(verifyGateOverrideToken(token, HASH, issuedAt + TTL_MS + 1)).toBe(
+      false
+    );
+  });
+
+  it("rejects a tampered signature (HMAC holds)", () => {
+    const token = issueGateOverrideToken(HASH);
+    const dot = token.indexOf(".");
+    const tampered =
+      token.slice(0, dot + 1) + "0".repeat(token.length - dot - 1);
+    expect(verifyGateOverrideToken(tampered, HASH)).toBe(false);
+  });
+
+  it("rejects malformed / non-hex tokens without throwing", () => {
+    expect(verifyGateOverrideToken("nodotseparator", HASH)).toBe(false);
+    expect(verifyGateOverrideToken("123.deadbeef", HASH)).toBe(false);
+    // 64 chars of invalid hex (same string length as a real sha256 sig) must
+    // be rejected via the buffer-length guard, never throw inside timingSafeEqual.
+    const future = 1_700_000_000_000 + TTL_MS;
+    expect(
+      verifyGateOverrideToken(`${future}.${"z".repeat(64)}`, HASH, 1_700_000_000_000)
+    ).toBe(false);
+  });
+});

--- a/tests/symptom-chat.route.test.ts
+++ b/tests/symptom-chat.route.test.ts
@@ -788,6 +788,88 @@ describe("symptom-chat mixed text + image routing", () => {
     });
   });
 
+  describe("IMP-05: server-bound image gate override", () => {
+    const GATE_WARNING = {
+      reason: "blurry" as const,
+      topLabel: "blur",
+      topScore: 0.9,
+    };
+
+    function makeImageRequest(extra: Record<string, unknown> = {}) {
+      return new Request("http://localhost/api/ai/symptom-chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "chat",
+          pet: PET,
+          session: createSession(),
+          image: IMAGE,
+          imageMeta: {
+            width: 900,
+            height: 900,
+            blurScore: 30,
+            estimatedKb: 120,
+          },
+          messages: [
+            { role: "user", content: "my dog has a wound on its leg" },
+          ],
+          ...extra,
+        }),
+      });
+    }
+
+    it("returns image_gate + a token when gateOverride lacks a valid token", async () => {
+      mockShouldAnalyzeWoundImage.mockReturnValue(true);
+      mockEvaluateImageGate.mockResolvedValueOnce(GATE_WARNING);
+
+      const { POST } = await import("@/app/api/ai/symptom-chat/route");
+      const response = await POST(makeImageRequest({ gateOverride: true }));
+      const payload = await response.json();
+
+      expect(payload.type).toBe("image_gate");
+      expect(typeof payload.gate_override_token).toBe("string");
+      expect(payload.gate_override_token.length).toBeGreaterThan(0);
+    });
+
+    it("bypasses the gate when a valid token is echoed for the same image", async () => {
+      mockShouldAnalyzeWoundImage.mockReturnValue(true);
+      // Persistent (not Once): the gate WOULD warn on both requests, so only a
+      // valid token — not a consumed mock — can keep the 2nd out of image_gate.
+      mockEvaluateImageGate.mockResolvedValue(GATE_WARNING);
+
+      const { POST } = await import("@/app/api/ai/symptom-chat/route");
+      // First request is gated and receives a server-issued token.
+      const gated = await (await POST(makeImageRequest())).json();
+      expect(gated.type).toBe("image_gate");
+      const token = gated.gate_override_token;
+      expect(typeof token).toBe("string");
+
+      // Re-send the SAME image with that token -> gateOverrideAccepted is true,
+      // the gate block is skipped entirely, vision proceeds.
+      const response = await POST(
+        makeImageRequest({ gateOverride: true, gateOverrideToken: token })
+      );
+      const payload = await response.json();
+      expect(payload.type).not.toBe("image_gate");
+    });
+
+    it("rejects a garbage/expired override token (gate still runs)", async () => {
+      mockShouldAnalyzeWoundImage.mockReturnValue(true);
+      mockEvaluateImageGate.mockResolvedValueOnce(GATE_WARNING);
+
+      const { POST } = await import("@/app/api/ai/symptom-chat/route");
+      const response = await POST(
+        makeImageRequest({
+          gateOverride: true,
+          gateOverrideToken: "123.deadbeef",
+        })
+      );
+      const payload = await response.json();
+
+      expect(payload.type).toBe("image_gate");
+    });
+  });
+
   it("records sanitized route telemetry for rate-limited symptom-chat requests", async () => {
     mockCheckRateLimit.mockResolvedValue({
       success: false,


### PR DESCRIPTION
## IMP-05 — server-bind the gateOverride

Plan: `plans/improve/05-server-bind-image-gate-override.md`

> **Base = the IMP-02 branch** (#618), not master — Plans 02 and 05 are serial on `route.ts`. Retarget to master after #618 merges. The diff here is just Plan 05.

### Problem
The symptom-chat image quality gate was skipped whenever the client sent `gateOverride: true` — the server never verified it had actually gated **this** image. So any client could set `gateOverride: true` on the first request and bypass the gate for any image, defeating its purpose.

### Fix
Bind the override to a **server-issued HMAC token**:
- New `src/lib/symptom-chat/gate-override-token.ts` — stateless HMAC over `(imageHash, expiresAt)`, 15-min TTL, constant-time verify.
- The `image_gate` response now carries `gate_override_token`. An override is honored only when `gateOverride===true` **AND** `verifyGateOverrideToken(token, imageHash)` passes. A bare/forged/stale `gateOverride` now re-runs the gate and re-issues a fresh token instead of bypassing it.
- UI: stores the token from `image_gate` alongside `pendingGateImage`, echoes it from **"Analyze anyway"**, clears it with the image. **UX unchanged.**

### Hardening note
The plan's `verify` compared **hex-string** lengths before `timingSafeEqual`; a 64-char *invalid-hex* token would pass that check but make `Buffer.from(...,"hex")` shorter, and `timingSafeEqual` **throws** on unequal buffer lengths. This implementation compares **Buffer** lengths (digest as Buffer), so malformed tokens are rejected by the guard and never throw. Covered by a unit test.

### Files changed (5)
- **NEW** `src/lib/symptom-chat/gate-override-token.ts`
- `src/app/api/ai/symptom-chat/route.ts` — `gateOverrideAccepted` + token issuance (gate block / RequestBody / destructure / import only)
- `src/app/(dashboard)/symptom-checker/page.tsx` — token state + plumbing
- **NEW** `tests/gate-override-token.test.ts` — 6 unit tests
- `tests/symptom-chat.route.test.ts` — 3 route tests

### Verification
- `tests/gate-override-token.test.ts`: **6/6** — round-trip, image-hash **binding**, **TTL** boundary, **tamper**, malformed/non-hex **no-throw**
- IMP-05 route tests: **3/3** — token issued on gate; **valid-token bypass** (gate set to warn persistently, so only a real token keeps the 2nd request out of `image_gate`); garbage token rejected
- `npx tsc --noEmit` clean; `npx eslint` **0 errors**; symptom-chat suite at the unchanged pre-existing baseline (0 new failures)
- Thermo-review (maintainability + security): PASS

### ⚠️ Deployment note
Set **`IMAGE_GATE_OVERRIDE_SECRET`** (or reuse `ASYNC_REVIEW_WEBHOOK_SECRET`) in production. Without it the known dev-fallback secret is used (forgeable from source). This is a **quality** gate, not an auth boundary, so the risk is bounded (a low-quality image reaches vision analysis) — and the fallback keeps demo mode working with zero config.

### Out of scope
The gate evaluation logic (`evaluateAndCacheGate`, `evaluateImageGate`), vision pipeline behavior after a valid override, clinical files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)