### PR TITLE
chore(VET-1564): make product-intelligence schema apply-ready

### DIFF
--- a/docs/apply-product-intelligence-schema-runbook.md
+++ b/docs/apply-product-intelligence-schema-runbook.md
@@ -1,0 +1,70 @@
+# Apply Runbook — VET-1564 Product-Intelligence Schema
+
+Applies `supabase-product-intelligence-schema.sql` (the `daily_readiness_snapshots` and
+`recovery_checkpoints` tables behind the Whoop-style product-intelligence surface).
+
+> **Owner-gated.** This is a production database change. It must be run by the owner/operator,
+> not by an agent. The schema is review-only until applied through this runbook.
+
+## Preconditions (do not skip)
+
+1. **Same-project env (guards GitHub issue #582).** `DATABASE_URL` must reference the **same**
+   Supabase project as `NEXT_PUBLIC_SUPABASE_URL`. Applying this schema against a `DATABASE_URL`
+   that points at a different project than REST/Auth will create the tables in the wrong place and
+   the API route will read/write a project the app never serves. Verify first:
+   ```bash
+   npm run check:supabase-env
+   ```
+   Do not proceed while #582 (REST/Auth vs `DATABASE_URL` split-brain) is open.
+2. `pets` table exists in the target project (foreign-key target).
+3. You have a current backup / point-in-time-recovery window on the target project.
+
+## Apply
+
+```bash
+# from repo root, with .env.local pointing at the approved project
+npm run db:apply-product-intelligence-schema
+```
+
+The script (`scripts/apply-schema.mjs`) runs the file in a single connection. The schema is
+**idempotent** — every object uses `IF NOT EXISTS` / `CREATE OR REPLACE` / `DROP ... IF EXISTS`,
+so re-running it is safe.
+
+## Verify (RLS is the safety boundary)
+
+```sql
+-- both tables present with RLS on
+select relname, relrowsecurity
+from pg_class
+where relname in ('daily_readiness_snapshots', 'recovery_checkpoints');
+-- expect relrowsecurity = true for both
+
+-- ownership policies present (6 total: select/insert/update per table)
+select tablename, policyname, cmd
+from pg_policies
+where tablename in ('daily_readiness_snapshots', 'recovery_checkpoints')
+order by tablename, cmd;
+```
+
+Then run the live owner-scoped smoke against the snapshots route (owner GET/POST/GET + an
+unowned-pet read that must return 404/denied). RLS correctness is what stops cross-owner reads —
+confirm it before widening access.
+
+## Rollback
+
+These are additive tables with no app dependency until the route is exercised. To roll back:
+
+```sql
+drop table if exists public.recovery_checkpoints;
+drop table if exists public.daily_readiness_snapshots;
+drop function if exists public.set_product_intelligence_updated_at();
+```
+
+`ON DELETE CASCADE` on both foreign keys means tester rows are removed automatically when the owner
+or pet is deleted — there is no direct `DELETE` grant to `authenticated`.
+
+## Static contract guard
+
+`tests/product-intelligence-schema.test.ts` locks the safety shape of this file (RLS enabled,
+owner+pet-ownership scoping, cascade-only deletion, idempotent re-apply, pinned state vocabularies).
+Run `npm test -- tests/product-intelligence-schema.test.ts` after any edit to the SQL.

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "embed:corpus:images": "node scripts/embed-corpus.mjs --kind=images",
     "ingest:csv": "node scripts/ingest-csv-corpus.mjs",
     "db:apply-audio-schema": "node scripts/apply-schema.mjs supabase-audio-schema.sql",
+    "db:apply-product-intelligence-schema": "node scripts/apply-schema.mjs supabase-product-intelligence-schema.sql",
     "index:audio-corpus": "node scripts/index-audio-corpus.mjs",
     "eval:benchmark": "npx ts-node --esm scripts/eval-harness.ts --suite=data/benchmarks/dog-triage/wave3-freeze --allow-blocked",
     "eval:benchmark:dangerous": "npx ts-node --esm scripts/eval-harness.ts --suite=data/benchmarks/dog-triage/wave3-freeze --risk-tier=tier_1_emergency --allow-blocked",

--- a/tests/product-intelligence-schema.test.ts
+++ b/tests/product-intelligence-schema.test.ts
@@ -41,4 +41,56 @@ describe("product intelligence persistence schema", () => {
     expect(sql).not.toContain("prognosis promise");
     expect(sql).not.toContain("emergency clearance");
   });
+
+  // --- VET-1564 apply-readiness invariants (locked before production migration) ---
+
+  it("cascades both tables on owner and pet deletion (no orphaned tester data)", () => {
+    const sql = readFileSync(schemaPath, "utf8");
+
+    const cascades = sql.match(/REFERENCES (auth\.users|public\.pets)\(id\) ON DELETE CASCADE/g) ?? [];
+    // user_id + pet_id on each of the two tables = 4 cascading foreign keys.
+    expect(cascades.length).toBe(4);
+  });
+
+  it("removes tester rows by cascade only (no direct DELETE grant to authenticated)", () => {
+    const sql = readFileSync(schemaPath, "utf8");
+
+    expect(sql).not.toMatch(/GRANT[^;]*\bDELETE\b[^;]*TO authenticated/);
+  });
+
+  it("defines UPDATE policies, not just SELECT/INSERT", () => {
+    const sql = readFileSync(schemaPath, "utf8");
+
+    expect(sql).toContain("daily_readiness_snapshots_update_own");
+    expect(sql).toContain("recovery_checkpoints_update_own");
+  });
+
+  it("re-applies cleanly (idempotent triggers, function, and policies)", () => {
+    const sql = readFileSync(schemaPath, "utf8");
+
+    expect(sql).toContain("CREATE OR REPLACE FUNCTION public.set_product_intelligence_updated_at");
+    expect(sql).toContain("DROP TRIGGER IF EXISTS set_daily_readiness_snapshots_updated_at");
+    expect(sql).toContain("DROP TRIGGER IF EXISTS set_recovery_checkpoints_updated_at");
+    // Every policy is dropped before recreate so a second apply does not error.
+    const dropPolicies = sql.match(/DROP POLICY IF EXISTS/g) ?? [];
+    const createPolicies = sql.match(/CREATE POLICY/g) ?? [];
+    expect(createPolicies.length).toBeGreaterThanOrEqual(6);
+    expect(dropPolicies.length).toBe(createPolicies.length);
+  });
+
+  it("pins the readiness_state vocabulary to the product-intelligence state machine", () => {
+    const sql = readFileSync(schemaPath, "utf8");
+
+    for (const state of ["stable", "watch", "urgent", "unknown"]) {
+      expect(sql).toMatch(new RegExp(`readiness_state[\\s\\S]*?CHECK[\\s\\S]*?'${state}'`));
+    }
+  });
+
+  it("pins the recovery_status vocabulary to the recovery-checkpoint contract", () => {
+    const sql = readFileSync(schemaPath, "utf8");
+
+    for (const status of ["ready", "insufficient_evidence", "urgent_override"]) {
+      expect(sql).toMatch(new RegExp(`recovery_status[\\s\\S]*?CHECK[\\s\\S]*?'${status}'`));
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `db:apply-product-intelligence-schema` npm script (reuses canonical `scripts/apply-schema.mjs`)
- Extends `product-intelligence-schema.test.ts` with 6 new schema-contract assertions: cascade deletion, cascade-only (no direct DELETE grant), idempotent re-apply, UPDATE policies, pinned `readiness_state`/`recovery_status` enum vocabularies
- Adds owner-gated apply runbook (`docs/VET-1564-apply-runbook.md`) with explicit #582 same-project guard
- Schema SQL untouched — already idempotent + full RLS

## Verification
- **jest 9/9 pass**
- **tsc clean**
- **thermo-review PASS** — minimal additive change, reuses canonical helpers, no new abstraction

## Remaining blocker (not in scope of this PR)
Issue #582 must be resolved (prod Supabase REST/Auth and `DATABASE_URL` pointed at the same project) before the migration can actually be applied. The runbook documents this explicitly.

## Thermo-review verdict
PASS — no structural regression, no file-size explosion, no spaghetti, no boundary leak, reuses canonical apply-schema.mjs pattern.

## SIA
verifier=jest+tsc | trajectory=9/9 tests + typecheck clean | decision=harness update (new test coverage) | Goodhart guard=tests lock real safety invariants, not grader

## AutoScientists run
N/A — single focused change, no disputed root cause, no multi-agent decomposition needed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)