### PR TITLE
fix(phrasing): replace regex opener-strip with character-scan

### DIFF
--- a/src/lib/symptom-chat/question-phrasing.ts
+++ b/src/lib/symptom-chat/question-phrasing.ts
@@ -72,17 +72,25 @@ export function sanitizeQuestionDraft(
     return fallbackMessage;
   }
 
-  // Strip lazy "Got it — value." / "Okay." / "Understood." openers that echo
-  // the extracted answer instead of writing a proper contextual sentence.
-  // Keep everything from the first real sentence onward (must contain the "?").
-  // Match "Got it — anything here." or standalone "Okay." / "Understood." etc.
-  // Uses [^?]*? so it stops at the first period/exclamation before any question mark.
-  const strippedOpener = cleaned.replace(
-    /^(?:Got it|Okay|Understood|Noted|Sure|Alright)[^?]*?[.!]\s*/i,
-    ""
-  );
-  if (strippedOpener.includes("?")) {
-    return strippedOpener.trim();
+  // Strip lazy "Got it — value." / "Okay — value." / etc. openers.
+  // Uses a character-scan to find the first ASCII sentence boundary (". " or "! ")
+  // rather than a regex quantifier, to avoid any compiled-JS edge cases.
+  if (/^(?:Got it|Okay|Understood|Noted|Sure|Alright)\b/i.test(cleaned)) {
+    let sentenceStart = -1;
+    for (let i = 0; i < cleaned.length - 1; i++) {
+      if ((cleaned[i] === "." || cleaned[i] === "!") && cleaned[i + 1] === " ") {
+        sentenceStart = i + 2;
+        break;
+      }
+    }
+    if (sentenceStart > 0) {
+      const rest = cleaned.substring(sentenceStart).trim();
+      if (rest.includes("?")) {
+        console.log("[sanitize] opener stripped →", rest.substring(0, 60));
+        return rest;
+      }
+    }
+    console.log("[sanitize] opener detected but no boundary found:", cleaned.substring(0, 80));
   }
 
   return cleaned;


### PR DESCRIPTION
## Summary
- Replaces the lazy-quantifier regex `/^(?:Got it|...)[^?]*?[.!]\s*/i` with an explicit character-scan that finds the first ASCII `. ` or `! ` sentence boundary
- Adds a `console.log` so the strip is visible in Vercel runtime logs for diagnosis
- All 626 tests passing, TypeScript clean

## Root cause hypothesis
The previous regex was confirmed correct in Node.js locally against all unicode dash variants. The character-scan approach removes any potential compiled-lambda quantifier edge case.

## Test plan
- [ ] Deploy and run 2-turn production test — confirm no "Got it —" in response
- [ ] Check Vercel runtime logs for `[sanitize] opener stripped` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)