### PR TITLE
fix(watcher): resolve TDZ crashes in bypass-merge daemon

### DIFF
--- a/scripts/agent-watcher.mjs
+++ b/scripts/agent-watcher.mjs
@@ -46,6 +46,9 @@ const STATE_FILE = join(STATE_DIR, 'state.json');
 const TASKS_DIR = join(REPO_ROOT, '.agent-tasks');
 const LOG_FILE = join(STATE_DIR, 'watcher.log');
 const PID_FILE = join(STATE_DIR, 'watcher.pid');
+const BYPASS_PID_FILE = join(STATE_DIR, 'bypass-merge.pid');
+const BYPASS_LOG_FILE = join(STATE_DIR, 'bypass-merge.log');
+const BYPASS_MERGE_INTERVAL = parseInt(process.env.BYPASS_MERGE_INTERVAL || '90', 10) * 1000;
 
 // Agent CLI dispatch map
 const CLI_AGENTS = {
@@ -588,6 +591,46 @@ async function mainLoop() {
 
 const args = process.argv.slice(2);
 
+// --bypass-merge must be evaluated before all single-flag handlers (--stop,
+// --once, --daemon) to prevent them from intercepting the combined flags.
+if (args.includes('--bypass-merge')) {
+  if (args.includes('--daemon')) {
+    ensureDir(STATE_DIR);
+    const child = spawn(process.execPath, [__filename, '--bypass-merge'], {
+      cwd: REPO_ROOT,
+      detached: true,
+      stdio: 'ignore',
+      env: { ...process.env, _WATCHER_DAEMON: '1' },
+    });
+    child.unref();
+    writeFileSync(BYPASS_PID_FILE, String(child.pid));
+    console.log(`Bypass-merge daemon started (PID ${child.pid})`);
+    console.log(`Log:  ${BYPASS_LOG_FILE}`);
+    console.log('Stop: node scripts/agent-watcher.mjs --bypass-merge --stop');
+    process.exit(0);
+  }
+  if (args.includes('--stop')) {
+    if (existsSync(BYPASS_PID_FILE)) {
+      const pid = readFileSync(BYPASS_PID_FILE, 'utf8').trim();
+      try { process.kill(parseInt(pid, 10)); console.log(`Stopped bypass-merge daemon (PID ${pid})`); }
+      catch (e) { console.log(`Could not stop PID ${pid}: ${e.message}`); }
+      try { unlinkSync(BYPASS_PID_FILE); } catch { /* ignore */ }
+    } else {
+      console.log('No bypass-merge daemon running.');
+    }
+    process.exit(0);
+  }
+  if (args.includes('--once')) {
+    blogLine('Running single bypass-merge check...');
+    await pollBypassMerge();
+    blogLine('Done.');
+    process.exit(0);
+  }
+  // Foreground loop (used by the detached child process started above)
+  await bypassMergeLoop();
+  process.exit(0);
+}
+
 if (args.includes('--status')) {
   const state = loadState();
   const prCount = Object.keys(state.prs).length;
@@ -634,43 +677,7 @@ if (args.includes('--stop')) {
   process.exit(0);
 }
 
-if (args.includes('--bypass-merge')) {
-  if (args.includes('--daemon')) {
-    ensureDir(STATE_DIR);
-    const child = spawn(process.execPath, [__filename, '--bypass-merge'], {
-      cwd: REPO_ROOT,
-      detached: true,
-      stdio: 'ignore',
-      env: { ...process.env, _WATCHER_DAEMON: '1' },
-    });
-    child.unref();
-    writeFileSync(BYPASS_PID_FILE, String(child.pid));
-    console.log(`Bypass-merge daemon started (PID ${child.pid})`);
-    console.log(`Log:  ${BYPASS_LOG_FILE}`);
-    console.log('Stop: node scripts/agent-watcher.mjs --bypass-merge --stop');
-    process.exit(0);
-  }
-  if (args.includes('--stop')) {
-    if (existsSync(BYPASS_PID_FILE)) {
-      const pid = readFileSync(BYPASS_PID_FILE, 'utf8').trim();
-      try { process.kill(parseInt(pid, 10)); console.log(`Stopped bypass-merge daemon (PID ${pid})`); }
-      catch (e) { console.log(`Could not stop PID ${pid}: ${e.message}`); }
-      try { unlinkSync(BYPASS_PID_FILE); } catch { /* ignore */ }
-    } else {
-      console.log('No bypass-merge daemon running.');
-    }
-    process.exit(0);
-  }
-  if (args.includes('--once')) {
-    blogLine('Running single bypass-merge check...');
-    await pollBypassMerge();
-    blogLine('Done.');
-    process.exit(0);
-  }
-  // Foreground loop
-  await bypassMergeLoop();
-  process.exit(0);
-}
+
 
 if (args.includes('--once')) {
   log('Running single check...');
@@ -704,10 +711,6 @@ if (args.includes('--daemon')) {
 // Bypass-merge mode: merge open PRs with admin flag when Actions is disabled
 // ---------------------------------------------------------------------------
 
-const BYPASS_MERGE_INTERVAL = parseInt(process.env.BYPASS_MERGE_INTERVAL || '90', 10) * 1000;
-const BYPASS_PID_FILE = join(STATE_DIR, 'bypass-merge.pid');
-const BYPASS_LOG_FILE = join(STATE_DIR, 'bypass-merge.log');
-
 function blogLine(msg) {
   const ts = new Date().toISOString().replace('T', ' ').slice(0, 19);
   const line = `[${ts}] ${msg}`;
@@ -725,10 +728,18 @@ function bypassMergePR(pr) {
     return;
   }
   try {
-    const out = gh(`pr merge ${pr.number} --merge --admin`);
-    blogLine(`  ✓ Merged PR #${pr.number}${out ? ': ' + out.split('\n')[0] : ''}`);
+    // Use execSync directly so a non-zero exit (conflict, already merged, etc.) throws
+    execSync(`gh pr merge ${pr.number} --merge --admin`, {
+      encoding: 'utf8',
+      cwd: REPO_ROOT,
+      timeout: 30000,
+      env: { ...process.env, GH_NO_UPDATE_NOTIFIER: '1' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    blogLine(`  ✓ Merged PR #${pr.number}`);
   } catch (e) {
-    blogLine(`  ✗ Failed to merge PR #${pr.number}: ${e.message}`);
+    const msg = (e.stderr || e.stdout || e.message || '').split('\n')[0].trim();
+    blogLine(`  ✗ Failed PR #${pr.number}: ${msg}`);
   }
 }
 


### PR DESCRIPTION
## Summary
Fixes three `ReferenceError: Cannot access before initialization` crashes that prevented the bypass-merge daemon from starting.

**Root cause:** Three `const` declarations (`BYPASS_PID_FILE`, `BYPASS_LOG_FILE`, `BYPASS_MERGE_INTERVAL`) were placed after the CLI section but referenced by code in it. JavaScript `const` has temporal dead zone — unlike `function` declarations, `const` is not hoisted.

**Fix:** Moved all three to the top constants block (lines 49-51). Also moved the `--bypass-merge` CLI check before `--status`/`--stop` so combined flags like `--bypass-merge --stop` aren't intercepted by the single-flag handlers that fired first.

## Verified
- `npm run pr:bypass-merge-daemon` → starts cleanly, prints PID + log path
- `npm run pr:bypass-merge-stop` → stops daemon cleanly
- `WATCHER_DRY_RUN=1 npm run pr:bypass-merge` → lists eligible PRs, skips bots/drafts/conflicts

🤖 Generated with [Claude Code](https://claude.ai/claude-code)