### PR TITLE
fix: repair all 17 pre-existing master test failures (route trajectory + GI registry)

### DIFF
--- a/docs/clinical-intelligence/question-card-gap-proposal-pack-kimi.md
+++ b/docs/clinical-intelligence/question-card-gap-proposal-pack-kimi.md
@@ -11,7 +11,7 @@
 
 VET-1424K identified eight candidate complaint-module areas that are **blocked** because they lack dedicated question-card coverage. This document converts those blockers into exact, implementation-ready question-card proposals.
 
-**Current registry:** 26 question cards, 35 canonical red flags, 14 clinical signals.
+**Current registry:** 29 question cards, 35 canonical red flags, 14 clinical signals.
 
 *Note: 7 of the 24 proposed cards were implemented by VET-1432K (`heat_exposure_check`, `brachycephalic_breed_check`, `panting_excess_check`, `trauma_mechanism_check`, `wound_characterization_check`, `bleeding_volume_check`, `laceration_depth_check`). The remaining 17 proposed cards are still pending implementation.*
 **Rule:** Every proposed ID below is prefixed with `(PROPOSED)` in this document. None are registered in `question-card-registry.ts` at the time of writing.

--- a/src/lib/clinical-intelligence/question-card-registry.ts
+++ b/src/lib/clinical-intelligence/question-card-registry.ts
@@ -22,6 +22,9 @@ import {
   giVomitingFrequency,
   giBloodCheck,
   giKeepWaterDownCheck,
+  recentDietChange,
+  currentMedications,
+  priorSimilarEpisode,
 } from "./question-cards/gi";
 
 import {
@@ -59,6 +62,9 @@ const SOURCE_CARDS: readonly ClinicalQuestionCard[] = [
   giVomitingFrequency,
   giBloodCheck,
   giKeepWaterDownCheck,
+  recentDietChange,
+  currentMedications,
+  priorSimilarEpisode,
   limpingWeightBearing,
   limpingTraumaOnset,
   urinaryStrainingOutput,

--- a/src/lib/clinical-intelligence/question-cards/gi.ts
+++ b/src/lib/clinical-intelligence/question-cards/gi.ts
@@ -86,3 +86,84 @@ export const giKeepWaterDownCheck: ClinicalQuestionCard = {
 
   sourceIds: ["internal_pending_review"],
 };
+
+export const recentDietChange: ClinicalQuestionCard = {
+  id: "recent_diet_change",
+  ownerText:
+    "Has your dog had any recent change in food, snacks, or table scraps, or gotten into something they shouldn't have (garbage, compost, or a new chew)?",
+  shortReason:
+    "A recent change in what your pet ate or getting into something unusual is one of the most common reasons for a sudden upset stomach.",
+
+  complaintFamilies: ["gastrointestinal", "vomiting", "diarrhea", "gi"],
+  bodySystems: ["gastrointestinal"],
+
+  phase: "history",
+
+  ownerAnswerability: 3,
+  urgencyImpact: 1,
+  discriminativeValue: 2,
+  reportValue: 2,
+
+  screensRedFlags: [],
+  changesUrgencyIf: {},
+
+  answerType: "free_text",
+
+  skipIfAnswered: ["gi_vomiting_frequency"],
+
+  sourceIds: ["internal_pending_review"],
+};
+
+export const currentMedications: ClinicalQuestionCard = {
+  id: "current_medications",
+  ownerText:
+    "Is your dog currently on any medicines or supplements (including flea and tick products, pain relievers, or anything started by another vet)?",
+  shortReason:
+    "Knowing what your pet is currently receiving gives the veterinary team important context about the digestive signs.",
+
+  complaintFamilies: ["gastrointestinal", "vomiting", "diarrhea", "gi"],
+  bodySystems: ["gastrointestinal"],
+
+  phase: "history",
+
+  ownerAnswerability: 3,
+  urgencyImpact: 1,
+  discriminativeValue: 2,
+  reportValue: 2,
+
+  screensRedFlags: [],
+  changesUrgencyIf: {},
+
+  answerType: "free_text",
+
+  skipIfAnswered: ["gi_vomiting_frequency"],
+
+  sourceIds: ["internal_pending_review"],
+};
+
+export const priorSimilarEpisode: ClinicalQuestionCard = {
+  id: "prior_similar_episode",
+  ownerText:
+    "Has your dog had a similar vomiting or diarrhea episode before? If so, how long did it last and how did it get better?",
+  shortReason:
+    "A history of similar past episodes helps the veterinary team understand whether this is a recurring pattern.",
+
+  complaintFamilies: ["gastrointestinal", "vomiting", "diarrhea", "gi"],
+  bodySystems: ["gastrointestinal"],
+
+  phase: "history",
+
+  ownerAnswerability: 3,
+  urgencyImpact: 1,
+  discriminativeValue: 2,
+  reportValue: 2,
+
+  screensRedFlags: [],
+  changesUrgencyIf: {},
+
+  answerType: "free_text",
+
+  skipIfAnswered: ["gi_vomiting_frequency"],
+
+  sourceIds: ["internal_pending_review"],
+};

--- a/src/lib/triage-engine.ts
+++ b/src/lib/triage-engine.ts
@@ -219,13 +219,26 @@ export function getMissingQuestions(session: TriageSession): string[] {
 export function getNextQuestion(session: TriageSession): string | null {
   const missing = getMissingQuestions(session);
 
-  // Ask trajectory question once — after ≥3 questions answered and not yet asked
+  // Ask the trajectory question once — after ≥3 answered and not yet asked — but
+  // only once no CRITICAL follow-up is still pending. "Is it getting worse?" must
+  // never preempt an essential clinical question (gum colour, spay status, etc.).
+  // This also keeps getNextQuestion consistent with isReadyForDiagnosis, which
+  // gates on the critical-question contract.
   const hasSymptoms = session.known_symptoms.length > 0;
   const sufficientHistory = session.answered_questions.length >= 3;
   const trajectoryNotAsked = !session.answered_questions.includes("condition_progression") &&
     !session.last_question_asked?.includes("condition_progression");
+  const hasPendingCriticalQuestion = missing.some(
+    (qId) => FOLLOW_UP_QUESTIONS[qId]?.critical
+  );
 
-  if (hasSymptoms && sufficientHistory && trajectoryNotAsked) {
+  if (
+    hasSymptoms &&
+    sufficientHistory &&
+    trajectoryNotAsked &&
+    !hasPendingCriticalQuestion &&
+    !isReadyForDiagnosis(session)
+  ) {
     return "condition_progression";
   }
 

--- a/tests/clinical-intelligence/heat-trauma-question-cards.test.ts
+++ b/tests/clinical-intelligence/heat-trauma-question-cards.test.ts
@@ -28,9 +28,9 @@ describe("VET-1432K Heatstroke and Trauma Question Cards", () => {
       }
     });
 
-    it("registry size increased from 19 to 26", () => {
+    it("registry size is 29 (19 base + heat-trauma pack + GI history cards)", () => {
       const cards = getAllQuestionCards();
-      expect(cards.length).toBe(26);
+      expect(cards.length).toBe(29);
     });
 
     it("new cards are retrievable by id", () => {

--- a/tests/clinical-intelligence/question-card-gap-proposal-pack.test.ts
+++ b/tests/clinical-intelligence/question-card-gap-proposal-pack.test.ts
@@ -212,12 +212,12 @@ const CANDIDATE_PROPOSALS: readonly CandidateProposal[] = [
 
 describe("Question Card Gap Proposal Pack (VET-1429K packaging)", () => {
   it("locks the current live registry counts in the proposal doc", () => {
-    expect(getAllQuestionCards()).toHaveLength(26);
+    expect(getAllQuestionCards()).toHaveLength(29);
     expect(EMERGENCY_RED_FLAG_IDS).toHaveLength(35);
     expect(KNOWN_SIGNAL_IDS).toHaveLength(14);
 
     expect(PROPOSAL_DOC).toContain(
-      "26 question cards, 35 canonical red flags, 14 clinical signals."
+      "29 question cards, 35 canonical red flags, 14 clinical signals."
     );
     expect(PROPOSAL_DOC).not.toContain("37 canonical red flags");
   });


### PR DESCRIPTION
## Repairs master's broken test suite (unblocks all open PRs)

Master (`82b39b7`, the "8 roadmap steps" merge) shipped with **17 failing tests**. Until they're fixed, CI is red and no PR can auto-merge. This PR fixes all 17.

### 1. Route flow — 7 failures (`symptom-chat.route.test.ts`)
The `condition_progression` trajectory question ("is it getting worse?") was preempting **critical** clinical questions (gum colour, spay status) after 3 answers. Fix: it now defers until no critical follow-up is pending **and** the case isn't already ready — criticals always come first. (Pure deterministic control-flow; no urgency/red-flag logic changed.)

### 2. Question-card registry — 10 failures + 2 count tripwires (`clinical-intelligence/*`)
`giVomitingDiarrheaModule` referenced three question-card IDs that were never registered. Rather than delete the references (which would *remove* valuable GI history questions — dietary indiscretion is a top cause of vomiting/diarrhea), this **adds** them as proper non-critical history cards: `recent_diet_change`, `current_medications`, `prior_similar_episode`. Registry count tripwires bumped 26→29 (the sanctioned mechanism for reviewed growth).

### Verification
- **1941/1941** pass across `symptom-chat.route` + `triage-engine` + `clinical-intelligence`
- `tsc` clean; new cards carry no red-flag/urgency wiring (validators green)

Merge this first; the three feature PRs (#640, #641, #642) rebase onto it and go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)