### PR TITLE
feat: add privacy, terms, and contact pages; wire footer links

### DIFF
--- a/src/app/(marketing)/contact/page.tsx
+++ b/src/app/(marketing)/contact/page.tsx
@@ -1,0 +1,85 @@
+import Link from "next/link";
+import { PawPrint, Mail } from "lucide-react";
+
+export const metadata = {
+  title: "Contact — PawVital AI",
+  description: "Get in touch with the PawVital team.",
+};
+
+export default function ContactPage() {
+  return (
+    <div className="min-h-screen bg-gray-950 text-gray-300">
+      <header className="border-b border-gray-800 bg-gray-900">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center gap-3">
+          <Link href="/" className="flex items-center gap-2">
+            <div className="w-8 h-8 bg-emerald-600 rounded-lg flex items-center justify-center">
+              <PawPrint className="w-5 h-5 text-white" />
+            </div>
+            <span className="text-white font-bold text-lg">PawVital AI</span>
+          </Link>
+        </div>
+      </header>
+
+      <main className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+        <h1 className="text-3xl font-bold text-white mb-4">Contact us</h1>
+        <p className="text-gray-400 mb-10">
+          We&apos;re a small team. The fastest way to reach us is email — we aim to reply within
+          one business day.
+        </p>
+
+        <div className="bg-gray-900 border border-gray-800 rounded-xl p-8">
+          <div className="flex items-start gap-4">
+            <div className="w-10 h-10 bg-emerald-900 rounded-lg flex items-center justify-center flex-shrink-0">
+              <Mail className="w-5 h-5 text-emerald-400" />
+            </div>
+            <div>
+              <h2 className="text-white font-semibold mb-1">Email support</h2>
+              <a
+                href="mailto:kandasubbarao4@gmail.com"
+                className="text-emerald-400 hover:text-emerald-300 transition-colors text-lg"
+              >
+                kandasubbarao4@gmail.com
+              </a>
+              <p className="text-gray-500 text-sm mt-2">
+                For billing, account issues, feedback, or data deletion requests.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-8 p-6 bg-amber-950/40 border border-amber-800/40 rounded-xl">
+          <p className="text-amber-400 font-medium mb-1">Veterinary emergency?</p>
+          <p className="text-gray-400 text-sm">
+            If your dog needs urgent care, do not wait for a reply — contact your vet or
+            nearest emergency animal hospital immediately. PawVital is triage guidance, not
+            emergency dispatch.
+          </p>
+        </div>
+
+        <div className="mt-10 space-y-2 text-sm text-gray-500">
+          <p>
+            Looking for our{" "}
+            <Link href="/privacy" className="text-emerald-400 hover:text-emerald-300 transition-colors">
+              Privacy Policy
+            </Link>{" "}
+            or{" "}
+            <Link href="/terms" className="text-emerald-400 hover:text-emerald-300 transition-colors">
+              Terms of Service
+            </Link>
+            ?
+          </p>
+        </div>
+      </main>
+
+      <footer className="border-t border-gray-800 mt-20 py-8 text-center text-sm text-gray-600">
+        <p>
+          <Link href="/" className="hover:text-gray-400 transition-colors">Home</Link>
+          {" · "}
+          <Link href="/privacy" className="hover:text-gray-400 transition-colors">Privacy</Link>
+          {" · "}
+          <Link href="/terms" className="hover:text-gray-400 transition-colors">Terms</Link>
+        </p>
+      </footer>
+    </div>
+  );
+}

