### PR TITLE
feat(ui): Whoop-style dark dashboard + declutter symptom report

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -26,31 +26,31 @@ const quickActions = [
     href: "/symptom-checker",
     icon: Stethoscope,
     label: "Check Symptoms",
-    color: "bg-green-50 text-green-600 border-green-200",
+    color: "bg-[#00c896]/10 text-[#00c896] border-[#00c896]/20",
   },
   {
     href: "/history",
     icon: Clock,
     label: "View History",
-    color: "bg-sky-50 text-sky-600 border-sky-200",
+    color: "bg-sky-500/10 text-sky-400 border-sky-500/20",
   },
   {
     href: "/supplements",
     icon: Pill,
     label: "View Supplements",
-    color: "bg-purple-50 text-purple-600 border-purple-200",
+    color: "bg-purple-500/10 text-purple-400 border-purple-500/20",
   },
   {
     href: "/reminders",
     icon: Bell,
     label: "Reminders",
-    color: "bg-amber-50 text-amber-600 border-amber-200",
+    color: "bg-amber-500/10 text-amber-400 border-amber-500/20",
   },
   {
     href: "/journal",
     icon: Plus,
     label: "Add Journal Entry",
-    color: "bg-pink-50 text-pink-600 border-pink-200",
+    color: "bg-pink-500/10 text-pink-400 border-pink-500/20",
   },
 ];
 
@@ -60,28 +60,28 @@ const recentActivity = [
     message: "Health score updated to 87",
     time: "2 hours ago",
     icon: Activity,
-    color: "text-green-600",
+    color: "text-emerald-400",
   },
   {
     type: "reminder",
     message: "Joint supplement administered",
     time: "8 hours ago",
     icon: Pill,
-    color: "text-purple-600",
+    color: "text-purple-400",
   },
   {
     type: "symptom",
     message: "Symptom check: Slight limping - Monitor",
     time: "1 day ago",
     icon: Stethoscope,
-    color: "text-blue-600",
+    color: "text-blue-400",
   },
   {
     type: "journal",
     message: "Weight logged: 68 lbs",
     time: "2 days ago",
     icon: TrendingUp,
-    color: "text-amber-600",
+    color: "text-amber-400",
   },
 ];
 
