### PR TITLE
feat(report): VET-1510 multimodal scorecard in report output

### DIFF
--- a/src/lib/symptom-chat/report-helpers.ts
+++ b/src/lib/symptom-chat/report-helpers.ts
@@ -927,3 +927,47 @@ Output ONLY valid JSON (no thinking, no markdown):
 
   return report;
 }
+
+// ---------------------------------------------------------------------------
+// VET-1510: Multimodal scorecard
+// Surfaces media analysis quality, confidence, and abstention reasons in the
+// owner report. advisory_only is always true: no vision inference increases
+// clinical urgency without a deterministic matrix confirmation.
+// ---------------------------------------------------------------------------
+
+export interface MediaScorecard {
+  domain: string;
+  confidence: number;
+  quality: string;
+  abstention_reason: string | null;
+  advisory_only: boolean;
+  influenced_question_selection: boolean;
+  limitations: string[];
+}
+
+export function buildMediaScorecard(
+  session: TriageSession
+): MediaScorecard | null {
+  const ve = session.latest_visual_evidence;
+  if (!ve) return null;
+
+  const prep = session.latest_preprocess;
+  const quality = prep?.imageQuality ?? "unknown";
+
+  // An abstention reason is present when all findings are empty and at least
+  // one limitation describes why analysis was declined.
+  const abstentionReason =
+    ve.findings.length === 0 && ve.limitations.length > 0
+      ? ve.limitations[0]
+      : null;
+
+  return {
+    domain: ve.domain,
+    confidence: ve.confidence,
+    quality,
+    abstention_reason: abstentionReason,
+    advisory_only: true,
+    influenced_question_selection: Boolean(ve.influencedQuestionSelection),
+    limitations: ve.limitations,
+  };
+}

--- a/src/lib/symptom-chat/report-pipeline.ts
+++ b/src/lib/symptom-chat/report-pipeline.ts
@@ -57,6 +57,7 @@ import {
 } from "@/lib/hf-sidecars";
 import {
   buildEvidenceChainForResponse,
+  buildMediaScorecard,
   buildReportRetrievalBundle,
   deriveBaselineReportConfidence,
   formatConsultEvidenceForReport,
@@ -1646,6 +1647,12 @@ export async function generateReport({
         "[Bayesian] Failed to score report differentials:",
         bayesianError
       );
+    }
+
+    // VET-1510: attach media scorecard (advisory-only; never mutates urgency)
+    const mediaScorecard = buildMediaScorecard(session);
+    if (mediaScorecard !== null) {
+      finalReport.media_scorecard = mediaScorecard;
     }
 
     const { persistence } = await persistFinalReportToHistory({

--- a/tests/vet-1510-media-scorecard.test.ts
+++ b/tests/vet-1510-media-scorecard.test.ts
@@ -1,0 +1,115 @@
+import {
+  buildMediaScorecard,
+  type MediaScorecard,
+} from "@/lib/symptom-chat/report-helpers";
+import { createSession } from "@/lib/triage-engine";
+import type { VisionClinicalEvidence, VisionPreprocessResult } from "@/lib/clinical-evidence";
+
+function makeEvidence(
+  overrides: Partial<VisionClinicalEvidence> = {}
+): VisionClinicalEvidence {
+  return {
+    domain: "skin_wound",
+    bodyRegion: "flank",
+    findings: ["redness", "swelling"],
+    severity: "needs_review",
+    confidence: 0.78,
+    supportedSymptoms: ["wound_skin_issue"],
+    contradictions: [],
+    requiresConsult: false,
+    limitations: [],
+    influencedQuestionSelection: true,
+    ...overrides,
+  };
+}
+
+function makePreprocess(
+  overrides: Partial<VisionPreprocessResult> = {}
+): VisionPreprocessResult {
+  return {
+    domain: "skin_wound",
+    bodyRegion: "flank",
+    detectedRegions: [],
+    bestCrop: null,
+    imageQuality: "good",
+    confidence: 0.78,
+    limitations: [],
+    ...overrides,
+  };
+}
+
+describe("VET-1510: buildMediaScorecard", () => {
+  it("returns null when no visual evidence is present", () => {
+    const session = createSession();
+    expect(buildMediaScorecard(session)).toBeNull();
+  });
+
+  it("builds a scorecard from visual evidence + preprocess", () => {
+    const session = createSession();
+    session.latest_visual_evidence = makeEvidence();
+    session.latest_preprocess = makePreprocess();
+
+    const card = buildMediaScorecard(session) as MediaScorecard;
+
+    expect(card).not.toBeNull();
+    expect(card.domain).toBe("skin_wound");
+    expect(card.confidence).toBe(0.78);
+    expect(card.quality).toBe("good");
+    expect(card.abstention_reason).toBeNull();
+    expect(card.advisory_only).toBe(true);
+    expect(card.influenced_question_selection).toBe(true);
+    expect(card.limitations).toEqual([]);
+  });
+
+  it("falls back to 'unknown' quality when preprocess is absent", () => {
+    const session = createSession();
+    session.latest_visual_evidence = makeEvidence();
+
+    const card = buildMediaScorecard(session) as MediaScorecard;
+    expect(card.quality).toBe("unknown");
+  });
+
+  it("sets abstention_reason when findings are empty and limitations exist", () => {
+    const session = createSession();
+    session.latest_visual_evidence = makeEvidence({
+      findings: [],
+      limitations: ["image_too_blurry", "low_resolution"],
+    });
+    session.latest_preprocess = makePreprocess({ imageQuality: "poor" });
+
+    const card = buildMediaScorecard(session) as MediaScorecard;
+
+    expect(card.abstention_reason).toBe("image_too_blurry");
+    expect(card.limitations).toEqual(["image_too_blurry", "low_resolution"]);
+    expect(card.quality).toBe("poor");
+  });
+
+  it("does not set abstention_reason when findings are present despite limitations", () => {
+    const session = createSession();
+    session.latest_visual_evidence = makeEvidence({
+      findings: ["redness"],
+      limitations: ["lighting_suboptimal"],
+    });
+
+    const card = buildMediaScorecard(session) as MediaScorecard;
+    expect(card.abstention_reason).toBeNull();
+  });
+
+  it("advisory_only is always true — vision never raises clinical urgency alone", () => {
+    const session = createSession();
+    session.latest_visual_evidence = makeEvidence({ severity: "urgent" });
+
+    const card = buildMediaScorecard(session) as MediaScorecard;
+    expect(card.advisory_only).toBe(true);
+  });
+
+  it("influenced_question_selection reflects evidence flag", () => {
+    const session = createSession();
+    session.latest_visual_evidence = makeEvidence({
+      influencedQuestionSelection: false,
+    });
+
+    const card = buildMediaScorecard(session) as MediaScorecard;
+    expect(card.influenced_question_selection).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `buildMediaScorecard()` to `report-helpers.ts` — surfaces vision domain, confidence, image quality, abstention reason, and limitations
- Wire `media_scorecard` field into `finalReport` in pipeline (omitted when no visual evidence)
- `advisory_only: true` always — vision inference never raises clinical urgency without deterministic matrix confirmation

## Test plan
- [x] 7 unit tests: no-evidence null, full scorecard, quality fallback, abstention path, findings-override, advisory_only invariant, flag propagation
- [x] `tsc --noEmit` clean
- [x] No changes to existing test assertions (field is additive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)