--- a/src/app/(marketing)/privacy/page.tsx
+++ b/src/app/(marketing)/privacy/page.tsx
@@ -1,0 +1,138 @@
+import Link from "next/link";
+import { PawPrint } from "lucide-react";
+
+export const metadata = {
+  title: "Privacy Policy — PawVital AI",
+  description: "How PawVital collects, uses, and protects your information.",
+};
+
+export default function PrivacyPage() {
+  return (
+    <div className="min-h-screen bg-gray-950 text-gray-300">
+      <header className="border-b border-gray-800 bg-gray-900">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center gap-3">
+          <Link href="/" className="flex items-center gap-2">
+            <div className="w-8 h-8 bg-emerald-600 rounded-lg flex items-center justify-center">
+              <PawPrint className="w-5 h-5 text-white" />
+            </div>
+            <span className="text-white font-bold text-lg">PawVital AI</span>
+          </Link>
+        </div>
+      </header>
+
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+        <h1 className="text-3xl font-bold text-white mb-2">Privacy Policy</h1>
+        <p className="text-sm text-gray-500 mb-10">Effective date: June 16, 2026</p>
+
+        <div className="space-y-10 text-gray-300 leading-relaxed">
+          <section>
+            <h2 className="text-xl font-semibold text-white mb-3">1. What we collect</h2>
+            <p>
+              When you create an account we collect your email address and the password hash
+              managed by Supabase Auth. When you use the symptom checker we store the
+              conversation history, extracted symptom data, urgency assessments, and any photos
+              you upload — all associated with your account.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white mb-3">2. How we use it</h2>
+            <ul className="list-disc list-inside space-y-1 ml-2">
+              <li>To operate the symptom triage and vet-handoff report features</li>
+              <li>To send account and session notifications you have opted into</li>
+              <li>To improve the accuracy of our canine clinical matrix (anonymised, aggregated only)</li>
+              <li>To fulfil legal obligations and prevent abuse</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white mb-3">3. Storage and security</h2>
+            <p>
+              Data is stored in Supabase (PostgreSQL) with row-level security policies that
+              prevent any user from reading another user&apos;s records. Images are stored in
+              Supabase Storage with per-owner access controls. We use HTTPS for all data in
+              transit.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white mb-3">4. Third-party services</h2>
+            <p>We use the following third-party services to operate PawVital:</p>
+            <ul className="list-disc list-inside space-y-1 ml-2 mt-2">
+              <li>
+                <strong className="text-gray-100">Supabase</strong> — database, auth, and file
+                storage
+              </li>
+              <li>
+                <strong className="text-gray-100">Vercel</strong> — hosting and edge functions
+              </li>
+              <li>
+                <strong className="text-gray-100">Anthropic / Azure OpenAI</strong> — AI model
+                inference (your symptom text is sent to these services)
+              </li>
+              <li>
+                <strong className="text-gray-100">Stripe</strong> — payment processing (we do
+                not store card numbers)
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white mb-3">5. Your rights</h2>
+            <p>
+              You may request export or deletion of your data at any time by emailing{" "}
+              <a
+                href="mailto:kandasubbarao4@gmail.com"
+                className="text-emerald-400 hover:text-emerald-300 transition-colors"
+              >
+                kandasubbarao4@gmail.com
+              </a>
+              . We will action deletion requests within 30 days.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white mb-3">6. Children</h2>
+            <p>PawVital is not directed at children under 13 and we do not knowingly collect data from them.</p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white mb-3">7. Changes</h2>
+            <p>
+              We will post any changes here with an updated effective date. Continued use after
+              the date constitutes acceptance.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white mb-3">8. Contact</h2>
+            <p>
+              Questions?{" "}
+              <Link href="/contact" className="text-emerald-400 hover:text-emerald-300 transition-colors">
+                Contact us
+              </Link>{" "}
+              or email{" "}
+              <a
+                href="mailto:kandasubbarao4@gmail.com"
+                className="text-emerald-400 hover:text-emerald-300 transition-colors"
+              >
+                kandasubbarao4@gmail.com
+              </a>
+              .
+            </p>
+          </section>
+        </div>
+      </main>
+
+      <footer className="border-t border-gray-800 mt-20 py-8 text-center text-sm text-gray-600">
+        <p>
+          <Link href="/" className="hover:text-gray-400 transition-colors">Home</Link>
+          {" · "}
+          <Link href="/terms" className="hover:text-gray-400 transition-colors">Terms</Link>
+          {" · "}
+          <Link href="/contact" className="hover:text-gray-400 transition-colors">Contact</Link>
+        </p>
+      </footer>
+    </div>
+  );
+}

