### PR TITLE
fix(triage): deeper adaptive questioning — stop concluding after ~3 questions (Ticket 1)

### DIFF
--- a/src/app/api/ai/symptom-chat/route.ts
+++ b/src/app/api/ai/symptom-chat/route.ts
@@ -13,6 +13,7 @@ import {
   getMissingQuestions,
   getQuestionText,
   getExtractionSchema,
+  hasMinimumDiagnosticInfo,
   isReadyForDiagnosis,
   buildDiagnosisContext,
   type TriageSession,
@@ -1570,7 +1571,7 @@ export async function POST(request: Request) {
         });
       }
 
-      if (!isReadyForDiagnosis(session)) {
+      if (!hasMinimumDiagnosticInfo(session)) {
         statusCode = 409;
         return NextResponse.json(
           {

--- a/src/lib/clinical-matrix.ts
+++ b/src/lib/clinical-matrix.ts
@@ -2432,6 +2432,20 @@ export const BREED_MODIFIERS: Record<string, BreedModifiers> = {
 // --- FOLLOW-UP QUESTION DEFINITIONS ---
 
 export const FOLLOW_UP_QUESTIONS: Record<string, FollowUpQuestion> = {
+  // Generic open-ended context capture. Asked once, after the structured
+  // follow-ups for the known symptoms are exhausted, so an owner who still has
+  // more to share is invited to add it instead of being cut off with an abrupt
+  // "I have enough information". Deliberately NOT linked to any disease or
+  // urgency mapping — it only widens the history before the report.
+  additional_context: {
+    id: "additional_context",
+    question_text:
+      "Before I put the report together — is there anything else you've noticed about your pet? Even small changes in appetite, energy, mood, drinking, or bathroom habits can matter, even if they seem unrelated.",
+    data_type: "string",
+    extraction_hint:
+      "any additional symptoms, changes, or context the owner volunteers",
+    critical: false,
+  },
   // Limping questions
   which_leg: {
     id: "which_leg",

--- a/src/lib/symptom-chat/question-response-flow.ts
+++ b/src/lib/symptom-chat/question-response-flow.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import {
   getQuestionText,
-  isReadyForDiagnosis,
+  hasMinimumDiagnosticInfo,
   type PetProfile,
   type TriageSession,
 } from "@/lib/triage-engine";
@@ -78,7 +78,7 @@ export async function buildQuestionResponseFlow(
     type: "question",
     message: safeMessage,
     session: sanitizeSessionForClient(session),
-    ready_for_report: isReadyForDiagnosis(session),
+    ready_for_report: hasMinimumDiagnosticInfo(session),
     conversationState: input.needsClarificationQuestionId
       ? "needs_clarification"
       : inferConversationState(getStateSnapshot(session)),

--- a/src/lib/triage-engine.ts
+++ b/src/lib/triage-engine.ts
@@ -245,12 +245,19 @@ export function getNextQuestion(session: TriageSession): string | null {
     (qId) => FOLLOW_UP_QUESTIONS[qId]?.critical
   );
 
+  // Inline readiness check — avoids mutual recursion with isReadyForDiagnosis.
+  // Ask trajectory when there is still more to gather (missing follow-ups or
+  // the capture turn hasn't been offered), mirroring what isReadyForDiagnosis
+  // would return without calling getNextQuestion.
+  const captureAlreadyOfferedForTrajectory =
+    session.answered_questions.includes(ADDITIONAL_CONTEXT_QUESTION_ID) ||
+    session.last_question_asked === ADDITIONAL_CONTEXT_QUESTION_ID;
   if (
     hasSymptoms &&
     sufficientHistory &&
     trajectoryNotAsked &&
     !hasPendingCriticalQuestion &&
-    !isReadyForDiagnosis(session)
+    (missing.length > 0 || !captureAlreadyOfferedForTrajectory)
   ) {
     return "condition_progression";
   }
@@ -1156,11 +1163,27 @@ export function isReadyForDiagnosis(session: TriageSession): boolean {
   // only a slightly less rich one.
   if (session.answered_questions.length >= MAX_QUESTIONS_BEFORE_READY) return true;
 
-  // Otherwise ready only when there is genuinely nothing left to ask. This now
-  // covers non-critical follow-ups and the one open-ended capture turn (see
-  // getNextQuestion), so we keep gathering context instead of stopping the
-  // moment the critical questions are cleared.
-  return getNextQuestion(session) === null;
+  // Ready only when there is genuinely nothing left to ask: no missing
+  // follow-ups, trajectory asked (or session too short for it), and the capture
+  // turn offered. Inlined here — NOT via getNextQuestion — to avoid mutual
+  // recursion (getNextQuestion calls isReadyForDiagnosis in the trajectory
+  // guard; calling back would overflow the call stack).
+  const missingForReady = getMissingQuestions(session);
+  if (missingForReady.length > 0) return false;
+
+  const sufficientHistoryForReady =
+    session.answered_questions.length >= MIN_QUESTIONS_BEFORE_READY;
+  const trajectoryNotAskedForReady =
+    !session.answered_questions.includes("condition_progression") &&
+    !session.last_question_asked?.includes("condition_progression");
+  if (sufficientHistoryForReady && trajectoryNotAskedForReady) return false;
+
+  const captureAlreadyOfferedForReady =
+    session.answered_questions.includes(ADDITIONAL_CONTEXT_QUESTION_ID) ||
+    session.last_question_asked === ADDITIONAL_CONTEXT_QUESTION_ID;
+  if (!captureAlreadyOfferedForReady) return false;
+
+  return true;
 }
 
 /**

--- a/src/lib/triage-engine.ts
+++ b/src/lib/triage-engine.ts
@@ -167,6 +167,18 @@ export function createSession(): TriageSession {
   };
 }
 
+// --- Question Flow Tuning ---
+// A real vet asks at least a few follow-ups before concluding, and keeps
+// gathering context (not just clearing red flags) up to a bounded ceiling.
+const MIN_QUESTIONS_BEFORE_READY = 3;
+const MAX_QUESTIONS_BEFORE_READY = 12;
+/**
+ * Generic open-ended capture turn, offered once when the structured follow-ups
+ * run out — see getNextQuestion / isReadyForDiagnosis. The entry itself lives in
+ * clinical-matrix's FOLLOW_UP_QUESTIONS.
+ */
+const ADDITIONAL_CONTEXT_QUESTION_ID = "additional_context";
+
 /**
  * Given known symptoms, return all required follow-up questions
  * minus ones already answered.
@@ -218,15 +230,16 @@ export function getMissingQuestions(session: TriageSession): string[] {
  */
 export function getNextQuestion(session: TriageSession): string | null {
   const missing = getMissingQuestions(session);
-
-  // Ask the trajectory question once — after ≥3 answered and not yet asked — but
-  // only once no CRITICAL follow-up is still pending. "Is it getting worse?" must
-  // never preempt an essential clinical question (gum colour, spay status, etc.).
-  // This also keeps getNextQuestion consistent with isReadyForDiagnosis, which
-  // gates on the critical-question contract.
   const hasSymptoms = session.known_symptoms.length > 0;
-  const sufficientHistory = session.answered_questions.length >= 3;
-  const trajectoryNotAsked = !session.answered_questions.includes("condition_progression") &&
+  const answeredCount = session.answered_questions.length;
+
+  // Hard ceiling: never keep asking past the bounded maximum.
+  if (answeredCount >= MAX_QUESTIONS_BEFORE_READY) return null;
+
+  // Ask the trajectory question once — after the minimum history and not yet asked.
+  const sufficientHistory = answeredCount >= MIN_QUESTIONS_BEFORE_READY;
+  const trajectoryNotAsked =
+    !session.answered_questions.includes("condition_progression") &&
     !session.last_question_asked?.includes("condition_progression");
   const hasPendingCriticalQuestion = missing.some(
     (qId) => FOLLOW_UP_QUESTIONS[qId]?.critical
@@ -242,29 +255,43 @@ export function getNextQuestion(session: TriageSession): string | null {
     return "condition_progression";
   }
 
-  if (missing.length === 0) return null;
+  // Prefer the most informative structured follow-up still missing. The pool
+  // includes non-critical follow-ups (getMissingQuestions surfaces them once the
+  // criticals are answered), so we keep narrowing instead of stopping early.
+  if (missing.length > 0) {
+    // Score each question by how many candidate diseases it helps narrow down
+    const scored = missing.map((qId, index) => {
+      let relevanceScore = 0;
+      const qDef = FOLLOW_UP_QUESTIONS[qId];
 
-  // Score each question by how many candidate diseases it helps narrow down
-  const scored = missing.map((qId, index) => {
-    let relevanceScore = 0;
-    const qDef = FOLLOW_UP_QUESTIONS[qId];
+      // Higher score for critical questions
+      if (qDef?.critical) relevanceScore += 10;
 
-    // Higher score for critical questions
-    if (qDef?.critical) relevanceScore += 10;
-
-    // Count how many current symptoms reference this question, weighted by urgency
-    for (const symptom of session.known_symptoms) {
-      const entry = SYMPTOM_MAP[symptom];
-      if (entry?.follow_up_questions.includes(qId)) {
-        relevanceScore += 5 + getSymptomPriorityScore(symptom);
+      // Count how many current symptoms reference this question, weighted by urgency
+      for (const symptom of session.known_symptoms) {
+        const entry = SYMPTOM_MAP[symptom];
+        if (entry?.follow_up_questions.includes(qId)) {
+          relevanceScore += 5 + getSymptomPriorityScore(symptom);
+        }
       }
-    }
 
-    return { qId, score: relevanceScore, index };
-  });
+      return { qId, score: relevanceScore, index };
+    });
 
-  scored.sort((a, b) => b.score - a.score || a.index - b.index);
-  return scored[0]?.qId || null;
+    scored.sort((a, b) => b.score - a.score || a.index - b.index);
+    return scored[0]?.qId || null;
+  }
+
+  // Structured follow-ups exhausted: offer one open-ended capture turn so an
+  // owner who still has more to share isn't cut off abruptly. Asked at most once.
+  const captureAlreadyOffered =
+    session.answered_questions.includes(ADDITIONAL_CONTEXT_QUESTION_ID) ||
+    session.last_question_asked === ADDITIONAL_CONTEXT_QUESTION_ID;
+  if (hasSymptoms && !captureAlreadyOffered) {
+    return ADDITIONAL_CONTEXT_QUESTION_ID;
+  }
+
+  return null;
 }
 
 /**
@@ -1120,17 +1147,46 @@ export function isReadyForDiagnosis(session: TriageSession): boolean {
   // NEVER ready if no symptoms identified yet
   if (session.known_symptoms.length === 0) return false;
 
-  // NEVER ready if fewer than 3 questions have been answered
-  // A real vet always asks at least a few follow-up questions
-  if (session.answered_questions.length < 3) return false;
+  // Bounded: once the hard ceiling is reached, conclude regardless. A
+  // non-emergency critical could in theory still be unanswered here, but the
+  // dangerous ones (emergency-grade criticals) remain enforced downstream by
+  // findReportBlockingCriticalInfo on the report path — so the ceiling can never
+  // release a dangerously premature report, only a slightly less rich one.
+  if (session.answered_questions.length >= MAX_QUESTIONS_BEFORE_READY) return true;
 
-  // Check if all critical questions are answered
-  const missing = getMissingQuestions(session);
-  const criticalMissing = missing.filter((qId) => {
-    const qDef = FOLLOW_UP_QUESTIONS[qId];
-    return qDef?.critical;
-  });
+  // Otherwise ready only when there is genuinely nothing left to ask. This now
+  // covers non-critical follow-ups and the one open-ended capture turn (see
+  // getNextQuestion), so we keep gathering context instead of stopping the
+  // moment the critical questions are cleared.
+  return getNextQuestion(session) === null;
+}
 
+/**
+ * Permissive readiness: does the case hold the *minimum* critical information
+ * needed to produce a safe report, even if optional follow-ups remain?
+ *
+ * Use this when the OWNER explicitly asks for a report (the "generate_report"
+ * action) or to decide whether to surface a "get the report now" affordance.
+ * It is intentionally distinct from isReadyForDiagnosis: the latter governs
+ * when the engine stops asking *on its own* (and now keeps gathering optional
+ * context first), while this lets an owner bail out to a report as soon as the
+ * case is minimally sufficient. Red flags and the critical-question contract
+ * are still required — this never lets a dangerously premature report through.
+ */
+export function hasMinimumDiagnosticInfo(session: TriageSession): boolean {
+  if (
+    session.red_flags_triggered.length > 0 ||
+    getCompositeEmergencyRedFlags(session).length > 0
+  ) {
+    return true;
+  }
+
+  if (session.known_symptoms.length === 0) return false;
+  if (session.answered_questions.length < MIN_QUESTIONS_BEFORE_READY) return false;
+
+  const criticalMissing = getMissingQuestions(session).filter(
+    (qId) => FOLLOW_UP_QUESTIONS[qId]?.critical
+  );
   return criticalMissing.length === 0;
 }
 

--- a/src/lib/triage-engine.ts
+++ b/src/lib/triage-engine.ts
@@ -1148,10 +1148,12 @@ export function isReadyForDiagnosis(session: TriageSession): boolean {
   if (session.known_symptoms.length === 0) return false;
 
   // Bounded: once the hard ceiling is reached, conclude regardless. A
-  // non-emergency critical could in theory still be unanswered here, but the
-  // dangerous ones (emergency-grade criticals) remain enforced downstream by
-  // findReportBlockingCriticalInfo on the report path — so the ceiling can never
-  // release a dangerously premature report, only a slightly less rich one.
+  // non-emergency critical could in theory still be unanswered here, but EVERY
+  // report — owner-requested or auto-concluded (the client re-issues
+  // generate_report after a "ready" turn) — funnels through the unbounded
+  // findReportBlockingCriticalInfo gate, which still blocks on emergency-grade
+  // criticals. So the ceiling can never release a dangerously premature report,
+  // only a slightly less rich one.
   if (session.answered_questions.length >= MAX_QUESTIONS_BEFORE_READY) return true;
 
   // Otherwise ready only when there is genuinely nothing left to ask. This now

--- a/tests/symptom-chat.route.test.ts
+++ b/tests/symptom-chat.route.test.ts
@@ -8661,8 +8661,11 @@ describe("VET-900: world-class symptom checker regression pack", () => {
 
       const readySession = recordAnswer(session, "gum_color", "pink_normal");
 
-      expect(isReadyForDiagnosis(readySession)).toBe(true);
-      expect(getNextQuestion(readySession)).toBeNull();
+      // All critical questions answered. PR-640 extended the conversation:
+      // trajectory and then the capture turn are offered before isReadyForDiagnosis
+      // returns true. The key clinical gate (blocked without gum_color) still holds.
+      expect(isReadyForDiagnosis(readySession)).toBe(false);
+      expect(getNextQuestion(readySession)).toBe("condition_progression");
     });
 
     it("routes the supported gum-color branch through one alternate observable retry before emergency", async () => {

--- a/tests/triage-engine.adaptive-questioning.test.ts
+++ b/tests/triage-engine.adaptive-questioning.test.ts
@@ -70,6 +70,30 @@ describe("Ticket 1 — deeper adaptive questioning", () => {
     expect(isReadyForDiagnosis(session)).toBe(true);
   });
 
+  it("does not re-offer the capture turn when only last_question_asked records it", () => {
+    // Production path: the capture turn is ASKED (last_question_asked set) but a
+    // long free-text reply is NOT persisted into answered_questions. Termination
+    // then relies solely on the last_question_asked half of the guard.
+    let session = createSession();
+    session = addSymptoms(session, ["wound_skin_issue"]);
+
+    let guard = 0;
+    while (guard < 30) {
+      const q = getNextQuestion(session);
+      if (!q || q === ADDITIONAL_CONTEXT_ID) break;
+      session = recordAnswer(session, q, "no");
+      guard++;
+    }
+    expect(getNextQuestion(session)).toBe(ADDITIONAL_CONTEXT_ID);
+
+    // Simulate "asked but reply not persisted as an answer".
+    session.last_question_asked = ADDITIONAL_CONTEXT_ID;
+    expect(session.answered_questions).not.toContain(ADDITIONAL_CONTEXT_ID);
+
+    expect(getNextQuestion(session)).toBeNull();
+    expect(isReadyForDiagnosis(session)).toBe(true);
+  });
+
   it("still concludes immediately when a red flag fires (regression guard)", () => {
     let session = createSession();
     session = addSymptoms(session, ["vomiting"]);

--- a/tests/triage-engine.adaptive-questioning.test.ts
+++ b/tests/triage-engine.adaptive-questioning.test.ts
@@ -1,0 +1,124 @@
+import {
+  createSession,
+  addSymptoms,
+  recordAnswer,
+  getNextQuestion,
+  getMissingQuestions,
+  isReadyForDiagnosis,
+  type TriageSession,
+} from "@/lib/triage-engine";
+import { FOLLOW_UP_QUESTIONS } from "@/lib/clinical-matrix";
+
+const ADDITIONAL_CONTEXT_ID = "additional_context";
+const MAX_QUESTIONS = 12; // mirrors MAX_QUESTIONS_BEFORE_READY in triage-engine
+
+// Ticket 1 — deeper adaptive questioning.
+// The engine must keep asking targeted follow-ups (not stop the moment the
+// critical questions clear), offer one open-ended capture turn before
+// concluding, stay bounded, and still short-circuit on red flags.
+describe("Ticket 1 — deeper adaptive questioning", () => {
+  it("registers a non-critical, free-text open-ended capture question", () => {
+    const q = FOLLOW_UP_QUESTIONS[ADDITIONAL_CONTEXT_ID];
+    expect(q).toBeDefined();
+    expect(q.critical).toBe(false);
+    expect(q.data_type).toBe("string");
+  });
+
+  it("does not conclude the moment the critical questions are cleared", () => {
+    let session = createSession();
+    session = addSymptoms(session, ["wound_skin_issue"]);
+
+    const criticalsRemain = (s: TriageSession) =>
+      getMissingQuestions(s).some((id) => FOLLOW_UP_QUESTIONS[id]?.critical);
+
+    let guard = 0;
+    while (criticalsRemain(session) && guard < 20) {
+      const q = getNextQuestion(session);
+      if (!q) break;
+      session = recordAnswer(session, q, "no");
+      guard++;
+    }
+
+    // With the criticals answered, there is still more to gather (non-critical
+    // follow-ups and/or the capture turn) — the engine must not be "ready" yet.
+    expect(session.answered_questions.length).toBeLessThan(MAX_QUESTIONS);
+    expect(isReadyForDiagnosis(session)).toBe(false);
+    expect(getNextQuestion(session)).not.toBeNull();
+  });
+
+  it("offers the open-ended capture turn exactly once, then concludes", () => {
+    let session = createSession();
+    session = addSymptoms(session, ["wound_skin_issue"]);
+
+    // Drain every structured follow-up (criticals, non-criticals, trajectory).
+    let guard = 0;
+    while (guard < 30) {
+      const q = getNextQuestion(session);
+      if (!q || q === ADDITIONAL_CONTEXT_ID) break;
+      session = recordAnswer(session, q, "no");
+      guard++;
+    }
+
+    // We must reach the capture turn before the hard ceiling.
+    expect(session.answered_questions.length).toBeLessThan(MAX_QUESTIONS);
+    expect(getNextQuestion(session)).toBe(ADDITIONAL_CONTEXT_ID);
+    expect(isReadyForDiagnosis(session)).toBe(false);
+
+    // After it is answered, the engine concludes and never re-asks it.
+    session = recordAnswer(session, ADDITIONAL_CONTEXT_ID, "nothing else really");
+    expect(getNextQuestion(session)).toBeNull();
+    expect(isReadyForDiagnosis(session)).toBe(true);
+  });
+
+  it("still concludes immediately when a red flag fires (regression guard)", () => {
+    let session = createSession();
+    session = addSymptoms(session, ["vomiting"]);
+    session = recordAnswer(session, "vomit_blood", true);
+    expect(session.red_flags_triggered.length).toBeGreaterThan(0);
+    expect(isReadyForDiagnosis(session)).toBe(true);
+  });
+
+  it("is bounded — concludes at the hard ceiling even if questions remain", () => {
+    let session = createSession();
+    session = addSymptoms(session, ["wound_skin_issue"]);
+    // Force the answered count to the ceiling with synthetic ids.
+    session.answered_questions = Array.from(
+      { length: MAX_QUESTIONS },
+      (_, i) => `synthetic_q_${i}`
+    );
+    expect(getNextQuestion(session)).toBeNull();
+    expect(isReadyForDiagnosis(session)).toBe(true);
+  });
+
+  it("never exceeds the ceiling while draining a multi-symptom case", () => {
+    let session = createSession();
+    session = addSymptoms(session, ["vomiting", "not_eating"]);
+    let guard = 0;
+    while (!isReadyForDiagnosis(session) && guard < 40) {
+      const q = getNextQuestion(session);
+      if (!q) break;
+      session = recordAnswer(session, q, "no");
+      guard++;
+    }
+    expect(isReadyForDiagnosis(session)).toBe(true);
+    expect(session.answered_questions.length).toBeLessThanOrEqual(MAX_QUESTIONS);
+  });
+
+  it("keeps isReadyForDiagnosis consistent with getNextQuestion in the normal band", () => {
+    let session = createSession();
+    session = addSymptoms(session, ["wound_skin_issue"]);
+    for (let i = 0; i < 8; i++) {
+      if (
+        session.answered_questions.length < MAX_QUESTIONS &&
+        session.red_flags_triggered.length === 0
+      ) {
+        expect(isReadyForDiagnosis(session)).toBe(
+          getNextQuestion(session) === null
+        );
+      }
+      const q = getNextQuestion(session);
+      if (!q) break;
+      session = recordAnswer(session, q, "no");
+    }
+  });
+});


### PR DESCRIPTION
## Ticket 1 of the symptom-checker depth/calibration program

**Problem (reported):** the symptom checker stops asking after ~3 questions, feels vague, and when the owner wants to add more it goes blank and concludes. Root cause: `isReadyForDiagnosis` flipped to ready the moment ≥3 questions were answered and the *critical* follow-ups cleared — non-critical follow-ups never blocked readiness, and an empty pool forced a cold "I have enough information."

### What changed
- **`getNextQuestion`** now asks: trajectory question → scored structured follow-ups (criticals **then non-criticals**) → **one open-ended capture turn** (`additional_context`: "is there anything else you've noticed?") → done. Bounded by a hard ceiling of **12** questions.
- **`isReadyForDiagnosis`** (auto-conclude) returns true only when red flags fire, the ceiling is hit, or there is genuinely nothing left to ask — so the engine keeps gathering context instead of stopping at criticals.
- **New `hasMinimumDiagnosticInfo`** (the *old* readiness semantics: red flags OR ≥3 answered AND all criticals answered) gates the explicit `generate_report` action and the `ready_for_report` affordance — so an owner can still **bail to a report any time** once minimally sufficient.
- Adds one generic, **non-critical, disease-unlinked** `additional_context` question.

**Red-flag / urgency / disease logic unchanged. Determinism preserved.**

### Verification
- 7 new behavior tests + **171** existing triage/orchestration/flow tests pass
- Route suites: only **7 pre-existing failures** (byte-identical on clean master), **0 new**
- `tsc` clean; `eslint` 0 errors
- **Clinical-reviewer: approve-with-nits, no required changes** — independently confirmed red flags can't be delayed (detection runs every turn, before the ready/question logic) and the emergency-grade critical contract still gates report generation via the unbounded `findReportBlockingCriticalInfo`.

> Note: master `82b39b7` currently has 7 failing tests in `symptom-chat.route.test.ts` independent of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)