### PR TITLE
feat(notifications): immediate owner email for urgent triage reports

### DIFF
--- a/src/lib/events/event-bus.ts
+++ b/src/lib/events/event-bus.ts
@@ -38,6 +38,7 @@ export interface UrgencyHighPayload {
   urgency: "emergency" | "high";
   petName: string;
   topDiagnosis: string;
+  reportStorageId?: string | null;
 }
 
 export interface OutcomeRequestedPayload {

--- a/src/lib/events/notification-handler.ts
+++ b/src/lib/events/notification-handler.ts
@@ -12,6 +12,10 @@
 import { on, EventType } from "./event-bus";
 import { getServiceSupabase } from "@/lib/supabase-admin";
 import { withNotificationDeliveryState } from "@/lib/notification-delivery";
+import {
+  deliverUrgentOwnerEmail,
+  type UrgentEmailUrgency,
+} from "@/lib/urgent-email";
 
 type NotificationRow = {
   user_id: string;
@@ -21,29 +25,76 @@ type NotificationRow = {
   metadata: Record<string, unknown>;
 };
 
-async function insertNotification(row: NotificationRow): Promise<void> {
+interface InsertedNotification {
+  id: string;
+  metadata: Record<string, unknown>;
+}
+
+async function insertNotification(
+  row: NotificationRow
+): Promise<InsertedNotification | null> {
   const supabase = getServiceSupabase();
   if (!supabase) {
     // Supabase not configured (dev/demo mode) — skip silently
-    return;
+    return null;
   }
 
-  const payload = {
-    ...row,
-    metadata: withNotificationDeliveryState(row.metadata, {
-      status: "pending",
-      attempts: 0,
-      dead_lettered: false,
-      last_attempt_at: null,
-      delivered_at: null,
-      confirmation_id: null,
-      last_error: null,
-    }),
-  };
+  const metadata = withNotificationDeliveryState(row.metadata, {
+    status: "pending",
+    attempts: 0,
+    dead_lettered: false,
+    last_attempt_at: null,
+    delivered_at: null,
+    confirmation_id: null,
+    last_error: null,
+  });
 
-  const { error } = await supabase.from("notifications").insert(payload);
+  const { data, error } = await supabase
+    .from("notifications")
+    .insert({ ...row, metadata })
+    .select("id")
+    .single();
+
   if (error) {
     console.error("[NotificationHandler] Failed to insert notification:", error);
+    return null;
+  }
+
+  const id = typeof data?.id === "string" ? data.id : null;
+  return id ? { id, metadata } : null;
+}
+
+function isHighUrgency(urgency: unknown): urgency is UrgentEmailUrgency {
+  return urgency === "emergency" || urgency === "high";
+}
+
+/**
+ * Attempt immediate urgent owner email for a freshly-inserted high-urgency
+ * notification. Non-fatal: failures are recorded as delivery state and never
+ * re-thrown into the event/report path.
+ */
+async function maybeSendUrgentEmail(
+  inserted: InsertedNotification | null,
+  input: {
+    userId: string;
+    urgency: UrgentEmailUrgency;
+    petName: string;
+    ownerMessage: string;
+    recommendedAction?: string | null;
+    reportStorageId?: string | null;
+  }
+): Promise<void> {
+  if (!inserted) {
+    return;
+  }
+  try {
+    await deliverUrgentOwnerEmail(
+      { notificationId: inserted.id, ...input },
+      inserted.metadata
+    );
+  } catch (error) {
+    // deliverUrgentOwnerEmail is designed never to throw; guard anyway.
+    console.error("[NotificationHandler] Urgent email delivery failed:", error);
   }
 }
 
@@ -60,10 +111,13 @@ function registerNotificationHandlers(): void {
         urgency: payload.urgency,
       },
     });
+    // Immediate urgent owner email is driven by the URGENCY_HIGH event, which
+    // the report pipeline always co-emits for high/emergency reports. Sending
+    // here too would double-email the owner, so REPORT_READY stays in-app only.
   });
 
   on(EventType.URGENCY_HIGH, async (payload) => {
-    await insertNotification({
+    const inserted = await insertNotification({
       user_id: payload.userId,
       type: "urgency_alert",
       title: `Urgent: ${payload.petName} needs attention`,
@@ -74,6 +128,20 @@ function registerNotificationHandlers(): void {
         topDiagnosis: payload.topDiagnosis,
       },
     });
+
+    if (isHighUrgency(payload.urgency)) {
+      await maybeSendUrgentEmail(inserted, {
+        userId: payload.userId,
+        urgency: payload.urgency,
+        petName: payload.petName,
+        ownerMessage: `Triage indicates ${payload.urgency} urgency for ${payload.petName}. Top differential: ${payload.topDiagnosis}.`,
+        recommendedAction:
+          payload.urgency === "emergency"
+            ? "Contact your veterinarian or an emergency clinic right away."
+            : "Arrange a veterinary visit as soon as possible.",
+        reportStorageId: payload.reportStorageId ?? null,
+      });
+    }
   });
 
   on(EventType.OUTCOME_REQUESTED, async (payload) => {

--- a/src/lib/symptom-chat/report-pipeline.ts
+++ b/src/lib/symptom-chat/report-pipeline.ts
@@ -286,6 +286,7 @@ async function persistFinalReportToHistory({
         urgency: highestUrgency as "emergency" | "high",
         petName: pet.name ?? "your dog",
         topDiagnosis,
+        reportStorageId,
       });
     }
   }

--- a/src/lib/urgent-email.ts
+++ b/src/lib/urgent-email.ts
@@ -1,0 +1,314 @@
+/**
+ * Immediate owner email delivery for URGENT / EMERGENCY triage reports.
+ *
+ * When a high-urgency notification is created, this module attempts an
+ * immediate single-report email to the pet owner via the existing
+ * Resend-backed sendEmail() transport, and records the outcome on the
+ * notification row using the shared notification-delivery state machine.
+ *
+ * Rules:
+ * - No medical decisions are made here. Only strings produced upstream are
+ *   rendered; no urgency/triage logic is computed.
+ * - Email failure must never throw into the caller (report pipeline /
+ *   notification handler). All work is wrapped and failures are recorded as
+ *   `failed` delivery state, logged internally only.
+ * - No-ops cleanly when RESEND_API_KEY is unset (sendEmail returns
+ *   { sent: false }); delivery is recorded as failed-but-not-dead-lettered so
+ *   the digest path can still pick it up.
+ * - Respects owner notification preferences: skips when email_digest is
+ *   explicitly false or urgency_alerts is explicitly false. Sends by default
+ *   for urgent reports when preferences are absent.
+ */
+
+import { getServiceSupabase } from "@/lib/supabase-admin";
+import { sendEmail } from "@/lib/email";
+import {
+  getNotificationDeliveryState,
+  withNotificationDeliveryState,
+  type NotificationDeliveryState,
+} from "@/lib/notification-delivery";
+
+const BRAND_COLOR = "#4f46e5";
+const URGENT_COLOR = "#dc2626";
+const BRAND_NAME = "PawVital";
+const DASHBOARD_URL = "https://app.pawvital.ai/dashboard";
+
+export type UrgentEmailUrgency = "emergency" | "high";
+
+export interface UrgentOwnerEmailInput {
+  /** Notification row id to record delivery state against. */
+  notificationId: string;
+  /** Owner (auth user) id used to look up email + preferences. */
+  userId: string;
+  urgency: UrgentEmailUrgency;
+  petName: string;
+  /** Concise one-line owner-facing message (already produced upstream). */
+  ownerMessage: string;
+  /** Recommended next step string (already produced upstream). */
+  recommendedAction?: string | null;
+  /** Optional report storage id for a deep link to the report. */
+  reportStorageId?: string | null;
+}
+
+export interface UrgentOwnerEmailResult {
+  status: "skipped" | "sent" | "failed";
+  reason?: string;
+}
+
+function escapeHtml(raw: string): string {
+  return raw
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function urgencyLabel(urgency: UrgentEmailUrgency): string {
+  return urgency === "emergency" ? "Emergency" : "Urgent";
+}
+
+export function buildUrgentEmailSubject(
+  petName: string,
+  urgency: UrgentEmailUrgency
+): string {
+  const label = urgency === "emergency" ? "emergency" : "urgent";
+  const name = petName?.trim() || "your dog";
+  return `${BRAND_NAME}: ${label} guidance for ${name}`;
+}
+
+export function buildUrgentEmailHtml(input: {
+  petName: string;
+  urgency: UrgentEmailUrgency;
+  ownerMessage: string;
+  recommendedAction?: string | null;
+  reportUrl: string;
+}): string {
+  const name = escapeHtml(input.petName?.trim() || "your dog");
+  const label = escapeHtml(urgencyLabel(input.urgency));
+  const message = escapeHtml(input.ownerMessage);
+  const action = input.recommendedAction
+    ? escapeHtml(input.recommendedAction)
+    : "";
+  const url = encodeURI(input.reportUrl);
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>${BRAND_NAME} ${label} guidance</title>
+</head>
+<body style="margin:0;padding:0;background:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f9fafb;padding:32px 0;">
+    <tr>
+      <td align="center">
+        <table width="600" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,.08);">
+          <tr>
+            <td style="background:${URGENT_COLOR};padding:24px 32px;">
+              <p style="margin:0;font-size:12px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:rgba(255,255,255,.85);">${label} guidance</p>
+              <h1 style="margin:6px 0 0;font-size:20px;font-weight:700;color:#ffffff;">${name} may need attention</h1>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:24px 32px;">
+              <p style="margin:0 0 16px;font-size:15px;line-height:1.5;color:#374151;">${message}</p>
+              ${
+                action
+                  ? `<p style="margin:0 0 20px;font-size:15px;line-height:1.5;color:#111827;"><strong>Recommended next step:</strong> ${action}</p>`
+                  : ""
+              }
+              <table cellpadding="0" cellspacing="0" style="margin:8px 0 4px;">
+                <tr>
+                  <td style="border-radius:6px;background:${BRAND_COLOR};">
+                    <a href="${url}" style="display:inline-block;padding:12px 24px;font-size:15px;font-weight:600;color:#ffffff;text-decoration:none;">View full report</a>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin:24px 0 0;font-size:13px;color:#9ca3af;">
+                ${BRAND_NAME} does not replace professional veterinary care. If this is an
+                emergency, contact your veterinarian or an emergency clinic right away.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+}
+
+interface OwnerEmailPreferences {
+  email: string | null;
+  emailDigest: boolean;
+  urgencyAlerts: boolean;
+}
+
+async function resolveOwnerEmailPreferences(
+  supabase: NonNullable<ReturnType<typeof getServiceSupabase>>,
+  userId: string
+): Promise<OwnerEmailPreferences> {
+  let email: string | null = null;
+  try {
+    const { data } = await supabase.auth.admin.getUserById(userId);
+    const candidate = data?.user?.email;
+    email = typeof candidate === "string" && candidate.includes("@") ? candidate : null;
+  } catch (error) {
+    console.error("[UrgentEmail] Failed to resolve owner email:", error);
+  }
+
+  // Preferences are optional. Absent rows default to sending for urgent.
+  let emailDigest = true;
+  let urgencyAlerts = true;
+  try {
+    const { data: prefs } = await supabase
+      .from("notification_preferences")
+      .select("email_digest, urgency_alerts")
+      .eq("user_id", userId)
+      .maybeSingle();
+
+    if (prefs) {
+      emailDigest = prefs.email_digest !== false;
+      urgencyAlerts = prefs.urgency_alerts !== false;
+    }
+  } catch (error) {
+    console.error("[UrgentEmail] Failed to read notification preferences:", error);
+  }
+
+  return { email, emailDigest, urgencyAlerts };
+}
+
+async function persistUrgentDeliveryState(
+  supabase: NonNullable<ReturnType<typeof getServiceSupabase>>,
+  notificationId: string,
+  userId: string,
+  existingMetadata: Record<string, unknown> | null,
+  patch: Partial<NotificationDeliveryState>
+): Promise<void> {
+  try {
+    const metadata = withNotificationDeliveryState(existingMetadata, patch);
+    const { error } = await supabase
+      .from("notifications")
+      .update({ metadata })
+      .eq("id", notificationId)
+      .eq("user_id", userId);
+    if (error) {
+      console.error("[UrgentEmail] Failed to persist delivery state:", error);
+    }
+  } catch (error) {
+    console.error("[UrgentEmail] Failed to persist delivery state:", error);
+  }
+}
+
+/**
+ * Attempt an immediate urgent owner email and record the delivery outcome.
+ *
+ * Always resolves (never rejects). Returns a small status object for internal
+ * use/telemetry — callers must not surface this to the user-facing payload.
+ */
+export async function deliverUrgentOwnerEmail(
+  input: UrgentOwnerEmailInput,
+  existingMetadata: Record<string, unknown> | null = null
+): Promise<UrgentOwnerEmailResult> {
+  const supabase = getServiceSupabase();
+  if (!supabase) {
+    return { status: "skipped", reason: "supabase_unconfigured" };
+  }
+
+  try {
+    const { email, emailDigest, urgencyAlerts } =
+      await resolveOwnerEmailPreferences(supabase, input.userId);
+
+    if (!emailDigest || !urgencyAlerts) {
+      return { status: "skipped", reason: "owner_opted_out" };
+    }
+
+    if (!email) {
+      return { status: "skipped", reason: "no_owner_email" };
+    }
+
+    const reportUrl = input.reportStorageId
+      ? `${DASHBOARD_URL}?report=${encodeURIComponent(input.reportStorageId)}`
+      : DASHBOARD_URL;
+
+    const subject = buildUrgentEmailSubject(input.petName, input.urgency);
+    const html = buildUrgentEmailHtml({
+      petName: input.petName,
+      urgency: input.urgency,
+      ownerMessage: input.ownerMessage,
+      recommendedAction: input.recommendedAction,
+      reportUrl,
+    });
+
+    const priorAttempts = getNotificationDeliveryState(existingMetadata).attempts;
+    const attempts = priorAttempts + 1;
+    const nowIso = new Date().toISOString();
+
+    let result: { sent: boolean; id?: string };
+    try {
+      result = await sendEmail({ to: email, subject, html });
+    } catch (sendError) {
+      const message =
+        sendError instanceof Error ? sendError.message : "send_failed";
+      console.error("[UrgentEmail] sendEmail threw:", sendError);
+      await persistUrgentDeliveryState(
+        supabase,
+        input.notificationId,
+        input.userId,
+        existingMetadata,
+        {
+          status: "failed",
+          attempts,
+          last_attempt_at: nowIso,
+          delivered_at: null,
+          confirmation_id: null,
+          last_error: message,
+          dead_lettered: false,
+        }
+      );
+      return { status: "failed", reason: message };
+    }
+
+    if (result.sent) {
+      await persistUrgentDeliveryState(
+        supabase,
+        input.notificationId,
+        input.userId,
+        existingMetadata,
+        {
+          status: "sent",
+          attempts,
+          last_attempt_at: nowIso,
+          delivered_at: nowIso,
+          confirmation_id: result.id ?? null,
+          last_error: null,
+          dead_lettered: false,
+        }
+      );
+      return { status: "sent" };
+    }
+
+    // sendEmail no-op (RESEND_API_KEY unset) or non-OK Resend response.
+    // Record as failed but NOT dead-lettered, so the digest path can retry.
+    await persistUrgentDeliveryState(
+      supabase,
+      input.notificationId,
+      input.userId,
+      existingMetadata,
+      {
+        status: "failed",
+        attempts,
+        last_attempt_at: nowIso,
+        delivered_at: null,
+        confirmation_id: null,
+        last_error: "email_not_sent",
+        dead_lettered: false,
+      }
+    );
+    return { status: "failed", reason: "email_not_sent" };
+  } catch (error) {
+    // Defensive: nothing in here may throw into the caller.
+    console.error("[UrgentEmail] Unexpected failure:", error);
+    return { status: "failed", reason: "unexpected_error" };
+  }
+}

--- a/tests/urgent-email.test.ts
+++ b/tests/urgent-email.test.ts
@@ -1,0 +1,198 @@
+/** @jest-environment node */
+
+import {
+  buildUrgentEmailSubject,
+  buildUrgentEmailHtml,
+  deliverUrgentOwnerEmail,
+} from "@/lib/urgent-email";
+import { sendEmail } from "@/lib/email";
+import { getServiceSupabase } from "@/lib/supabase-admin";
+
+jest.mock("@/lib/email", () => ({
+  sendEmail: jest.fn(),
+}));
+jest.mock("@/lib/supabase-admin", () => ({
+  getServiceSupabase: jest.fn(),
+}));
+
+const mockSendEmail = sendEmail as jest.MockedFunction<typeof sendEmail>;
+const mockGetServiceSupabase = getServiceSupabase as jest.MockedFunction<
+  typeof getServiceSupabase
+>;
+
+type Prefs = { email_digest?: boolean; urgency_alerts?: boolean } | null;
+
+/**
+ * Minimal Supabase test double covering exactly the calls urgent-email makes:
+ * auth.admin.getUserById, a notification_preferences read, and a notifications
+ * metadata update. The update spy is returned so tests can assert delivery
+ * state was persisted.
+ */
+function buildSupabaseMock({
+  email,
+  prefs,
+}: {
+  email: string | null;
+  prefs: Prefs;
+}) {
+  const updateEqEq = jest.fn().mockResolvedValue({ error: null });
+  const update = jest.fn(() => ({
+    eq: jest.fn(() => ({ eq: updateEqEq })),
+  }));
+
+  const supabase = {
+    auth: {
+      admin: {
+        getUserById: jest.fn().mockResolvedValue({
+          data: { user: email ? { email } : null },
+        }),
+      },
+    },
+    from: jest.fn((table: string) => {
+      if (table === "notification_preferences") {
+        return {
+          select: jest.fn(() => ({
+            eq: jest.fn(() => ({
+              maybeSingle: jest.fn().mockResolvedValue({ data: prefs }),
+            })),
+          })),
+        };
+      }
+      // notifications
+      return { update };
+    }),
+  };
+
+  return { supabase, update, updateEqEq };
+}
+
+const BASE_INPUT = {
+  notificationId: "notif-1",
+  userId: "user-1",
+  urgency: "emergency" as const,
+  petName: "Rex",
+  ownerMessage: "Triage indicates emergency urgency for Rex.",
+  recommendedAction: "Contact a vet right away.",
+  reportStorageId: "report-9",
+};
+
+describe("urgent-email builders", () => {
+  it("builds an urgency-specific subject", () => {
+    expect(buildUrgentEmailSubject("Rex", "emergency")).toContain("emergency");
+    expect(buildUrgentEmailSubject("Rex", "high")).toContain("urgent");
+    expect(buildUrgentEmailSubject("", "high")).toContain("your dog");
+  });
+
+  it("escapes owner-provided strings in the email HTML", () => {
+    const html = buildUrgentEmailHtml({
+      petName: "<script>",
+      urgency: "high",
+      ownerMessage: "a & b < c",
+      recommendedAction: null,
+      reportUrl: "https://app.pawvital.ai/dashboard",
+    });
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).toContain("a &amp; b &lt; c");
+  });
+});
+
+describe("deliverUrgentOwnerEmail", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("sends an email and records sent delivery state when configured", async () => {
+    const { supabase, updateEqEq } = buildSupabaseMock({
+      email: "owner@example.com",
+      prefs: null,
+    });
+    mockGetServiceSupabase.mockReturnValue(
+      supabase as unknown as ReturnType<typeof getServiceSupabase>
+    );
+    mockSendEmail.mockResolvedValue({ sent: true, id: "resend-123" });
+
+    const result = await deliverUrgentOwnerEmail(BASE_INPUT);
+
+    expect(result.status).toBe("sent");
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    const arg = mockSendEmail.mock.calls[0][0];
+    expect(arg.to).toBe("owner@example.com");
+    expect(arg.subject).toContain("emergency");
+    // delivery state persisted as sent with the Resend confirmation id
+    const persisted = updateEqEq.mock.calls.length;
+    expect(persisted).toBeGreaterThan(0);
+  });
+
+  it("no-ops to failed (retryable) when email transport is unconfigured", async () => {
+    const { supabase } = buildSupabaseMock({
+      email: "owner@example.com",
+      prefs: null,
+    });
+    mockGetServiceSupabase.mockReturnValue(
+      supabase as unknown as ReturnType<typeof getServiceSupabase>
+    );
+    mockSendEmail.mockResolvedValue({ sent: false });
+
+    const result = await deliverUrgentOwnerEmail(BASE_INPUT);
+
+    expect(result.status).toBe("failed");
+    expect(result.reason).toBe("email_not_sent");
+  });
+
+  it("skips when the owner opted out of urgency alerts", async () => {
+    const { supabase } = buildSupabaseMock({
+      email: "owner@example.com",
+      prefs: { urgency_alerts: false },
+    });
+    mockGetServiceSupabase.mockReturnValue(
+      supabase as unknown as ReturnType<typeof getServiceSupabase>
+    );
+
+    const result = await deliverUrgentOwnerEmail(BASE_INPUT);
+
+    expect(result.status).toBe("skipped");
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("skips when the owner has no email on file", async () => {
+    const { supabase } = buildSupabaseMock({ email: null, prefs: null });
+    mockGetServiceSupabase.mockReturnValue(
+      supabase as unknown as ReturnType<typeof getServiceSupabase>
+    );
+
+    const result = await deliverUrgentOwnerEmail(BASE_INPUT);
+
+    expect(result.status).toBe("skipped");
+    expect(result.reason).toBe("no_owner_email");
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("never throws when sendEmail itself rejects", async () => {
+    const { supabase } = buildSupabaseMock({
+      email: "owner@example.com",
+      prefs: null,
+    });
+    mockGetServiceSupabase.mockReturnValue(
+      supabase as unknown as ReturnType<typeof getServiceSupabase>
+    );
+    mockSendEmail.mockRejectedValue(new Error("network down"));
+
+    const result = await deliverUrgentOwnerEmail(BASE_INPUT);
+
+    expect(result.status).toBe("failed");
+    expect(result.reason).toContain("network down");
+  });
+
+  it("skips cleanly when Supabase is not configured", async () => {
+    mockGetServiceSupabase.mockReturnValue(
+      null as unknown as ReturnType<typeof getServiceSupabase>
+    );
+
+    const result = await deliverUrgentOwnerEmail(BASE_INPUT);
+
+    expect(result.status).toBe("skipped");
+    expect(result.reason).toBe("supabase_unconfigured");
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What
Closes the gap where the owner-notification "brain" created **in-app notifications only** — `sendEmail()` and the digest path were dead code, so owners received **zero emails** even for emergencies.

## Changes
- `urgent-email.ts`: gated, never-throws delivery via the existing Resend `sendEmail()`, recording outcome through the shared notification-delivery state machine.
- `notification-handler`: `insertNotification` returns the row id; `URGENCY_HIGH` fires the urgent email (REPORT_READY stays in-app to avoid double-emailing).
- `event-bus`/`report-pipeline`: thread `reportStorageId` for a report deep link.
- No-ops cleanly without `RESEND_API_KEY`; respects owner opt-out; **no clinical logic or payload-shape changes.**

## Verify
- tsc 0, eslint 0 on changed files; 8 new unit tests (sent / unconfigured no-op / opt-out / no-email / throws / supabase-unconfigured).

## Prod note
Live email requires `RESEND_API_KEY` (+ optional `RESEND_FROM_EMAIL`) set in Vercel. Without it, behavior is unchanged (in-app only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)