--- a/src/app/(marketing)/terms/page.tsx
+++ b/src/app/(marketing)/terms/page.tsx
@@ -1,0 +1,130 @@
+import Link from "next/link";
+import { PawPrint } from "lucide-react";
+
+export const metadata = {
+  title: "Terms of Service — PawVital AI",
+  description: "Terms governing your use of PawVital AI.",
+};
+
+export default function TermsPage() {
+  return (
+    <div className="min-h-screen bg-gray-950 text-gray-300">
+      <header className="border-b border-gray-800 bg-gray-900">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center gap-3">
+          <Link href="/" className="flex items-center gap-2">
+            <div className="w-8 h-8 bg-emerald-600 rounded-lg flex items-center justify-center">
+              <PawPrint className="w-5 h-5 text-white" />
+            </div>
+            <span className="text-white font-bold text-lg">PawVital AI</span>
+          </Link>
+        </div>
+      </header>
+
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+        <h1 className="text-3xl font-bold text-white mb-2">Terms of Service</h1>
+        <p className="text-sm text-gray-500 mb-10">Effective date: June 16, 2026</p>
+
+        <div className="space-y-10 text-gray-300 leading-relaxed">
+          <section>
+            <h2 className="text-xl font-semibold text-white mb-3">1. Not veterinary advice</h2>
+            <p className="font-medium text-amber-400">
+              PawVital is not a veterinarian and does not provide veterinary diagnosis or
+              treatment. Output is triage guidance only.
+            </p>
+            <p className="mt-2">
+              If your dog is in immediate danger — struggling to breathe, collapsed, bleeding
+              heavily, having seizures, or unable to urinate — contact a veterinarian or
+              emergency animal hospital immediately. Do not use PawVital as a substitute for
+              emergency care.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white mb-3">2. Eligibility</h2>
+            <p>
+              You must be 18 or older to create an account. By using PawVital you confirm you
+              are not using the service on behalf of a veterinary practice for clinical
+              diagnosis.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white mb-3">3. Account</h2>
+            <p>
+              You are responsible for keeping your login credentials secure. Notify us
+              immediately if you suspect unauthorized use of your account. We reserve the right
+              to suspend accounts that violate these terms.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white mb-3">4. Acceptable use</h2>
+            <p>You agree not to:</p>
+            <ul className="list-disc list-inside space-y-1 ml-2 mt-2">
+              <li>Attempt to extract or reverse-engineer the clinical matrix</li>
+              <li>Abuse the API or submit automated bulk requests</li>
+              <li>Upload content that is illegal or violates third-party rights</li>
+              <li>Misrepresent PawVital output as a formal veterinary diagnosis</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white mb-3">5. Subscription and billing</h2>
+            <p>
+              Paid plans are billed monthly. You may cancel at any time from your account
+              settings. Cancellation takes effect at the end of the current billing period.
+              We do not offer prorated refunds for partial months unless required by applicable
+              law.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white mb-3">6. Limitation of liability</h2>
+            <p>
+              To the fullest extent permitted by law, PawVital and its operators are not liable
+              for any harm to your pet arising from reliance on triage guidance provided by the
+              service. Use PawVital as one input among many — your vet has the full picture.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white mb-3">7. Changes to these terms</h2>
+            <p>
+              We may update these terms at any time. We will notify registered users by email
+              and update the effective date above. Continued use after changes constitutes
+              acceptance.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white mb-3">8. Contact</h2>
+            <p>
+              Questions?{" "}
+              <Link href="/contact" className="text-emerald-400 hover:text-emerald-300 transition-colors">
+                Contact us
+              </Link>{" "}
+              or email{" "}
+              <a
+                href="mailto:kandasubbarao4@gmail.com"
+                className="text-emerald-400 hover:text-emerald-300 transition-colors"
+              >
+                kandasubbarao4@gmail.com
+              </a>
+              .
+            </p>
+          </section>
+        </div>
+      </main>
+
+      <footer className="border-t border-gray-800 mt-20 py-8 text-center text-sm text-gray-600">
+        <p>
+          <Link href="/" className="hover:text-gray-400 transition-colors">Home</Link>
+          {" · "}
+          <Link href="/privacy" className="hover:text-gray-400 transition-colors">Privacy</Link>
+          {" · "}
+          <Link href="/contact" className="hover:text-gray-400 transition-colors">Contact</Link>
+        </p>
+      </footer>
+    </div>
+  );
+}

--- a/src/components/landing/footer.tsx
+++ b/src/components/landing/footer.tsx
@@ -73,19 +73,19 @@ export default function Footer() {
             <h3 className="text-white font-semibold mb-4">Legal</h3>
             <ul className="space-y-2">
               <li>
-                <a href="#" className="hover:text-white transition-colors">
+                <Link href="/privacy" className="hover:text-white transition-colors">
                   Privacy Policy
-                </a>
+                </Link>
               </li>
               <li>
-                <a href="#" className="hover:text-white transition-colors">
+                <Link href="/terms" className="hover:text-white transition-colors">
                   Terms of Service
-                </a>
+                </Link>
               </li>
               <li>
-                <a href="#" className="hover:text-white transition-colors">
+                <Link href="/contact" className="hover:text-white transition-colors">
                   Contact
-                </a>
+                </Link>
               </li>
             </ul>
           </div>


### PR DESCRIPTION
## Summary
- `/privacy` — 8-section Privacy Policy covering data collection, storage, RLS, third-party services (Supabase, Vercel, Anthropic/Azure, Stripe), user rights (deletion within 30 days), and contact
- `/terms` — 8-section Terms of Service with prominent not-veterinary-advice warning highlighted in amber, eligibility, acceptable use, billing/cancellation, and liability cap
- `/contact` — email contact card with veterinary-emergency callout and cross-links to legal pages
- `footer.tsx` — replaces three `href="#"` placeholder anchors with proper Next.js `<Link>` components pointing to `/privacy`, `/terms`, `/contact`

## Verification
- All three pages confirmed rendering in dev server snapshot (no console errors)
- `/privacy` title: "Privacy Policy — PawVital AI" ✓
- `/terms` title: "Terms of Service — PawVital AI" ✓
- `/contact` title: "Contact — PawVital AI" ✓, email link + emergency callout present ✓
- Footer cross-links verified in accessibility tree

## Thermo-review
Docs/pages only — no clinical, API, or runtime logic touched. Minimal, additive.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)