### PR TITLE
fix(phrasing): strip Got-it opener in sanitizeQuestionDraft

### DIFF
--- a/src/lib/symptom-chat/question-phrasing.ts
+++ b/src/lib/symptom-chat/question-phrasing.ts
@@ -72,6 +72,17 @@ export function sanitizeQuestionDraft(
     return fallbackMessage;
   }
 
+  // Strip lazy "Got it — value." / "Okay." / "Understood." openers that echo
+  // the extracted answer instead of writing a proper contextual sentence.
+  // Keep everything from the first real sentence onward (must contain the "?").
+  const strippedOpener = cleaned.replace(
+    /^(Got it[\s—–\-][^\.\?!]*?[\.\?!]\s*|(?:Got it|Okay|Understood|Noted|Sure|Alright)[\.\?!]\s*)/i,
+    ""
+  );
+  if (strippedOpener.includes("?")) {
+    return strippedOpener.trim();
+  }
+
   return cleaned;
 }
 


### PR DESCRIPTION
## Summary
- Code-level filter strips 'Got it — value.' / 'Okay.' / 'Understood.' style first sentences from Llama output
- Llama ignores the prompt-level rule; this sanitizer catches it downstream
- If the stripped remainder still contains '?' the filtered version is returned, otherwise falls through to original

## Tests
- 421/421 tests pass, TypeScript clean