@@ -125,8 +125,8 @@ function PrivateTesterDashboard({
     <div className="mx-auto max-w-5xl space-y-6">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
-          <h1 className="text-2xl font-bold text-gray-900">Private tester home</h1>
-          <p className="mt-1 text-gray-600">
+          <h1 className="text-2xl font-bold text-white">Private tester home</h1>
+          <p className="mt-1" style={{ color: "rgba(255,255,255,0.5)" }}>
             {PRIVATE_TESTER_FOCUS_SUMMARY}
           </p>
         </div>
@@ -140,16 +140,16 @@ function PrivateTesterDashboard({
         </a>
       </div>
 
-      <Card className="border-amber-200 bg-amber-50 p-5">
+      <Card className="p-5" style={{ background: "rgba(251,191,36,0.08)", borderColor: "rgba(251,191,36,0.2)" }}>
         <div className="flex items-start gap-3">
-          <div className="rounded-2xl bg-amber-100 p-3 text-amber-700">
+          <div className="rounded-2xl p-3" style={{ background: "rgba(251,191,36,0.12)", color: "#fbbf24" }}>
             <ShieldAlert className="h-6 w-6" />
           </div>
           <div>
-            <p className="text-sm font-semibold uppercase tracking-wide text-amber-900">
+            <p className="text-sm font-semibold uppercase tracking-wide" style={{ color: "#fbbf24" }}>
               Not part of this private test
             </p>
-            <p className="mt-2 text-sm leading-6 text-amber-900">
+            <p className="mt-2 text-sm leading-6" style={{ color: "rgba(251,191,36,0.8)" }}>
               Supplements, Paw Circle, analytics, reminders, and journal tools
               are hidden or disabled for private testers.
             </p>
@@ -160,11 +160,11 @@ function PrivateTesterDashboard({
       <div className="grid gap-4 md:grid-cols-3">
         {privateTesterActions.map((action) => (
           <Card key={action.href} className="p-5">
-            <action.icon className="h-6 w-6 text-blue-600" />
-            <h2 className="mt-4 text-lg font-semibold text-gray-900">
+            <action.icon className="h-6 w-6" style={{ color: "#00c896" }} />
+            <h2 className="mt-4 text-lg font-semibold text-white">
               {action.label}
             </h2>
-            <p className="mt-2 text-sm leading-6 text-gray-600">
+            <p className="mt-2 text-sm leading-6" style={{ color: "rgba(255,255,255,0.5)" }}>
               {action.description}
             </p>
             <a
@@ -179,10 +179,10 @@ function PrivateTesterDashboard({
       </div>
 
       <Card className="p-5">
-        <h2 className="text-lg font-semibold text-gray-900">
+        <h2 className="text-lg font-semibold text-white">
           Keep the private test focused
         </h2>
-        <p className="mt-2 text-sm leading-6 text-gray-600">
+        <p className="mt-2 text-sm leading-6" style={{ color: "rgba(255,255,255,0.5)" }}>
           Use the symptom checker for {activePetName || "your dog"}, open saved
           reports from History, and share feedback from the report view so we can
           improve the private test safely.
@@ -205,10 +205,10 @@ export default function DashboardPage() {
       {/* Header */}
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
-          <h1 className="text-2xl font-bold text-gray-900">
+          <h1 className="text-2xl font-bold text-white">
             {activePet ? `${activePet.name}'s Dashboard` : "Dashboard"}
           </h1>
-          <p className="text-gray-500 mt-1">
+          <p className="mt-1 text-sm" style={{ color: "rgba(255,255,255,0.45)" }}>
             Here&apos;s how your dog is doing today
           </p>
         </div>
@@ -226,38 +226,47 @@ export default function DashboardPage() {
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Health Score */}
         <Card className="p-8 flex flex-col items-center justify-center">
-          <h2 className="text-sm font-medium text-gray-500 mb-4 uppercase tracking-wide">
+          <h2
+            className="text-xs font-medium mb-4 uppercase tracking-widest"
+            style={{ color: "rgba(255,255,255,0.35)" }}
+          >
             Daily Health Score
           </h2>
           <HealthScoreCircle score={healthScore} size="lg" />
-          <div className="mt-4 grid w-full grid-cols-3 gap-2 text-center sm:gap-4">
+          <div className="mt-6 grid w-full grid-cols-3 gap-2 text-center sm:gap-4">
             <div>
-              <div className="text-sm font-semibold text-gray-900">92</div>
-              <div className="text-xs text-gray-500">Activity</div>
+              <div className="text-lg font-bold text-white">92</div>
+              <div className="text-xs" style={{ color: "rgba(255,255,255,0.4)" }}>Activity</div>
             </div>
             <div>
-              <div className="text-sm font-semibold text-gray-900">85</div>
-              <div className="text-xs text-gray-500">Nutrition</div>
+              <div className="text-lg font-bold text-white">85</div>
+              <div className="text-xs" style={{ color: "rgba(255,255,255,0.4)" }}>Nutrition</div>
             </div>
             <div>
-              <div className="text-sm font-semibold text-gray-900">78</div>
-              <div className="text-xs text-gray-500">Mood</div>
+              <div className="text-lg font-bold text-white">78</div>
+              <div className="text-xs" style={{ color: "rgba(255,255,255,0.4)" }}>Mood</div>
             </div>
           </div>
         </Card>
 
         {/* Quick Actions */}
         <Card className="p-6">
-          <h2 className="text-sm font-medium text-gray-500 mb-4 uppercase tracking-wide">
+          <h2
+            className="text-xs font-medium mb-4 uppercase tracking-widest"
+            style={{ color: "rgba(255,255,255,0.35)" }}
+          >
             Quick Actions
           </h2>
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             {quickActions.map((action) => (
               <a key={action.href} href={action.href} target="_top">
                 <div
-                  className={`${action.color} border rounded-xl p-4 hover:shadow-sm transition-all cursor-pointer`}
+                  className={`${action.color} border rounded-xl p-4 transition-all cursor-pointer`}
+                  style={{ transition: "opacity 0.15s" }}
+                  onMouseEnter={(e) => { e.currentTarget.style.opacity = "0.75"; }}
+                  onMouseLeave={(e) => { e.currentTarget.style.opacity = "1"; }}
                 >
-                  <action.icon className="w-6 h-6 mb-2" />
+                  <action.icon className="w-5 h-5 mb-2" />
                   <span className="text-sm font-medium">{action.label}</span>
                 </div>
               </a>
@@ -268,13 +277,17 @@ export default function DashboardPage() {
         {/* Upcoming Reminders */}
         <Card className="p-6">
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-sm font-medium text-gray-500 uppercase tracking-wide">
+            <h2
+              className="text-xs font-medium uppercase tracking-widest"
+              style={{ color: "rgba(255,255,255,0.35)" }}
+            >
               Upcoming Reminders
             </h2>
             <a
               href="/reminders"
               target="_top"
-              className="text-xs text-blue-600 font-medium hover:text-blue-700"
+              className="text-xs font-medium"
+              style={{ color: "#00c896" }}
             >
               View all
             </a>
@@ -283,14 +296,15 @@ export default function DashboardPage() {
             {upcomingReminders.map((r, i) => (
               <div
                 key={i}
-                className="flex items-center gap-3 p-3 bg-gray-50 rounded-xl"
+                className="flex items-center gap-3 p-3 rounded-xl"
+                style={{ background: "rgba(255,255,255,0.04)" }}
               >
-                <div className="w-2 h-2 rounded-full bg-amber-500 flex-shrink-0" />
+                <div className="w-2 h-2 rounded-full flex-shrink-0" style={{ background: "#f59e0b" }} />
                 <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium text-gray-900 truncate">
+                  <p className="text-sm font-medium text-white truncate">
                     {r.title}
                   </p>
-                  <p className="text-xs text-gray-500">{r.time}</p>
+                  <p className="text-xs" style={{ color: "rgba(255,255,255,0.4)" }}>{r.time}</p>
                 </div>
               </div>
             ))}
@@ -300,23 +314,30 @@ export default function DashboardPage() {
 
       {/* Recent Activity */}
       <Card className="p-6">
-        <h2 className="text-sm font-medium text-gray-500 mb-4 uppercase tracking-wide">
+        <h2
+          className="text-xs font-medium mb-4 uppercase tracking-widest"
+          style={{ color: "rgba(255,255,255,0.35)" }}
+        >
           Recent Activity
         </h2>
-        <div className="space-y-3">
+        <div className="space-y-1">
           {recentActivity.map((item, i) => (
             <div
               key={i}
-              className="flex items-center gap-3 rounded-xl p-3 transition-colors hover:bg-gray-50 sm:gap-4"
+              className="flex items-center gap-3 rounded-xl p-3 transition-colors sm:gap-4"
+              style={{ transition: "background 0.15s" }}
+              onMouseEnter={(e) => { e.currentTarget.style.background = "rgba(255,255,255,0.04)"; }}
+              onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; }}
             >
               <div
-                className={`w-10 h-10 rounded-xl bg-gray-50 flex items-center justify-center ${item.color}`}
+                className={`w-10 h-10 rounded-xl flex items-center justify-center ${item.color}`}
+                style={{ background: "rgba(255,255,255,0.05)" }}
               >
                 <item.icon className="w-5 h-5" />
               </div>
               <div className="flex-1">
-                <p className="text-sm text-gray-900">{item.message}</p>
-                <p className="text-xs text-gray-500">{item.time}</p>
+                <p className="text-sm text-white">{item.message}</p>
+                <p className="text-xs" style={{ color: "rgba(255,255,255,0.4)" }}>{item.time}</p>
               </div>
             </div>
           ))}
@@ -324,14 +345,17 @@ export default function DashboardPage() {
       </Card>
 
       {/* Health Alert Banner */}
-      <Card className="p-4 border-amber-200 bg-amber-50">
+      <Card
+        className="p-4"
+        style={{ background: "rgba(251,191,36,0.07)", borderColor: "rgba(251,191,36,0.18)" }}
+      >
         <div className="flex items-start gap-3">
-          <AlertCircle className="w-5 h-5 text-amber-600 mt-0.5 flex-shrink-0" />
+          <AlertCircle className="w-5 h-5 mt-0.5 flex-shrink-0" style={{ color: "#fbbf24" }} />
           <div>
-            <p className="text-sm font-medium text-amber-800">
+            <p className="text-sm font-medium" style={{ color: "#fbbf24" }}>
               Upcoming: Annual vaccination due in 2 weeks
             </p>
-            <p className="text-xs text-amber-600 mt-1">
+            <p className="text-xs mt-1" style={{ color: "rgba(251,191,36,0.65)" }}>
               Schedule a vet appointment for {activePet?.name || "your dog"}
               &apos;s annual shots.
             </p>

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -19,7 +19,7 @@ export default function DashboardLayout({
 
   return (
     <SubscriptionProvider>
-      <div className="min-h-screen overflow-x-hidden bg-gray-50">
+      <div className="app-dark min-h-screen overflow-x-hidden" style={{ background: "#0a0a0a" }}>
         <PetOnboardingHost />
         <Sidebar />
         <div

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,11 +1,12 @@
 @import "tailwindcss";
 
+/* ─── Light mode (landing / auth pages) ─────────────────────────────────── */
 :root {
   --background: #ffffff;
   --foreground: #171717;
   --primary: #2563eb;
   --primary-dark: #1d4ed8;
-  --accent: #f59e0b;
+  --accent: #00c896;
   --success: #10b981;
   --warning: #f59e0b;
   --danger: #ef4444;
@@ -13,6 +14,23 @@
   --border: #e5e7eb;
   --card: #ffffff;
   --card-hover: #f9fafb;
+}
+
+/* ─── Dashboard dark theme (Whoop-style) ────────────────────────────────── */
+.app-dark {
+  --background: #0a0a0a;
+  --foreground: #f1f5f9;
+  --primary: #3b82f6;
+  --primary-dark: #2563eb;
+  --accent: #00c896;
+  --success: #22c55e;
+  --warning: #f59e0b;
+  --danger: #f43f5e;
+  --muted: #6b7280;
+  --border: rgba(255, 255, 255, 0.07);
+  --card: #141414;
+  --card-hover: #1c1c1c;
+  color-scheme: dark;
 }
 
 @theme inline {
@@ -38,43 +56,56 @@ body {
   font-family: Arial, Helvetica, sans-serif;
 }
 
+/* ─── Animations ─────────────────────────────────────────────────────────── */
 @keyframes fadeIn {
-  from { opacity: 0; transform: translateY(10px); }
-  to { opacity: 1; transform: translateY(0); }
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0);   }
 }
 
 @keyframes pulse-glow {
-  0%, 100% { box-shadow: 0 0 20px rgba(37, 99, 235, 0.3); }
-  50% { box-shadow: 0 0 40px rgba(37, 99, 235, 0.6); }
+  0%, 100% { box-shadow: 0 0 0 0 rgba(0, 200, 150, 0); }
+  50%       { box-shadow: 0 0 24px 4px rgba(0, 200, 150, 0.25); }
 }
 
-.animate-fade-in {
-  animation: fadeIn 0.5s ease-out;
+@keyframes ring-glow {
+  0%, 100% { filter: drop-shadow(0 0 3px rgba(0, 200, 150, 0.35)); }
+  50%       { filter: drop-shadow(0 0 9px rgba(0, 200, 150, 0.65)); }
 }
 
-.animate-pulse-glow {
-  animation: pulse-glow 2s ease-in-out infinite;
+@keyframes shimmer {
+  from { background-position: -200% center; }
+  to   { background-position:  200% center; }
 }
 
-/* Health score gradient */
+.animate-fade-in    { animation: fadeIn 0.4s ease-out; }
+.animate-pulse-glow { animation: pulse-glow 3s ease-in-out infinite; }
+.animate-ring-glow  { animation: ring-glow  3s ease-in-out infinite; }
+
+/* ─── Health score ring ──────────────────────────────────────────────────── */
 .health-score-ring {
   background: conic-gradient(
     var(--success) calc(var(--score) * 1%),
-    var(--border) calc(var(--score) * 1%)
+    var(--border)  calc(var(--score) * 1%)
   );
 }
 
-/* Custom scrollbar */
-::-webkit-scrollbar {
-  width: 6px;
+/* ─── Stat shimmer text (Whoop-style gradient numbers) ──────────────────── */
+.stat-shimmer {
+  background: linear-gradient(90deg, #00c896 0%, #3b82f6 50%, #00c896 100%);
+  background-size: 200% auto;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  animation: shimmer 4s linear infinite;
 }
-::-webkit-scrollbar-track {
-  background: #f1f5f9;
-}
-::-webkit-scrollbar-thumb {
-  background: #cbd5e1;
-  border-radius: 3px;
-}
-::-webkit-scrollbar-thumb:hover {
-  background: #94a3b8;
-}
+
+/* ─── Custom scrollbar ───────────────────────────────────────────────────── */
+.app-dark ::-webkit-scrollbar         { width: 5px; }
+.app-dark ::-webkit-scrollbar-track   { background: #111; }
+.app-dark ::-webkit-scrollbar-thumb   { background: #2a2a2a; border-radius: 3px; }
+.app-dark ::-webkit-scrollbar-thumb:hover { background: #444; }
+
+::-webkit-scrollbar       { width: 6px; }
+::-webkit-scrollbar-track { background: #f1f5f9; }
+::-webkit-scrollbar-thumb { background: #cbd5e1; border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: #94a3b8; }

--- a/src/components/dashboard/sidebar.tsx
+++ b/src/components/dashboard/sidebar.tsx
@@ -86,27 +86,41 @@ export default function Sidebar() {
         <button
           type="button"
           aria-label="Close navigation"
-          className="fixed inset-0 z-30 bg-slate-900/35 backdrop-blur-[1px] lg:hidden"
+          className="fixed inset-0 z-30 backdrop-blur-[1px] lg:hidden"
+          style={{ background: "rgba(0,0,0,0.6)" }}
           onClick={toggleSidebar}
         />
       ) : null}
 
       <aside
-        className={`fixed left-0 top-0 z-40 flex h-screen max-w-[calc(100vw-1rem)] flex-col border-r border-gray-200 bg-white shadow-xl transition-all duration-300 lg:max-w-none lg:shadow-none ${
+        className={`fixed left-0 top-0 z-40 flex h-screen max-w-[calc(100vw-1rem)] flex-col transition-all duration-300 lg:max-w-none ${
           sidebarOpen
             ? "w-[min(18rem,calc(100vw-1rem))] translate-x-0 lg:w-64"
             : "-translate-x-full lg:w-20 lg:translate-x-0"
         }`}
+        style={{
+          background: "#0a0a0a",
+          borderRight: "1px solid rgba(255,255,255,0.06)",
+        }}
       >
         {/* Logo */}
-        <div className="flex items-center gap-3 border-b border-gray-200 px-5 py-5">
-          <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl bg-blue-600">
-            <Heart className="h-6 w-6 fill-white text-white" />
+        <div
+          className="flex items-center gap-3 px-5 py-5"
+          style={{ borderBottom: "1px solid rgba(255,255,255,0.06)" }}
+        >
+          <div
+            className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl"
+            style={{ background: "rgba(0,200,150,0.15)" }}
+          >
+            <Heart className="h-6 w-6" style={{ color: "#00c896" }} />
           </div>
           {sidebarOpen && (
             <div className="min-w-0">
-              <span className="text-lg font-bold text-gray-900">PawVital</span>
-              <span className="ml-1 rounded bg-blue-100 px-1.5 py-0.5 text-xs font-medium text-blue-700">
+              <span className="text-lg font-bold text-white">PawVital</span>
+              <span
+                className="ml-1 rounded px-1.5 py-0.5 text-xs font-medium"
+                style={{ background: "rgba(0,200,150,0.12)", color: "#00c896" }}
+              >
                 AI
               </span>
             </div>
@@ -115,14 +129,28 @@ export default function Sidebar() {
 
         {/* Active Pet */}
         {activePet && sidebarOpen && (
-          <div className="mx-4 mt-4 rounded-xl border border-blue-200 bg-blue-50 p-3">
+          <div
+            className="mx-4 mt-4 rounded-xl p-3"
+            style={{
+              background: "rgba(255,255,255,0.04)",
+              border: "1px solid rgba(255,255,255,0.07)",
+            }}
+          >
             <div className="flex items-center gap-3">
-              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-200 text-lg">🐕</div>
+              <div
+                className="flex h-10 w-10 items-center justify-center rounded-full text-lg"
+                style={{ background: "rgba(255,255,255,0.08)" }}
+              >
+                🐕
+              </div>
               <div className="min-w-0">
-                <p className="truncate text-sm font-semibold text-gray-900">
+                <p className="truncate text-sm font-semibold text-white">
                   {activePet.name}
                 </p>
-                <p className="truncate text-xs text-gray-500">
+                <p
+                  className="truncate text-xs"
+                  style={{ color: "rgba(255,255,255,0.45)" }}
+                >
                   {activePet.breed}
                   {" · "}
                   {activePet.age_months > 0
@@ -135,25 +163,35 @@ export default function Sidebar() {
         )}
 
         {/* Navigation */}
-        <nav className="flex-1 space-y-1 overflow-y-auto px-3 py-4">
+        <nav className="flex-1 space-y-0.5 overflow-y-auto px-3 py-4">
           {visibleNavItems.map((item) => {
             const isActive = pathname === item.href;
             return (
               <Link
                 key={item.href}
                 href={item.href}
-                className={`group flex items-center gap-3 rounded-xl px-3 py-2.5 transition-all duration-200 ${
-                  isActive
-                    ? "bg-blue-50 font-semibold text-blue-700"
-                    : "text-gray-600 hover:bg-gray-50 hover:text-gray-900"
-                }`}
+                className="group flex items-center gap-3 rounded-xl px-3 py-2.5 transition-all duration-200"
+                style={{
+                  background: isActive ? "rgba(0,200,150,0.08)" : "transparent",
+                  color: isActive ? "#00c896" : "rgba(255,255,255,0.55)",
+                  fontWeight: isActive ? 600 : 400,
+                }}
+                onMouseEnter={(e) => {
+                  if (!isActive) {
+                    (e.currentTarget as HTMLElement).style.background = "rgba(255,255,255,0.05)";
+                    (e.currentTarget as HTMLElement).style.color = "rgba(255,255,255,0.9)";
+                  }
+                }}
+                onMouseLeave={(e) => {
+                  if (!isActive) {
+                    (e.currentTarget as HTMLElement).style.background = "transparent";
+                    (e.currentTarget as HTMLElement).style.color = "rgba(255,255,255,0.55)";
+                  }
+                }}
               >
                 <item.icon
-                  className={`h-5 w-5 flex-shrink-0 ${
-                    isActive
-                      ? "text-blue-600"
-                      : "text-gray-400 group-hover:text-gray-600"
-                  }`}
+                  className="h-5 w-5 flex-shrink-0"
+                  style={{ color: isActive ? "#00c896" : "inherit" }}
                 />
                 {sidebarOpen && <span className="text-sm">{item.label}</span>}
               </Link>
@@ -162,10 +200,22 @@ export default function Sidebar() {
         </nav>
 
         {/* Collapse toggle */}
-        <div className="border-t border-gray-200 px-3 py-3">
+        <div
+          className="px-3 py-3"
+          style={{ borderTop: "1px solid rgba(255,255,255,0.06)" }}
+        >
           <button
             onClick={toggleSidebar}
-            className="flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-gray-500 transition-colors hover:bg-gray-50 hover:text-gray-700"
+            className="flex w-full items-center gap-3 rounded-xl px-3 py-2.5 transition-colors"
+            style={{ color: "rgba(255,255,255,0.35)" }}
+            onMouseEnter={(e) => {
+              (e.currentTarget as HTMLElement).style.background = "rgba(255,255,255,0.05)";
+              (e.currentTarget as HTMLElement).style.color = "rgba(255,255,255,0.65)";
+            }}
+            onMouseLeave={(e) => {
+              (e.currentTarget as HTMLElement).style.background = "transparent";
+              (e.currentTarget as HTMLElement).style.color = "rgba(255,255,255,0.35)";
+            }}
           >
             {sidebarOpen ? (
               <>
@@ -180,7 +230,14 @@ export default function Sidebar() {
           {sidebarOpen && (
             <button
               onClick={signOut}
-              className="mt-1 flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-red-500 transition-colors hover:bg-red-50"
+              className="mt-1 flex w-full items-center gap-3 rounded-xl px-3 py-2.5 transition-colors"
+              style={{ color: "#f43f5e" }}
+              onMouseEnter={(e) => {
+                (e.currentTarget as HTMLElement).style.background = "rgba(244,63,94,0.1)";
+              }}
+              onMouseLeave={(e) => {
+                (e.currentTarget as HTMLElement).style.background = "transparent";
+              }}
             >
               <LogOut className="h-5 w-5" />
               <span className="text-sm">Sign Out</span>

--- a/src/components/dashboard/top-bar.tsx
+++ b/src/components/dashboard/top-bar.tsx
@@ -20,22 +20,60 @@ export default function TopBar() {
           ? "Pro"
           : "Free";
 
+  const badgeStyle: React.CSSProperties =
+    badge === "Demo"
+      ? { background: "rgba(139,92,246,0.15)", color: "#a78bfa", border: "1px solid rgba(139,92,246,0.3)" }
+      : badge === "Clinic"
+        ? { background: "rgba(0,200,150,0.12)", color: "#00c896", border: "1px solid rgba(0,200,150,0.25)" }
+        : badge === "Pro"
+          ? { background: "rgba(59,130,246,0.12)", color: "#60a5fa", border: "1px solid rgba(59,130,246,0.25)" }
+          : { background: "rgba(255,255,255,0.06)", color: "rgba(255,255,255,0.45)", border: "1px solid rgba(255,255,255,0.1)" };
+
   return (
-    <header className="sticky top-0 z-30 bg-white/80 backdrop-blur-md border-b border-gray-200">
+    <header
+      className="sticky top-0 z-30 backdrop-blur-md"
+      style={{
+        background: "rgba(10,10,10,0.92)",
+        borderBottom: "1px solid rgba(255,255,255,0.07)",
+      }}
+    >
       <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-3 sm:px-6">
         <div className="flex min-w-0 flex-1 items-center gap-3 sm:gap-4">
           <button
             onClick={toggleSidebar}
-            className="rounded-lg p-2 hover:bg-gray-100 lg:hidden"
+            className="rounded-lg p-2 transition-colors lg:hidden"
+            style={{ color: "rgba(255,255,255,0.6)" }}
+            onMouseEnter={(e) => {
+              (e.currentTarget as HTMLElement).style.background = "rgba(255,255,255,0.08)";
+            }}
+            onMouseLeave={(e) => {
+              (e.currentTarget as HTMLElement).style.background = "transparent";
+            }}
           >
-            <Menu className="w-5 h-5 text-gray-600" />
+            <Menu className="w-5 h-5" />
           </button>
           <div className="relative min-w-0 flex-1 max-w-full sm:max-w-xs lg:max-w-sm">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+            <Search
+              className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4"
+              style={{ color: "rgba(255,255,255,0.3)" }}
+            />
             <input
               type="text"
               placeholder="Search..."
-              className="w-full rounded-xl border border-gray-200 bg-gray-50 py-2 pl-10 pr-4 text-sm text-gray-900 placeholder-gray-400 transition-colors focus:border-blue-500 focus:bg-white focus:outline-none"
+              className="w-full rounded-xl py-2 pl-10 pr-4 text-sm focus:outline-none transition-colors"
+              style={{
+                background: "rgba(255,255,255,0.05)",
+                border: "1px solid rgba(255,255,255,0.07)",
+                color: "rgba(255,255,255,0.9)",
+              }}
+              onFocus={(e) => {
+                e.currentTarget.style.borderColor = "rgba(0,200,150,0.4)";
+                e.currentTarget.style.background = "rgba(255,255,255,0.07)";
+              }}
+              onBlur={(e) => {
+                e.currentTarget.style.borderColor = "rgba(255,255,255,0.07)";
+                e.currentTarget.style.background = "rgba(255,255,255,0.05)";
+              }}
             />
           </div>
         </div>
@@ -43,30 +81,29 @@ export default function TopBar() {
         <div className="ml-auto flex min-w-0 items-center gap-2 sm:gap-3">
           <NotificationBell />
 
-          <div className="flex min-w-0 items-center gap-2 border-l border-gray-200 pl-2 sm:gap-3 sm:pl-3">
+          <div
+            className="flex min-w-0 items-center gap-2 pl-2 sm:gap-3 sm:pl-3"
+            style={{ borderLeft: "1px solid rgba(255,255,255,0.07)" }}
+          >
             <span
-              className={`inline-flex shrink-0 rounded-lg border px-2 py-1 text-xs font-semibold sm:px-2.5 ${
-                badge === "Demo"
-                  ? "bg-violet-50 text-violet-700 border-violet-200"
-                  : badge === "Clinic"
-                    ? "bg-emerald-50 text-emerald-800 border-emerald-200"
-                    : badge === "Pro"
-                      ? "bg-blue-50 text-blue-700 border-blue-200"
-                      : "bg-gray-50 text-gray-600 border-gray-200"
-              }`}
+              className="inline-flex shrink-0 rounded-lg px-2 py-1 text-xs font-semibold sm:px-2.5"
+              style={badgeStyle}
             >
               {badge}
             </span>
-            <div className="w-8 h-8 bg-blue-100 rounded-full flex items-center justify-center">
-              <span className="text-sm font-semibold text-blue-600">
+            <div
+              className="w-8 h-8 rounded-full flex items-center justify-center"
+              style={{ background: "rgba(0,200,150,0.15)" }}
+            >
+              <span className="text-sm font-semibold" style={{ color: "#00c896" }}>
                 {user?.full_name?.charAt(0) || "U"}
               </span>
             </div>
             <div className="hidden min-w-0 md:block">
-              <p className="truncate text-sm font-medium text-gray-900">
+              <p className="truncate text-sm font-medium text-white">
                 {user?.full_name || "Pet Parent"}
               </p>
-              <p className="text-xs text-gray-500">
+              <p className="text-xs" style={{ color: "rgba(255,255,255,0.4)" }}>
                 {user?.subscription_status === "active"
                   ? "Pro Member"
                   : "Free Trial"}

--- a/src/components/symptom-report/full-report.tsx
+++ b/src/components/symptom-report/full-report.tsx
@@ -8,18 +8,11 @@ import { WhatsHappeningSection } from "./whats-happening";
 import { UrgencyRationaleSection } from "./urgency-rationale";
 import { WhatItCouldBeSection } from "./what-it-could-be";
 import { VetHandoffCard } from "./vet-handoff-card";
-import { ConfidenceCalibrationSection } from "./confidence-calibration";
-import { EvidenceSourcesBar } from "./evidence-sources-bar";
-import { ClinicalNotesSection } from "./clinical-notes";
-import { EvidenceChainSection } from "./evidence-chain";
-import { SimilarCasesSection } from "./similar-cases";
 import { ReferenceImagesSection } from "./reference-images";
 import { RecommendedTestsSection } from "./recommended-tests";
 import { HomeCareSection } from "./home-care";
 import { ActionStepsSection } from "./action-steps";
-import { VetQuestionsSection } from "./vet-questions";
 import { OutcomeFeedbackSection } from "./outcome-feedback";
-import { OwnerSummarySection } from "./owner-summary";
 import { NearestVetFinder } from "./nearest-vet-finder";
 import Button from "@/components/ui/button";
 import Card from "@/components/ui/card";
@@ -275,40 +268,6 @@ export function FullReport({
         (report.recommendation === "emergency_vet" ||
           report.severity === "emergency") && <NearestVetFinder />}
 
-      <OwnerSummarySection
-        canExport={canExport}
-        confidenceCalibration={
-          report.calibrated_confidence ?? report.confidence_calibration
-        }
-        explanation={report.explanation}
-        feedbackEnabled={feedbackEnabled}
-        limitations={presentation.limitations}
-        pdfBusy={pdfBusy}
-        recommendationLabel={presentation.recommendationLabel}
-        onCopyVetSummary={copyVetSummary}
-        onJumpToHandoff={
-          report.vet_handoff_summary
-            ? () =>
-                handoffRef.current?.scrollIntoView({
-                  behavior: "smooth",
-                  block: "start",
-                })
-            : undefined
-        }
-        onJumpToFeedback={
-          !readOnlyShared
-            ? () =>
-                feedbackRef.current?.scrollIntoView({
-                  behavior: "smooth",
-                  block: "start",
-                })
-            : undefined
-        }
-        onDownloadPdf={() => void downloadPdf()}
-        onOpenShareModal={openShareModal}
-        readOnlyShared={readOnlyShared}
-      />
-
       <Modal
         isOpen={shareModalOpen}
         onClose={() => setShareModalOpen(false)}
@@ -380,34 +339,12 @@ export function FullReport({
         </div>
       </Modal>
 
-      <EvidenceSourcesBar report={report} />
-
       {report.recommended_tests && report.recommended_tests.length > 0 && (
         <RecommendedTestsSection tests={report.recommended_tests} />
       )}
 
       {report.home_care && report.home_care.length > 0 && (
         <HomeCareSection items={report.home_care} />
-      )}
-
-      {report.vet_questions && report.vet_questions.length > 0 && (
-        <VetQuestionsSection questions={report.vet_questions} />
-      )}
-
-      <ConfidenceCalibrationSection
-        calibration={report.calibrated_confidence ?? report.confidence_calibration}
-      />
-
-      {report.clinical_notes && (
-        <ClinicalNotesSection notes={report.clinical_notes} />
-      )}
-
-      {report.evidenceChain && report.evidenceChain.length > 0 && (
-        <EvidenceChainSection items={report.evidenceChain} />
-      )}
-
-      {report.similar_cases && report.similar_cases.length > 0 && (
-        <SimilarCasesSection cases={report.similar_cases} />
       )}
 
       {report.reference_images && report.reference_images.length > 0 && (
@@ -434,8 +371,11 @@ export function FullReport({
         </div>
       ) : null}
 
-      <div className="p-4 bg-gray-50 rounded-xl border border-gray-200">
-        <p className="text-xs text-gray-500 leading-relaxed">
+      <div
+        className="p-4 rounded-xl"
+        style={{ background: "var(--card)", border: "1px solid var(--border)" }}
+      >
+        <p className="text-xs leading-relaxed" style={{ color: "var(--muted)" }}>
           <strong>Medical Disclaimer:</strong> PawVital is an informational
           screening tool and cannot replace a hands-on veterinary exam,
           diagnostic testing, or professional veterinary advice. A licensed

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -3,12 +3,22 @@ interface CardProps {
   className?: string;
   hover?: boolean;
   onClick?: () => void;
+  style?: React.CSSProperties;
 }
 
-export default function Card({ children, className = "", hover = false, onClick }: CardProps) {
+export default function Card({ children, className = "", hover = false, onClick, style }: CardProps) {
   return (
     <div
-      className={`bg-white rounded-2xl border border-gray-200 shadow-sm ${hover ? "hover:shadow-md hover:border-gray-300 transition-all duration-200 cursor-pointer" : ""} ${className}`}
+      className={`rounded-2xl border ${
+        hover
+          ? "cursor-pointer transition-all duration-200 hover:border-white/[0.12] hover:bg-[#1c1c1c]"
+          : ""
+      } ${className}`}
+      style={{
+        background: "var(--card)",
+        borderColor: "var(--border)",
+        ...style,
+      }}
       onClick={onClick}
     >
       {children}

--- a/src/components/ui/health-score-circle.tsx
+++ b/src/components/ui/health-score-circle.tsx
@@ -7,47 +7,56 @@ interface HealthScoreCircleProps {
 }
 
 export default function HealthScoreCircle({ score, size = "md", showLabel = true }: HealthScoreCircleProps) {
-  const sizes = { sm: 80, md: 140, lg: 200 };
-  const strokeWidths = { sm: 6, md: 10, lg: 14 };
-  const fontSizes = { sm: "text-lg", md: "text-3xl", lg: "text-5xl" };
+  const sizes        = { sm: 80,  md: 140, lg: 200 };
+  const strokeWidths = { sm: 6,   md: 10,  lg: 14  };
+  const fontSizes    = { sm: "text-lg", md: "text-3xl", lg: "text-5xl" };
 
-  const s = sizes[size];
+  const s           = sizes[size];
   const strokeWidth = strokeWidths[size];
-  const radius = (s - strokeWidth) / 2;
+  const radius      = (s - strokeWidth) / 2;
   const circumference = radius * 2 * Math.PI;
-  const offset = circumference - (score / 100) * circumference;
+  const offset      = circumference - (score / 100) * circumference;
 
-  const getColor = (score: number) => {
-    if (score >= 80) return "#10b981";
-    if (score >= 60) return "#f59e0b";
-    if (score >= 40) return "#f97316";
-    return "#ef4444";
+  const getColor = (v: number) => {
+    if (v >= 80) return "#00c896";
+    if (v >= 60) return "#f59e0b";
+    if (v >= 40) return "#f97316";
+    return "#f43f5e";
   };
 
-  const getLabel = (score: number) => {
-    if (score >= 80) return "Excellent";
-    if (score >= 60) return "Good";
-    if (score >= 40) return "Fair";
+  const getLabel = (v: number) => {
+    if (v >= 80) return "Excellent";
+    if (v >= 60) return "Good";
+    if (v >= 40) return "Fair";
     return "Needs Attention";
   };
 
+  const color = getColor(score);
+
   return (
     <div className="flex flex-col items-center gap-2">
-      <div className="relative" style={{ width: s, height: s }}>
+      <div className="relative animate-ring-glow" style={{ width: s, height: s }}>
+        {/* Outer glow ring */}
+        <div
+          className="absolute inset-0 rounded-full opacity-20 blur-md"
+          style={{ background: `radial-gradient(circle, ${color} 0%, transparent 70%)` }}
+        />
         <svg width={s} height={s} className="-rotate-90">
+          {/* Track */}
           <circle
             cx={s / 2}
             cy={s / 2}
             r={radius}
-            stroke="#e5e7eb"
+            stroke="#1f1f1f"
             strokeWidth={strokeWidth}
             fill="none"
           />
+          {/* Progress */}
           <circle
             cx={s / 2}
             cy={s / 2}
             r={radius}
-            stroke={getColor(score)}
+            stroke={color}
             strokeWidth={strokeWidth}
             fill="none"
             strokeLinecap="round"
@@ -57,13 +66,13 @@ export default function HealthScoreCircle({ score, size = "md", showLabel = true
           />
         </svg>
         <div className="absolute inset-0 flex items-center justify-center">
-          <span className={`font-bold ${fontSizes[size]}`} style={{ color: getColor(score) }}>
+          <span className={`font-bold ${fontSizes[size]}`} style={{ color }}>
             {score}
           </span>
         </div>
       </div>
       {showLabel && (
-        <span className="text-sm font-medium text-gray-600">{getLabel(score)}</span>
+        <span className="text-sm font-medium text-gray-400">{getLabel(score)}</span>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

- **Dark theme**: Near-black `#0a0a0a` background scoped under `.app-dark` class on the dashboard layout wrapper — landing and auth pages stay light
- **Teal accent** `#00c896` throughout: sidebar logo, active nav items, avatar, AI badge, health ring
- **Sidebar**: Fully rewritten — dark bg, teal active state, inline hover handlers, subtle `rgba` borders
- **TopBar**: Dark frosted glass (`rgba(10,10,10,0.92)` + `backdrop-blur`), teal-focused search on focus, plan badge dark variants
- **Dashboard page**: Tracking-widest section labels, dark quick-action tint chips, dark reminder rows, amber alert with `rgba` tint
- **Health score ring**: Outer glow animation, dark track `#1f1f1f`, `stat-shimmer` gradient effect ready
- **Symptom report decluttered**: Removed 7 bloat sections (OwnerSummary, ConfidenceCalibration, EvidenceSourcesBar, EvidenceChain, SimilarCases, ClinicalNotes, VetQuestions). Kept the signal: UrgencyHero → WhatsHappening → UrgencyRationale → WhatItCouldBe → ActionSteps → VetHandoffCard → RecommendedTests/HomeCare → Feedback
- **Card component**: Added optional `style` prop for tinted alert overrides

## Test plan

- [ ] Dashboard renders with dark theme — no white flash on load
- [ ] Sidebar active item shows teal; hover shows white tint
- [ ] TopBar search focus shows teal border
- [ ] Health score ring glows; sub-metrics show white numbers
- [ ] Quick action chips use dark tint variants (green/sky/purple/amber/pink)
- [ ] Symptom report no longer shows ConfidenceCalibration, EvidenceChain, SimilarCases, ClinicalNotes, VetQuestions, OwnerSummary, or EvidenceSourcesBar
- [ ] Landing page and auth pages remain light (`.app-dark` not applied there)
- [ ] Share modal and PDF download still functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)