### PR TITLE
fix(symptom-chat): fix repeat question, urgency escalation, and Got-it prefix

### DIFF
--- a/src/lib/symptom-chat/answer-extraction.ts
+++ b/src/lib/symptom-chat/answer-extraction.ts
@@ -191,6 +191,10 @@ export function deriveDeterministicAnswerForQuestion(
       return extractRestlessness(rawMessage);
     case "onset_during_exercise":
       return extractOnsetDuringExercise(rawMessage);
+    case "lethargy_severity":
+      return extractLethargySeverity(rawMessage);
+    case "abdomen_pain":
+      return extractAbdomenPain(rawMessage);
     default:
       return null;
   }
@@ -1025,6 +1029,58 @@ function extractOnsetDuringExercise(rawMessage: string): string | null {
     )
   ) {
     return "during";
+  }
+
+  return null;
+}
+
+function extractLethargySeverity(rawMessage: string): string | null {
+  const lower = rawMessage.toLowerCase();
+
+  if (
+    /\b(lies there|barely moves?|not moving|won'?t move|can'?t get up|unable to get up|collapse|collapsed|won'?t stand|not standing)\b/.test(
+      lower
+    )
+  ) {
+    return "severe";
+  }
+
+  if (
+    /\b(somewhat lethargic|pretty tired|quite tired|moderately lethargic|a (bit|little) more lethargic)\b/.test(
+      lower
+    )
+  ) {
+    return "moderate";
+  }
+
+  if (
+    /\b(less active than usual|a (bit|little) slow(?:er)?|slightly less active|not as active|low energy|tired but)\b/.test(
+      lower
+    )
+  ) {
+    return "mild";
+  }
+
+  return null;
+}
+
+function extractAbdomenPain(rawMessage: string): boolean | null {
+  const lower = rawMessage.toLowerCase();
+
+  if (
+    /\b(yelped|cried out|flinched|winced|react(?:s|ed) when|painful when|sore (belly|abdomen|stomach)|pain when (touched|pressed)|sensitive (belly|abdomen|stomach))\b/.test(
+      lower
+    )
+  ) {
+    return true;
+  }
+
+  if (
+    /\b(doesn'?t react|no (pain|reaction|sensitivity)|not sensitive|not painful|not sore)\b/.test(
+      lower
+    )
+  ) {
+    return false;
   }
 
   return null;

--- a/src/lib/symptom-chat/question-phrasing.ts
+++ b/src/lib/symptom-chat/question-phrasing.ts
@@ -200,7 +200,7 @@ REQUIRED QUESTION:
 - Answer type: ${answerType}
 
 WRITE EXACTLY 2 SENTENCES:
-1. One brief acknowledgment that SPECIFICALLY references 1-2 of the confirmed answers above (e.g. "Since ${pet.name} has been drinking less than usual and this has been going on for 3 days..."). Do NOT write a generic "I'm keeping track" phrase.
+1. One acknowledgment sentence that SPECIFICALLY references 1-2 of the confirmed answers above in a full contextual sentence (e.g. "Since ${pet.name} has been vomiting for two days and has stopped eating..."). Do NOT start with "Got it", "Got it —", "Okay", "Understood", or any short echo of the extracted value alone. Write a complete sentence that sets the clinical context.
 2. Ask the exact required question in caring, simple language.
 
 HARD RULES:

--- a/src/lib/triage-engine.ts
+++ b/src/lib/triage-engine.ts
@@ -435,7 +435,9 @@ function isRedFlagTriggered(flag: string, session: TriageSession): boolean {
         "just started",
       ]) ||
       (session.known_symptoms.includes("swollen_abdomen") &&
-        answers.restlessness === true);
+        answers.restlessness === true) ||
+      (session.known_symptoms.includes("swollen_abdomen") &&
+        answers.abdomen_pain === true);
     case "unresponsive":
       return answers.consciousness_level === "unresponsive";
     default:


### PR DESCRIPTION
## Summary
- P1 repeat question bug: Add extractLethargySeverity() and extractAbdomenPain() — questions now marked answered on first reply
- P1 urgency escalation: Add abdomen_pain condition to rapid_onset_distension red flag — GDV fires on pain-on-touch too
- P2 Got-it prefix: Prompt now bans echoed-value openers, requires full contextual sentence

Tests: 161/161 pass. TypeScript clean.