### PR TITLE
feat(clinical): breed-specific question cards and planner scoring (Ticket 4)

### DIFF
--- a/docs/clinical-intelligence/question-card-gap-proposal-pack-kimi.md
+++ b/docs/clinical-intelligence/question-card-gap-proposal-pack-kimi.md
@@ -11,9 +11,11 @@
 
 VET-1424K identified eight candidate complaint-module areas that are **blocked** because they lack dedicated question-card coverage. This document converts those blockers into exact, implementation-ready question-card proposals.
 
-**Current registry:** 29 question cards, 35 canonical red flags, 14 clinical signals.
+**Current registry:** 31 question cards, 35 canonical red flags, 14 clinical signals.
 
 *Note: 7 of the 24 proposed cards were implemented by VET-1432K (`heat_exposure_check`, `brachycephalic_breed_check`, `panting_excess_check`, `trauma_mechanism_check`, `wound_characterization_check`, `bleeding_volume_check`, `laceration_depth_check`). The remaining 17 proposed cards are still pending implementation.*
+
+*Note: 2 additional breed-targeted cards were added by the breed-specific questions ticket (`long_back_breed_spinal_check`, `deep_chested_breed_abdomen_check`); these are not part of the original 24-card proposal pack and bring the live registry total to 31.*
 **Rule:** Every proposed ID below is prefixed with `(PROPOSED)` in this document. None are registered in `question-card-registry.ts` at the time of writing.
 
 ---

