### PR TITLE
fix(phrasing): add authoritative opener strip at response boundary

### DIFF
--- a/src/lib/symptom-chat/question-response-flow.ts
+++ b/src/lib/symptom-chat/question-response-flow.ts
@@ -68,9 +68,14 @@ export async function buildQuestionResponseFlow(
     nextQuestionId: input.nextQuestionId,
   });
 
+  // Final safety strip: remove any "Got it — X." / "Okay." / "Understood." opener
+  // that survived phrasing model sanitization. Acts as the authoritative last gate
+  // before the message reaches the client.
+  const safeMessage = stripOpenerPhrase(phrasedQuestion);
+
   return NextResponse.json({
     type: "question",
-    message: phrasedQuestion,
+    message: safeMessage,
     session: sanitizeSessionForClient(session),
     ready_for_report: isReadyForDiagnosis(session),
     conversationState: input.needsClarificationQuestionId
@@ -79,6 +84,26 @@ export async function buildQuestionResponseFlow(
     asking_because: input.askingBecause ?? session.case_memory?.asking_because ?? null,
     prompt_vet_record: Boolean(input.promptVetRecord),
   });
+}
+
+function stripOpenerPhrase(text: string): string {
+  if (!/^(?:Got it|Okay|Understood|Noted|Sure|Alright)\b/i.test(text)) return text;
+  // Find the first ASCII sentence boundary (". " or "! ") after the opener
+  const ptIdx = text.indexOf(". ");
+  const exIdx = text.indexOf("! ");
+  const boundary =
+    ptIdx >= 0 && exIdx >= 0
+      ? Math.min(ptIdx, exIdx) + 2
+      : ptIdx >= 0
+        ? ptIdx + 2
+        : exIdx >= 0
+          ? exIdx + 2
+          : -1;
+  if (boundary <= 0) return text;
+  const rest = text.substring(boundary).trim();
+  if (!rest.includes("?")) return text;
+  console.log("[flow] opener stripped:", text.substring(0, 70));
+  return rest;
 }
 
 function buildNoQuestionPayload(

--- a/tests/symptom-chat.route.test.ts
+++ b/tests/symptom-chat.route.test.ts
@@ -1314,7 +1314,7 @@ describe("symptom-chat mixed text + image routing", () => {
       "EXPLICITLY REFERENCE PHOTO IN WORDING: NO"
     );
     expect(payload.message).toBe(
-      "Got it — left leg. How big is the affected area? Compare to a coin, golf ball, or your palm."
+      "How big is the affected area? Compare to a coin, golf ball, or your palm."
     );
     expect(payload.message).not.toContain("photo");
   });
@@ -1339,7 +1339,7 @@ describe("symptom-chat mixed text + image routing", () => {
     expect(response.status).toBe(200);
     expect(payload.type).toBe("question");
     expect(payload.message).toBe(
-      "Got it — left leg. How big is the affected area? Compare to a coin, golf ball, or your palm."
+      "How big is the affected area? Compare to a coin, golf ball, or your palm."
     );
     expect(mockPhraseWithLlama).not.toHaveBeenCalled();
     expect(mockVerifyQuestionWithNemotron).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Adds `stripOpenerPhrase()` in `question-response-flow.ts` as the last gate before any question message reaches the client
- Removes "Got it — X.", "Okay — X.", etc. openers regardless of what phrasing models produce
- Adds `console.log('[flow] opener stripped')` so any strip is visible in Vercel logs
- Updates 2 tests that had locked in the old "Got it —" mock output

## Root cause
Previous `sanitizeQuestionDraft` fixes in `question-phrasing.ts` were not taking effect in production — likely the Vercel Turbopack build cache served the old compiled chunk despite source changes. This fix is in a different file (`question-response-flow.ts`) that is guaranteed to recompile.

## Test plan
- [x] 618 tests passing, TypeScript clean
- [ ] Deploy and run 5-turn limping test — confirm 0 opener failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)