### PR TITLE
feat(voice-input): actionable feedback + reliable browser fallback for dictation

### DIFF
--- a/src/components/symptom-checker/speech-input-button.tsx
+++ b/src/components/symptom-checker/speech-input-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Loader2, Mic } from "lucide-react";
+import { Loader2, Mic, MicOff } from "lucide-react";
 import Button from "@/components/ui/button";
 import { useAzureSpeechInput } from "@/hooks/useAzureSpeechInput";
 
@@ -11,10 +11,10 @@ type SpeechInputButtonProps = {
 
 function titleForState(state: string, error: string | null): string {
   if (error) {
-    return "Speech input unavailable";
+    return error;
   }
   if (state === "listening") {
-    return "Listening";
+    return "Listening — speak now";
   }
   if (state === "starting") {
     return "Starting speech input";
@@ -29,34 +29,66 @@ export function SpeechInputButton({
   disabled = false,
   onTranscript,
 }: SpeechInputButtonProps) {
-  const { error, isBusy, isSupported, start, state } = useAzureSpeechInput({
-    onText: onTranscript,
-  });
+  const { error, errorReason, isBusy, isSupported, start, state } =
+    useAzureSpeechInput({
+      onText: onTranscript,
+    });
 
   if (!isSupported) {
     return null;
   }
 
-  const isUnavailable = state === "disabled" && !error;
+  const hasError = Boolean(error);
+  // "unsupported" means this browser can never recognize speech here — keep the
+  // button visible (so the user understands why) but disabled. Every other
+  // error is transient, so the mic stays tappable for an immediate retry.
+  const isPermanentlyUnavailable = errorReason === "unsupported";
   const title = titleForState(state, error);
+  const isListening = state === "listening";
 
   return (
-    <Button
-      aria-label={title}
-      className="shrink-0 px-3"
-      disabled={disabled || isBusy || isUnavailable}
-      onClick={() => {
-        void start();
-      }}
-      title={title}
-      type="button"
-      variant="outline"
-    >
-      {isBusy ? (
-        <Loader2 className="w-5 h-5 animate-spin text-gray-500" />
-      ) : (
-        <Mic className="w-5 h-5 text-gray-500" />
+    <div className="relative shrink-0">
+      <Button
+        aria-label={title}
+        className={`px-3 ${
+          isListening
+            ? "border-purple-400 bg-purple-50 text-purple-700"
+            : hasError
+              ? "border-red-300 text-red-600"
+              : ""
+        }`}
+        disabled={disabled || isBusy || isPermanentlyUnavailable}
+        onClick={() => {
+          void start();
+        }}
+        title={title}
+        type="button"
+        variant="outline"
+      >
+        {isBusy ? (
+          <Loader2
+            className={`w-5 h-5 animate-spin ${
+              isListening ? "text-purple-600" : "text-gray-500"
+            }`}
+          />
+        ) : hasError ? (
+          <MicOff className="w-5 h-5 text-red-500" />
+        ) : (
+          <Mic className="w-5 h-5 text-gray-500" />
+        )}
+      </Button>
+      {/* Accessible status for screen readers — announces listening + errors. */}
+      <span className="sr-only" aria-live="polite">
+        {isListening ? "Listening, speak now." : error ?? ""}
+      </span>
+      {hasError && (
+        <p
+          role="status"
+          className="absolute bottom-full left-0 z-10 mb-2 w-56 rounded-lg border border-red-200 bg-white px-3 py-2 text-xs leading-snug text-red-700 shadow-md"
+        >
+          {error}
+        </p>
       )}
-    </Button>
+    </div>
   );
 }

--- a/src/hooks/useAzureSpeechInput.ts
+++ b/src/hooks/useAzureSpeechInput.ts
@@ -9,6 +9,66 @@ export type AzureSpeechInputState =
   | "listening"
   | "starting";
 
+/**
+ * Specific, actionable reasons voice input can fail. The UI maps these to
+ * short owner-facing guidance instead of a single opaque "failed" message —
+ * the most common real-world causes (a denied mic prompt, a silent pause that
+ * trips the no-speech timeout, or a browser with no Web Speech support) each
+ * need a different next step from the user.
+ */
+export type SpeechErrorReason =
+  | "permission_denied"
+  | "no_speech"
+  | "no_microphone"
+  | "unsupported"
+  | "network"
+  | "failed";
+
+const SPEECH_ERROR_MESSAGES: Record<SpeechErrorReason, string> = {
+  permission_denied:
+    "Microphone access was blocked. Allow the mic for this site, then tap the mic again.",
+  no_speech: "I didn't catch anything — tap the mic and speak after it lights up.",
+  no_microphone: "No microphone was found. Check your mic, then try again.",
+  unsupported:
+    "Voice input isn't supported in this browser. Try Chrome or Edge, or type instead.",
+  network: "Voice input needs a connection right now. Check your network and retry.",
+  failed: "Voice input didn't work that time. Tap the mic to try again, or type instead.",
+};
+
+export function speechErrorMessage(reason: SpeechErrorReason): string {
+  return SPEECH_ERROR_MESSAGES[reason];
+}
+
+/**
+ * Map a raw Web Speech `SpeechRecognitionErrorEvent.error` code (or an Azure
+ * SDK error string) to a stable {@link SpeechErrorReason}. Unknown codes fall
+ * back to "failed" so the user still gets a retry affordance.
+ */
+export function classifySpeechError(raw: unknown): SpeechErrorReason {
+  const code = (
+    raw instanceof Error ? raw.message : typeof raw === "string" ? raw : ""
+  )
+    .toLowerCase()
+    .trim();
+
+  if (code === "not-allowed" || code === "service-not-allowed") {
+    return "permission_denied";
+  }
+  if (code === "no-speech") {
+    return "no_speech";
+  }
+  if (code === "audio-capture") {
+    return "no_microphone";
+  }
+  if (code === "network") {
+    return "network";
+  }
+  if (code.includes("unavailable") || code.includes("unsupported")) {
+    return "unsupported";
+  }
+  return "failed";
+}
+
 export type AzureSpeechBrowserToken = {
   enabled: true;
   expiresInSeconds: number;
@@ -176,6 +236,7 @@ export function useAzureSpeechInput({
 }: UseAzureSpeechInputOptions) {
   const [state, setState] = useState<AzureSpeechInputState>("idle");
   const [error, setError] = useState<string | null>(null);
+  const [errorReason, setErrorReason] = useState<SpeechErrorReason | null>(null);
   const [isSupported, setIsSupported] = useState(false);
   const mountedRef = useRef(false);
   const onTextRef = useRef(onText);
@@ -192,13 +253,23 @@ export function useAzureSpeechInput({
     onTextRef.current = onText;
   }, [onText]);
 
+  const failWith = useCallback((reason: SpeechErrorReason) => {
+    if (!mountedRef.current) {
+      return;
+    }
+    setErrorReason(reason);
+    setError(speechErrorMessage(reason));
+    setState("error");
+  }, []);
+
   const start = useCallback(async () => {
     if (!mountedRef.current || !browserSupportsSpeechInput()) {
-      setState("disabled");
+      failWith("unsupported");
       return;
     }
 
     setError(null);
+    setErrorReason(null);
     setState("starting");
 
     let recognizer: SpeechRecognizerLike | null = null;
@@ -250,19 +321,33 @@ export function useAzureSpeechInput({
         return;
       }
 
-      setState("disabled");
-    } catch {
-      if (mountedRef.current) {
-        setError("Speech input failed");
-        setState("error");
+      // Reached only when the browser exposed a microphone but no usable
+      // recognition path (no Azure token and no Web Speech API). Tell the user
+      // why instead of leaving a dead, silent button.
+      failWith("unsupported");
+    } catch (caught) {
+      // A user-initiated stop (Web Speech "aborted") is not a failure — reset
+      // quietly so the next tap starts cleanly.
+      if (caught instanceof Error && caught.message === "aborted") {
+        if (mountedRef.current) {
+          setState("idle");
+        }
+        return;
       }
+      // An empty transcript means recognition ran but heard nothing usable.
+      const reason =
+        caught instanceof Error && caught.message === "empty transcript"
+          ? "no_speech"
+          : classifySpeechError(caught);
+      failWith(reason);
     } finally {
       recognizer?.close();
     }
-  }, [fetchToken, language, loadSdk]);
+  }, [failWith, fetchToken, language, loadSdk]);
 
   return {
     error,
+    errorReason,
     isBusy: state === "starting" || state === "listening",
     isSupported,
     start,

--- a/tests/azure-speech-input-hook.test.ts
+++ b/tests/azure-speech-input-hook.test.ts
@@ -3,7 +3,9 @@
 import React, { useState } from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import {
+  classifySpeechError,
   requestAzureSpeechBrowserToken,
+  speechErrorMessage,
   useAzureSpeechInput,
   type AzureSpeechBrowserToken,
   type SpeechSdkLike,
@@ -76,6 +78,16 @@ function SpeechHarness({
       "span",
       { "data-testid": "speech-state" },
       speech.state
+    ),
+    React.createElement(
+      "span",
+      { "data-testid": "speech-error" },
+      speech.error ?? ""
+    ),
+    React.createElement(
+      "span",
+      { "data-testid": "speech-error-reason" },
+      speech.errorReason ?? ""
     ),
     React.createElement("span", { "data-testid": "transcript" }, transcript)
   );
@@ -172,5 +184,117 @@ describe("useAzureSpeechInput", () => {
     );
     expect(sdk.SpeechRecognizer).not.toHaveBeenCalled();
     expect(screen.getByTestId("speech-state").textContent).toBe("idle");
+  });
+
+  it("surfaces a permission-denied reason when the mic is blocked", async () => {
+    const { sdk } = makeSpeechSdk("ignored");
+    const SpeechRecognitionMock = jest.fn(() => ({
+      continuous: false,
+      interimResults: false,
+      lang: "en-US",
+      maxAlternatives: 1,
+      onerror: null,
+      onresult: null,
+      start: jest.fn(),
+      stop: jest.fn(),
+    }));
+    Object.defineProperty(window, "SpeechRecognition", {
+      configurable: true,
+      value: SpeechRecognitionMock,
+    });
+
+    render(
+      React.createElement(SpeechHarness, {
+        fetchToken: async () => null,
+        loadSdk: async () => sdk,
+      })
+    );
+
+    await waitFor(() =>
+      expect((screen.getByRole("button") as HTMLButtonElement).disabled).toBe(
+        false
+      )
+    );
+    fireEvent.click(screen.getByRole("button", { name: "start" }));
+
+    const recognition = await waitFor(() => {
+      const value = SpeechRecognitionMock.mock.results[0]?.value;
+      expect(value).toBeTruthy();
+      return value;
+    });
+    recognition.onerror({ error: "not-allowed" });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("speech-error-reason").textContent).toBe(
+        "permission_denied"
+      )
+    );
+    expect(screen.getByTestId("speech-state").textContent).toBe("error");
+    expect(screen.getByTestId("speech-error").textContent).toContain(
+      "Microphone access was blocked"
+    );
+  });
+
+  it("reports an unsupported reason when no recognition path exists", async () => {
+    const { sdk } = makeSpeechSdk("ignored");
+    // Microphone is present (button renders) but no Web Speech API and no Azure
+    // token — the user should learn why instead of facing a dead button.
+    Reflect.deleteProperty(window, "SpeechRecognition");
+    Reflect.deleteProperty(window, "webkitSpeechRecognition");
+
+    render(
+      React.createElement(SpeechHarness, {
+        fetchToken: async () => null,
+        loadSdk: async () => sdk,
+      })
+    );
+
+    await waitFor(() =>
+      expect((screen.getByRole("button") as HTMLButtonElement).disabled).toBe(
+        false
+      )
+    );
+    fireEvent.click(screen.getByRole("button", { name: "start" }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("speech-error-reason").textContent).toBe(
+        "unsupported"
+      )
+    );
+  });
+});
+
+describe("classifySpeechError", () => {
+  it("maps known Web Speech error codes to actionable reasons", () => {
+    expect(classifySpeechError(new Error("not-allowed"))).toBe(
+      "permission_denied"
+    );
+    expect(classifySpeechError("service-not-allowed")).toBe(
+      "permission_denied"
+    );
+    expect(classifySpeechError(new Error("no-speech"))).toBe("no_speech");
+    expect(classifySpeechError("audio-capture")).toBe("no_microphone");
+    expect(classifySpeechError(new Error("network"))).toBe("network");
+    expect(classifySpeechError("Web Speech API unavailable")).toBe(
+      "unsupported"
+    );
+  });
+
+  it("falls back to a retryable failure for unknown codes", () => {
+    expect(classifySpeechError(new Error("weird-glitch"))).toBe("failed");
+    expect(classifySpeechError(null)).toBe("failed");
+  });
+
+  it("provides a non-empty owner-facing message for every reason", () => {
+    for (const reason of [
+      "permission_denied",
+      "no_speech",
+      "no_microphone",
+      "unsupported",
+      "network",
+      "failed",
+    ] as const) {
+      expect(speechErrorMessage(reason).length).toBeGreaterThan(0);
+    }
   });
 });

--- a/tests/symptom-checker-speech-input.test.ts
+++ b/tests/symptom-checker-speech-input.test.ts
@@ -76,4 +76,53 @@ describe("SpeechInputButton", () => {
       ).disabled
     ).toBe(true);
   });
+
+  it("shows a specific error message and keeps a transient error retryable", () => {
+    const start = jest.fn();
+    mockUseAzureSpeechInput.mockReturnValue({
+      error:
+        "Microphone access was blocked. Allow the mic for this site, then tap the mic again.",
+      errorReason: "permission_denied",
+      isBusy: false,
+      isSupported: true,
+      start,
+      state: "error",
+    });
+
+    render(
+      React.createElement(SpeechInputButton, { onTranscript: jest.fn() })
+    );
+
+    expect(screen.getByRole("status").textContent).toContain(
+      "Microphone access was blocked"
+    );
+    // Transient errors stay tappable so the owner can retry immediately.
+    const button = screen.getByRole("button");
+    expect((button as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(button);
+    expect(start).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the mic when voice input is unsupported in this browser", () => {
+    mockUseAzureSpeechInput.mockReturnValue({
+      error:
+        "Voice input isn't supported in this browser. Try Chrome or Edge, or type instead.",
+      errorReason: "unsupported",
+      isBusy: false,
+      isSupported: true,
+      start: jest.fn(),
+      state: "error",
+    });
+
+    render(
+      React.createElement(SpeechInputButton, { onTranscript: jest.fn() })
+    );
+
+    expect((screen.getByRole("button") as HTMLButtonElement).disabled).toBe(
+      true
+    );
+    expect(screen.getByRole("status").textContent).toContain(
+      "isn't supported in this browser"
+    );
+  });
 });


### PR DESCRIPTION
## What
Speech-to-text (click-to-talk) already fell back to the browser Web Speech API when Azure is disabled in prod, but **every failure collapsed to one opaque "Speech input failed"**, and browsers without Web Speech left a **dead, silent mic button**. Owners read that as "voice doesn't work."

## Changes
- Classify failures into specific reasons: permission_denied / no_speech / no_microphone / unsupported / network / failed, each with short actionable guidance.
- Transient errors stay tappable for instant retry; only `unsupported` disables the mic (with an explanation, not silence).
- Listening affordance + aria-live status for accessibility.
- **No change** to the Azure-primary / Web-Speech-fallback flow, payloads, or clinical logic.

## Verify
- tsc 0 errors, eslint 0 errors on changed files
- 22 speech tests pass (16 new assertions across hook + button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)