--- a/src/lib/clinical-intelligence/next-question-planner.ts
+++ b/src/lib/clinical-intelligence/next-question-planner.ts
@@ -25,6 +25,13 @@ export interface PlannerOptions {
   maxQuestionsPerTurn?: number;
   preferredQuestionIds?: string[];
   discouragedQuestionIds?: string[];
+  /**
+   * The pet's breed, threaded through from the turn orchestrator. When set, a
+   * card whose `breedFamilies` matches the breed (case-insensitive substring)
+   * receives a small deterministic relevance boost. Purely additive — it never
+   * changes urgency, red-flag, or emergency-screen behavior.
+   */
+  petBreed?: string | null;
 }
 
 export interface PlannerFallbackResult {
@@ -47,6 +54,29 @@ const OFF_TOPIC_PENALTY = 15;
 const TOO_MANY_QUESTIONS_PENALTY = 10;
 const PREFERRED_QUESTION_BONUS = 20;
 const DISCOURAGED_QUESTION_PENALTY = 40;
+const BREED_RELEVANCE_BONUS = 12;
+
+function cardMatchesBreed(
+  card: ClinicalQuestionCard,
+  petBreed: string | null | undefined
+): boolean {
+  if (!petBreed || !card.breedFamilies || card.breedFamilies.length === 0) {
+    return false;
+  }
+
+  const normalizedBreed = petBreed.toLowerCase();
+  if (normalizedBreed.trim().length === 0) {
+    return false;
+  }
+
+  return card.breedFamilies.some((keyword) => {
+    const normalizedKeyword = keyword.toLowerCase().trim();
+    return (
+      normalizedKeyword.length > 0 &&
+      normalizedBreed.includes(normalizedKeyword)
+    );
+  });
+}
 
 function isQuestionAlreadyAnswered(
   card: ClinicalQuestionCard,
@@ -205,6 +235,12 @@ export function buildQuestionScoreBreakdown(
     breakdown["discouragedQuestionPenalty"] = -DISCOURAGED_QUESTION_PENALTY;
   } else {
     breakdown["discouragedQuestionPenalty"] = 0;
+  }
+
+  if (cardMatchesBreed(card, options?.petBreed)) {
+    breakdown["breedRelevance"] = BREED_RELEVANCE_BONUS;
+  } else {
+    breakdown["breedRelevance"] = 0;
   }
 
   return breakdown;

--- a/src/lib/clinical-intelligence/question-card-registry.ts
+++ b/src/lib/clinical-intelligence/question-card-registry.ts
@@ -46,6 +46,11 @@ import {
   lacerationDepthCheck,
 } from "./question-cards/heat-trauma";
 
+import {
+  longBackBreedSpinalCheck,
+  deepChestedBreedAbdomenCheck,
+} from "./question-cards/breed";
+
 const SOURCE_CARDS: readonly ClinicalQuestionCard[] = [
   emergencyGlobalScreen,
   gumColorCheck,
@@ -76,6 +81,8 @@ const SOURCE_CARDS: readonly ClinicalQuestionCard[] = [
   woundCharacterizationCheck,
   bleedingVolumeCheck,
   lacerationDepthCheck,
+  longBackBreedSpinalCheck,
+  deepChestedBreedAbdomenCheck,
 ];
 
 function cloneQuestionCard(card: ClinicalQuestionCard): ClinicalQuestionCard {
@@ -84,6 +91,7 @@ function cloneQuestionCard(card: ClinicalQuestionCard): ClinicalQuestionCard {
       ...card,
       complaintFamilies: [...card.complaintFamilies],
       bodySystems: [...card.bodySystems],
+      breedFamilies: card.breedFamilies ? [...card.breedFamilies] : undefined,
       screensRedFlags: [...card.screensRedFlags],
       changesUrgencyIf: { ...card.changesUrgencyIf },
       allowedAnswers: [...card.allowedAnswers] as [string, ...string[]],
@@ -99,6 +107,7 @@ function cloneQuestionCard(card: ClinicalQuestionCard): ClinicalQuestionCard {
     ...card,
     complaintFamilies: [...card.complaintFamilies],
     bodySystems: [...card.bodySystems],
+    breedFamilies: card.breedFamilies ? [...card.breedFamilies] : undefined,
     screensRedFlags: [...card.screensRedFlags],
     changesUrgencyIf: { ...card.changesUrgencyIf },
     skipIfAnswered: [...card.skipIfAnswered],

--- a/src/lib/clinical-intelligence/question-card-types.ts
+++ b/src/lib/clinical-intelligence/question-card-types.ts
@@ -6,6 +6,16 @@ interface BaseClinicalQuestionCard {
   complaintFamilies: string[];
   bodySystems: string[];
 
+  /**
+   * Optional breed keywords this card targets (case-insensitive substring
+   * match against the pet's breed), e.g. ["dachshund"] or
+   * ["deep_chested", "german shepherd", "great dane"]. When the pet's breed
+   * matches one of these keywords, the planner applies a small deterministic
+   * relevance boost so the card surfaces earlier. Purely additive: it never
+   * affects urgency, red-flag, or emergency-screen logic.
+   */
+  breedFamilies?: string[];
+
   phase:
     | "emergency_screen"
     | "characterize"

--- a/src/lib/clinical-intelligence/question-cards/breed.ts
+++ b/src/lib/clinical-intelligence/question-cards/breed.ts
@@ -1,0 +1,92 @@
+import type { ClinicalQuestionCard } from "../question-card-types";
+
+/**
+ * Breed-targeted, NON-emergency screening cards.
+ *
+ * These cards are surfaced earlier (via a small deterministic relevance boost
+ * in the planner) when the pet's breed matches one of the keywords listed in
+ * `breedFamilies`. They do NOT change urgency, red-flag, or emergency-screen
+ * logic — they simply prompt an owner-observable question that is especially
+ * worth asking for breeds with a known predisposition.
+ */
+
+export const longBackBreedSpinalCheck: ClinicalQuestionCard = {
+  id: "long_back_breed_spinal_check",
+  ownerText:
+    "Has your dog seemed reluctant to jump up or use stairs, yelped when picked up or touched along the back, or shown wobbly, weak, or dragging back legs?",
+  shortReason:
+    "Long-backed breeds such as Dachshunds and Corgis are prone to back and spinal problems, so back pain or weak hind legs is especially worth checking in these dogs.",
+
+  complaintFamilies: ["musculoskeletal", "neuro", "mobility"],
+  bodySystems: ["musculoskeletal", "neurological"],
+
+  breedFamilies: [
+    "dachshund",
+    "corgi",
+    "basset",
+    "shih tzu",
+    "pekingese",
+    "beagle",
+    "long_back",
+  ],
+
+  phase: "characterize",
+
+  ownerAnswerability: 3,
+  urgencyImpact: 1,
+  discriminativeValue: 2,
+  reportValue: 3,
+
+  screensRedFlags: [],
+  changesUrgencyIf: {
+    "dragging back legs":
+      "Increase urgency for same-day evaluation if the back legs are weak, wobbly, or dragging.",
+  },
+
+  answerType: "boolean",
+
+  skipIfAnswered: [],
+
+  sourceIds: ["internal_pending_review"],
+};
+
+export const deepChestedBreedAbdomenCheck: ClinicalQuestionCard = {
+  id: "deep_chested_breed_abdomen_check",
+  ownerText:
+    "Does your dog's belly look bloated, swollen, or tight, and are they trying to be sick or retching without bringing anything up?",
+  shortReason:
+    "Deep-chested breeds such as German Shepherds, Great Danes, and Weimaraners are prone to sudden bloating of the belly, so a distended abdomen with unproductive retching is especially important to flag in these dogs.",
+
+  complaintFamilies: ["gastrointestinal", "gi", "abdominal"],
+  bodySystems: ["gastrointestinal"],
+
+  breedFamilies: [
+    "deep_chested",
+    "german shepherd",
+    "great dane",
+    "weimaraner",
+    "standard poodle",
+    "doberman",
+    "boxer",
+    "setter",
+  ],
+
+  phase: "characterize",
+
+  ownerAnswerability: 3,
+  urgencyImpact: 2,
+  discriminativeValue: 3,
+  reportValue: 3,
+
+  screensRedFlags: [],
+  changesUrgencyIf: {
+    "bloated abdomen with retching":
+      "Escalate to immediate emergency evaluation if the belly is swollen and the dog is retching without bringing anything up.",
+  },
+
+  answerType: "boolean",
+
+  skipIfAnswered: [],
+
+  sourceIds: ["internal_pending_review"],
+};

--- a/src/lib/clinical-intelligence/shadow-planner-complaint-adapter.ts
+++ b/src/lib/clinical-intelligence/shadow-planner-complaint-adapter.ts
@@ -38,6 +38,12 @@ export interface BuildShadowPlannerComplaintIntegrationInput {
   ownerText: string;
   caseState: ClinicalCaseState;
   existingQuestionId?: string | null;
+  /**
+   * The pet's breed, threaded through to the planner so breed-targeted cards
+   * (cards with a matching `breedFamilies`) receive a small deterministic
+   * relevance boost. Optional and purely additive.
+   */
+  petBreed?: string | null;
 }
 
 export interface ShadowPlannerComplaintIntegrationResult {
@@ -245,6 +251,7 @@ export function buildShadowPlannerComplaintIntegration(
     activeComplaintModule: plannerActiveComplaintModule,
     preferredQuestionIds: routingHints.preferredQuestionIds,
     discouragedQuestionIds: routingHints.discouragedQuestionIds,
+    petBreed: input.petBreed ?? null,
   });
 
   const shadowPlannedQuestion = toShadowPlannedQuestion(plannerResult);

--- a/src/lib/symptom-chat/turn-pipeline/clinical-turn-orchestrator.ts
+++ b/src/lib/symptom-chat/turn-pipeline/clinical-turn-orchestrator.ts
@@ -127,10 +127,13 @@ export function runClinicalTurnPipeline(
       : undefined,
   });
 
+  const petBreed = input.session.effective_breed ?? input.pet.breed ?? null;
+
   const integration = buildShadowPlannerComplaintIntegration({
     ownerText: input.ownerText,
     caseState,
     existingQuestionId: input.legacyQuestionId,
+    petBreed,
   });
 
   const plannerQuestionId = isPlannerFallbackResult(integration.plannerResult)

--- a/tests/clinical-intelligence/heat-trauma-question-cards.test.ts
+++ b/tests/clinical-intelligence/heat-trauma-question-cards.test.ts
@@ -28,9 +28,9 @@ describe("VET-1432K Heatstroke and Trauma Question Cards", () => {
       }
     });
 
-    it("registry size is 29 (19 base + heat-trauma pack + GI history cards)", () => {
+    it("registry size is 31 (19 base + heat-trauma pack + GI history cards + breed pack)", () => {
       const cards = getAllQuestionCards();
-      expect(cards.length).toBe(29);
+      expect(cards.length).toBe(31);
     });
 
     it("new cards are retrievable by id", () => {

--- a/tests/clinical-intelligence/question-card-gap-proposal-pack.test.ts
+++ b/tests/clinical-intelligence/question-card-gap-proposal-pack.test.ts
@@ -212,12 +212,12 @@ const CANDIDATE_PROPOSALS: readonly CandidateProposal[] = [
 
 describe("Question Card Gap Proposal Pack (VET-1429K packaging)", () => {
   it("locks the current live registry counts in the proposal doc", () => {
-    expect(getAllQuestionCards()).toHaveLength(29);
+    expect(getAllQuestionCards()).toHaveLength(31);
     expect(EMERGENCY_RED_FLAG_IDS).toHaveLength(35);
     expect(KNOWN_SIGNAL_IDS).toHaveLength(14);
 
     expect(PROPOSAL_DOC).toContain(
-      "29 question cards, 35 canonical red flags, 14 clinical signals."
+      "31 question cards, 35 canonical red flags, 14 clinical signals."
     );
     expect(PROPOSAL_DOC).not.toContain("37 canonical red flags");
   });


### PR DESCRIPTION
## Summary
- Adds optional breedFamilies?: string[] to BaseClinicalQuestionCard
- Two new breed-targeted cards:
  - long_back_breed_spinal_check — IVDD screen for dachshunds, corgis, bassets, shih tzus, pekingese
  - deep_chested_breed_abdomen_check — GDV/bloat awareness for German shepherds, Great Danes, Weimaraners, etc.
- Threads petBreed (session.effective_breed ?? pet.breed) from turn orchestrator → shadow-planner adapter → PlannerOptions
- +12 breedRelevance score term nudges matching cards up among non-emergency candidates; cannot outrank emergency/red-flag cards (≥+15 base)
- Zero behavioral change when breed is absent or a card has no breedFamilies

## Clinical safety
- No urgency/red-flag/emergency logic touched
- Breed boost (+12) provably cannot leapfrog an emergency_screen card
- changesUrgencyIf on new cards is descriptive metadata only (no live consumer)
- Cards are phase: "characterize", ownerAnswerability: 3

## Test plan
- [x] 1371 clinical-intelligence tests pass across 54 suites
- [x] tsc --noEmit clean; eslint clean
- [x] Registry count tripwires updated 29 → 31
- [x] Rebased cleanly onto master (b259a89)

🤖 Generated with [Claude Code](https://claude.com/claude-code)