### PR TITLE
feat(analytics): plain-language owner readout replaces abstract graphs

### DIFF
--- a/plans/analytics-owner-readout-redesign.md
+++ b/plans/analytics-owner-readout-redesign.md
@@ -1,0 +1,62 @@
+# Analytics Owner-Readout Redesign
+
+**Goal:** Replace the confusing 5-widget "Health Analytics" dashboard (evidence-coverage
+ring, wellness index number, urgency donut, top-symptoms bar, severity scatter) with a
+calming, plain-language readout that answers what a worried dog owner actually asks:
+*"Is my dog okay, and what do I do?"*
+
+Grounded in 3 parallel research passes (owner-needs research, calming-health-UX design
+spec, full code map). Sources cited in those agent reports.
+
+## Design (top-to-bottom, single column, mobile-first)
+1. **Hero verdict card** — ONE 4-state answer from the latest check's deterministic
+   `urgency`: Watch at home / Plan a vet visit / Call your vet today / Emergency.
+   Status ring (color = state, fill = latest check confidence), plain headline + reassuring
+   sub-line, always-present "call a vet" path. Never diagnoses, never gives all-clear.
+2. **Recovery trend strip** — the ONLY chart: a minimal wellness sparkline framed by a
+   plain-language verdict ("Bella seems to be improving"), derived from
+   `snapshot.baselineShift.direction`. Falls back to a text state when <3 checks.
+3. **Recent signs** — plain chips from the latest check (replaces the bar chart).
+4. **"See the full details"** — collapsed `<details>` accordion holding the ORIGINAL
+   widgets (ProductIntelligencePanel + urgency donut + top symptoms + severity chart) and
+   the save-snapshot persistence flow. Nothing is deleted; power/vet use preserved.
+5. **Safety footer** — standing not-a-diagnosis / contact-your-vet disclaimer.
+
+## Empty / low-data states (the 1-check case is the COMMON case)
+- 0 checks → friendly "start a check" hero, no empty chart frames.
+- 1 check → real verdict from that check; trend shows text, not a 1-point line.
+- 2 checks → verdict + cautious 2-point trend ("not enough yet to call a trend").
+- 3+ → full trend verdict.
+
+## Safety guardrails (hard rules in copy)
+- Never diagnose, never give the all-clear, never recommend treatment/dose.
+- Every state keeps a visible "contact a vet" path; always defer to a real vet.
+- Verdict + trend come ONLY from deterministic triage state (urgency, baselineShift).
+  The presentation layer re-phrases; it never decides medical meaning.
+
+## Files
+- NEW `src/lib/analytics/owner-readout.ts` — pure mapper (entries+snapshot → view model). Tested.
+- NEW `src/components/analytics/owner-status-hero.tsx`
+- NEW `src/components/analytics/recovery-trend-strip.tsx`
+- NEW `src/components/analytics/recent-signs.tsx`
+- EDIT `src/components/analytics/index.ts` — export new components.
+- EDIT `src/app/(dashboard)/analytics/page.tsx` — new layout; old grid → accordion.
+- NEW `tests/owner-readout.test.ts` — mapper unit tests (verdict/trend/data-state).
+
+## Verification
+- `npx jest tests/owner-readout.test.ts` green.
+- `npm run build` passes.
+- Real browser test on the running preview: demo mode (9 checks) + low-data behavior.
+
+## Status: COMPLETE (2026-06-18)
+- Mapper unit tests: 9/9 green (`tests/owner-readout.test.ts`).
+- `npx tsc --noEmit`: clean. `npx eslint <changed>`: clean.
+- `npm run build`: passed; `/analytics` prerenders static (○), 66/66 pages.
+- Server-side render confirmed via preview (header + h1 present).
+- Dedicated read-only review pass: verdict SHIP, no blocking findings; the one
+  SHOULD-FIX (2-point line under "no trend yet") resolved — chart now shows only
+  at 3+ checks.
+- Note: local demo-mode browser render stalls on the app's root `loading.tsx`
+  Suspense for EVERY route (dashboard included) — a pre-existing app-shell
+  behaviour with no `.env.local`, unrelated to this change. Authed prod renders
+  normally; verify the visual there.

--- a/src/app/(dashboard)/analytics/page.tsx
+++ b/src/app/(dashboard)/analytics/page.tsx
@@ -1,14 +1,19 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
 import { subDays } from "date-fns";
-import { BarChart3, Loader2 } from "lucide-react";
+import { BarChart3, ChevronDown, Loader2, Stethoscope } from "lucide-react";
 import { PrivateTesterQuarantinedSurface } from "@/components/private-tester/quarantined-surface";
 import Card from "@/components/ui/card";
 import Select from "@/components/ui/select";
+import { buttonClassName } from "@/components/ui/button";
 import {
   HealthScoreCard,
+  OwnerStatusHero,
   ProductIntelligencePanel,
+  RecentSigns,
+  RecoveryTrendStrip,
   SeverityTrendChart,
   SymptomFrequencyChart,
   UrgencyDistribution,
@@ -17,6 +22,7 @@ import type { SymptomCheckEntry } from "@/components/timeline/types";
 import { symptomCheckRowToEntry, type SymptomCheckDbRow } from "@/lib/symptom-check-entry-map";
 import { getPrivateTesterQuarantinedSurface } from "@/lib/private-tester-scope";
 import { buildProductIntelligenceSnapshot } from "@/lib/product-intelligence";
+import { buildOwnerReadout } from "@/lib/analytics/owner-readout";
 import {
   buildOwnerRecoveryCheckpoint,
   loadProductIntelligenceHistory,
@@ -155,6 +161,32 @@ function AnalyticsPageContent() {
     [filtered, now, selectedPetIdForRecovery]
   );
 
+  const selectedPetName = useMemo(() => {
+    if (petId === "all") return undefined;
+    return petOptions.find((option) => option.value === petId)?.label;
+  }, [petId, petOptions]);
+
+  const ownerReadout = useMemo(
+    () =>
+      buildOwnerReadout({
+        entries: filtered,
+        snapshot: productSnapshot,
+        now,
+        fallbackPetName: selectedPetName ?? "your dog",
+      }),
+    [filtered, productSnapshot, now, selectedPetName]
+  );
+
+  // Latest check's confidence drives the hero ring fill (0..1).
+  const latestConfidence = useMemo(() => {
+    if (filtered.length === 0) return 0.5;
+    const latest = [...filtered].sort(
+      (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+    )[0];
+    const c = latest?.confidence ?? 0.5;
+    return c > 1 ? c / 100 : c;
+  }, [filtered]);
+
   const loadProductHistory = useCallback(async () => {
     if (!selectedPetIdForPersistence) {
       setProductUiState((current) => ({ ...current, history: null }));
@@ -248,20 +280,25 @@ function AnalyticsPageContent() {
   ]);
 
   return (
-    <div className="max-w-7xl mx-auto space-y-6">
-      <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4">
+    <div className="mx-auto max-w-2xl space-y-5">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
         <div>
-          <div className="flex items-center gap-2 text-blue-600 mb-1">
-            <BarChart3 className="h-6 w-6" aria-hidden />
-            <span className="text-sm font-semibold uppercase tracking-wide">Insights</span>
+          <div className="mb-1 flex items-center gap-2 text-[#00a878]">
+            <BarChart3 className="h-5 w-5" aria-hidden />
+            <span className="text-sm font-semibold uppercase tracking-wide">
+              {ownerReadout.petName === "your dog"
+                ? "Health overview"
+                : `${ownerReadout.petName}'s health`}
+            </span>
           </div>
-          <h1 className="text-2xl font-bold text-gray-900">Health analytics</h1>
-          <p className="text-gray-500 mt-1">
-            Trends from symptom checks{!isSupabaseConfigured ? " (demo data)" : ""}
+          <h1 className="text-2xl font-bold text-[#2c2a26]">How is your dog doing?</h1>
+          <p className="mt-1 text-sm text-[#6b665d]">
+            A plain-language read on your recent symptom checks
+            {!isSupabaseConfigured ? " (demo data)" : ""}.
           </p>
         </div>
-        <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
-          <div className="w-full sm:w-48">
+        <div className="flex flex-col gap-3 sm:flex-row">
+          <div className="w-full sm:w-40">
             <Select
               label="Dog"
               options={petOptions}
@@ -269,9 +306,9 @@ function AnalyticsPageContent() {
               onChange={(e) => setPetId(e.target.value)}
             />
           </div>
-          <div className="w-full sm:w-48">
+          <div className="w-full sm:w-40">
             <Select
-              label="Date range"
+              label="Time"
               options={RANGE_OPTIONS}
               value={range}
               onChange={(e) => setRange(e.target.value)}
@@ -281,56 +318,113 @@ function AnalyticsPageContent() {
       </div>
 
       {loading ? (
-        <div className="flex items-center justify-center py-24 text-gray-500 gap-2">
+        <div className="flex items-center justify-center gap-2 py-24 text-[#6b665d]">
           <Loader2 className="h-6 w-6 animate-spin" aria-hidden />
-          Loading analytics…
+          Loading…
         </div>
       ) : isSupabaseConfigured && pets.length === 0 ? (
-        <Card className="p-10 text-center text-gray-600">
-          <p>Add a dog profile to see analytics from your symptom checks.</p>
+        <Card className="p-10 text-center text-[#6b665d]">
+          <p>Add a dog profile to start tracking how your dog is doing.</p>
         </Card>
+      ) : ownerReadout.checkCount === 0 || !ownerReadout.verdict ? (
+        <section className="rounded-3xl border border-[#e8e2d8] bg-white p-8 text-center shadow-sm">
+          <div
+            className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl"
+            style={{ background: "rgba(0,168,120,0.12)", color: "#0a7d5b" }}
+          >
+            <Stethoscope className="h-7 w-7" aria-hidden />
+          </div>
+          <h2 className="mt-4 text-xl font-bold text-[#2c2a26]">
+            Let&apos;s get to know {ownerReadout.petName}
+          </h2>
+          <p className="mx-auto mt-2 max-w-sm text-sm leading-relaxed text-[#6b665d]">
+            Do a quick symptom check and we&apos;ll show you how {ownerReadout.petName}
+            {" "}is doing — in plain language, with what to watch for.
+          </p>
+          <Link
+            href="/symptom-checker"
+            className={`${buttonClassName()} mt-5 inline-flex`}
+          >
+            <Stethoscope className="mr-2 h-4 w-4" aria-hidden />
+            Start a quick check
+          </Link>
+        </section>
       ) : (
         <>
-          <Card className="p-6">
-            <ProductIntelligencePanel
-              snapshot={productSnapshot}
-              historyCount={productUiState.history?.readiness.length}
-              onSaveSnapshot={selectedPetIdForPersistence ? saveReadinessSnapshot : undefined}
-              saveSnapshotDisabled={productUiState.historyLoading}
-              saveSnapshotInProgress={productUiState.readinessSaving}
-              saveSnapshotStatus={productUiState.readinessStatus}
-              recoveryCheckpoint={recoveryCheckpoint}
-              recoveryHistoryCount={productUiState.history?.recovery.length}
-              onSaveRecoveryCheckpoint={
-                selectedPetIdForPersistence ? saveRecoveryCheckpoint : undefined
-              }
-              saveRecoveryDisabled={productUiState.historyLoading}
-              saveRecoveryInProgress={productUiState.recoverySaving}
-              saveRecoveryStatus={productUiState.recoveryStatus}
-            />
-          </Card>
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <Card className="p-6">
-              <HealthScoreCard entries={filtered} />
-            </Card>
-            <Card className="p-6">
-              <h2 className="text-sm font-semibold text-gray-900 mb-2">Urgency mix</h2>
-              <p className="text-xs text-gray-500 mb-2">How often each urgency level appeared</p>
-              <UrgencyDistribution entries={filtered} />
-            </Card>
-          </div>
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <Card className="p-6">
-              <h2 className="text-sm font-semibold text-gray-900 mb-1">Top symptoms</h2>
-              <p className="text-xs text-gray-500 mb-4">Five most common primary concerns</p>
-              <SymptomFrequencyChart entries={filtered} />
-            </Card>
-            <Card className="p-6">
-              <h2 className="text-sm font-semibold text-gray-900 mb-1">Severity over time</h2>
-              <p className="text-xs text-gray-500 mb-4">Per-check severity (chronological)</p>
-              <SeverityTrendChart entries={filtered} />
-            </Card>
-          </div>
+          <OwnerStatusHero
+            verdict={ownerReadout.verdict}
+            petName={ownerReadout.petName}
+            asOf={ownerReadout.asOf}
+            confidence={latestConfidence}
+          />
+
+          <RecoveryTrendStrip readout={ownerReadout.trend} petName={ownerReadout.petName} />
+
+          <RecentSigns signs={ownerReadout.signs} asOf={ownerReadout.asOf} />
+
+          <details className="group rounded-2xl border border-[#e8e2d8] bg-white">
+            <summary className="flex cursor-pointer list-none items-center justify-between gap-2 px-5 py-4 text-sm font-medium text-[#7c4dc4]">
+              <span>See the full details</span>
+              <ChevronDown
+                className="h-4 w-4 transition-transform group-open:rotate-180"
+                aria-hidden
+              />
+            </summary>
+            <div className="space-y-5 border-t border-[#e8e2d8] px-4 py-5 sm:px-5">
+              <ProductIntelligencePanel
+                snapshot={productSnapshot}
+                historyCount={productUiState.history?.readiness.length}
+                onSaveSnapshot={
+                  selectedPetIdForPersistence ? saveReadinessSnapshot : undefined
+                }
+                saveSnapshotDisabled={productUiState.historyLoading}
+                saveSnapshotInProgress={productUiState.readinessSaving}
+                saveSnapshotStatus={productUiState.readinessStatus}
+                recoveryCheckpoint={recoveryCheckpoint}
+                recoveryHistoryCount={productUiState.history?.recovery.length}
+                onSaveRecoveryCheckpoint={
+                  selectedPetIdForPersistence ? saveRecoveryCheckpoint : undefined
+                }
+                saveRecoveryDisabled={productUiState.historyLoading}
+                saveRecoveryInProgress={productUiState.recoverySaving}
+                saveRecoveryStatus={productUiState.recoveryStatus}
+              />
+              <div className="grid grid-cols-1 gap-5 lg:grid-cols-2">
+                <Card className="p-5">
+                  <HealthScoreCard entries={filtered} />
+                </Card>
+                <Card className="p-5">
+                  <h2 className="mb-2 text-sm font-semibold text-gray-900">Urgency mix</h2>
+                  <p className="mb-2 text-xs text-gray-500">
+                    How often each urgency level appeared
+                  </p>
+                  <UrgencyDistribution entries={filtered} />
+                </Card>
+                <Card className="p-5">
+                  <h2 className="mb-1 text-sm font-semibold text-gray-900">Top symptoms</h2>
+                  <p className="mb-4 text-xs text-gray-500">
+                    Five most common primary concerns
+                  </p>
+                  <SymptomFrequencyChart entries={filtered} />
+                </Card>
+                <Card className="p-5">
+                  <h2 className="mb-1 text-sm font-semibold text-gray-900">
+                    Severity over time
+                  </h2>
+                  <p className="mb-4 text-xs text-gray-500">
+                    Per-check severity (chronological)
+                  </p>
+                  <SeverityTrendChart entries={filtered} />
+                </Card>
+              </div>
+            </div>
+          </details>
+
+          <p className="px-2 pb-4 pt-1 text-center text-xs leading-relaxed text-[#8a857a]">
+            PawVital helps you understand your dog&apos;s signs — it&apos;s not a
+            diagnosis and doesn&apos;t replace a vet. If you&apos;re worried or things
+            get worse, contact your vet. In an emergency, call an emergency vet right away.
+          </p>
         </>
       )}
     </div>

--- a/src/components/analytics/index.ts
+++ b/src/components/analytics/index.ts
@@ -3,3 +3,6 @@ export { default as SeverityTrendChart } from "./severity-trend-chart";
 export { default as UrgencyDistribution } from "./urgency-distribution";
 export { default as HealthScoreCard } from "./health-score-card";
 export { default as ProductIntelligencePanel } from "./product-intelligence-panel";
+export { OwnerStatusHero } from "./owner-status-hero";
+export { RecoveryTrendStrip } from "./recovery-trend-strip";
+export { RecentSigns } from "./recent-signs";

--- a/src/components/analytics/owner-status-hero.tsx
+++ b/src/components/analytics/owner-status-hero.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import Link from "next/link";
+import { AlertCircle, PawPrint, Phone, Stethoscope } from "lucide-react";
+import { buttonClassName } from "@/components/ui/button";
+import type { OwnerVerdict, OwnerVerdictState } from "@/lib/analytics/owner-readout";
+
+type StateStyle = {
+  ring: string;
+  pillBg: string;
+  pillText: string;
+  iconBg: string;
+  iconText: string;
+  pillLabel: string;
+};
+
+const STATE_STYLES: Record<OwnerVerdictState, StateStyle> = {
+  watch: {
+    ring: "#00a878",
+    pillBg: "rgba(0,168,120,0.12)",
+    pillText: "#0a7d5b",
+    iconBg: "rgba(0,168,120,0.12)",
+    iconText: "#0a7d5b",
+    pillLabel: "Stable",
+  },
+  schedule: {
+    ring: "#e0a458",
+    pillBg: "rgba(224,164,88,0.16)",
+    pillText: "#9a6b1f",
+    iconBg: "rgba(224,164,88,0.16)",
+    iconText: "#9a6b1f",
+    pillLabel: "Worth a visit",
+  },
+  urgent: {
+    ring: "#d98b3a",
+    pillBg: "rgba(217,139,58,0.16)",
+    pillText: "#8a4f15",
+    iconBg: "rgba(217,139,58,0.16)",
+    iconText: "#8a4f15",
+    pillLabel: "Get advice",
+  },
+  emergency: {
+    ring: "#e25c5c",
+    pillBg: "rgba(226,92,92,0.14)",
+    pillText: "#b23636",
+    iconBg: "rgba(226,92,92,0.14)",
+    iconText: "#b23636",
+    pillLabel: "Act now",
+  },
+};
+
+function StatusRing({
+  color,
+  fill,
+  petName,
+}: {
+  color: string;
+  fill: number;
+  petName: string;
+}) {
+  const size = 150;
+  const stroke = 12;
+  const radius = (size - stroke) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const clamped = Math.max(0.08, Math.min(1, fill));
+  const dash = circumference * clamped;
+  const initial = petName.trim().charAt(0).toUpperCase() || "🐾";
+
+  return (
+    <div className="relative shrink-0" style={{ width: size, height: size }}>
+      <svg width={size} height={size} className="-rotate-90" aria-hidden>
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          stroke="#e8e2d8"
+          strokeWidth={stroke}
+        />
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          stroke={color}
+          strokeWidth={stroke}
+          strokeLinecap="round"
+          strokeDasharray={`${dash} ${circumference}`}
+        />
+      </svg>
+      <div className="absolute inset-0 flex flex-col items-center justify-center">
+        <div
+          className="flex h-11 w-11 items-center justify-center rounded-full text-lg font-bold"
+          style={{ background: "rgba(0,0,0,0.04)", color }}
+        >
+          {initial === "🐾" ? <PawPrint className="h-5 w-5" /> : initial}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The hero verdict card — the single 2-second answer for a worried owner.
+ * State and copy come from the deterministic triage verdict; this only renders it.
+ */
+export function OwnerStatusHero({
+  verdict,
+  petName,
+  asOf,
+  confidence,
+}: {
+  verdict: OwnerVerdict;
+  petName: string;
+  asOf: string | null;
+  /** 0..1 — drives the ring fill (latest check confidence). */
+  confidence: number;
+}) {
+  const style = STATE_STYLES[verdict.state];
+
+  return (
+    <section
+      className="rounded-3xl border border-[#e8e2d8] bg-white p-6 shadow-sm sm:p-8"
+      aria-label="Current status"
+    >
+      <div className="flex flex-col items-center gap-5 text-center sm:flex-row sm:items-center sm:gap-7 sm:text-left">
+        <StatusRing color={style.ring} fill={confidence} petName={petName} />
+        <div className="min-w-0 flex-1">
+          <span
+            className="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold"
+            style={{ background: style.pillBg, color: style.pillText }}
+          >
+            <span
+              className="inline-block h-1.5 w-1.5 rounded-full"
+              style={{ background: style.ring }}
+            />
+            {style.pillLabel}
+          </span>
+          <h2 className="mt-2 text-2xl font-bold text-[#2c2a26] sm:text-[28px]">
+            {verdict.headline}
+          </h2>
+          <p className="mt-2 text-[15px] leading-relaxed text-[#6b665d]">
+            {verdict.subline}
+          </p>
+          {asOf ? (
+            <p className="mt-1 text-xs text-[#8a857a]">{asOf}</p>
+          ) : null}
+        </div>
+      </div>
+
+      {verdict.emergency ? (
+        <div
+          className="mt-5 flex items-start gap-2 rounded-2xl px-4 py-3 text-sm"
+          style={{ background: "rgba(226,92,92,0.1)", color: "#b23636" }}
+          role="alert"
+        >
+          <AlertCircle className="mt-0.5 h-5 w-5 shrink-0" aria-hidden />
+          <span>
+            If {petName} is struggling to breathe, collapsed, bleeding heavily, or
+            having repeated seizures, contact an emergency vet right away.
+          </span>
+        </div>
+      ) : null}
+
+      <div className="mt-5 flex flex-col gap-2 sm:flex-row">
+        <Link
+          href="/symptom-checker"
+          className={`${buttonClassName()} w-full sm:w-auto`}
+          style={
+            verdict.emergency
+              ? { background: "#e25c5c", borderColor: "#e25c5c" }
+              : undefined
+          }
+        >
+          {verdict.emergency ? (
+            <Phone className="mr-2 h-4 w-4" aria-hidden />
+          ) : (
+            <Stethoscope className="mr-2 h-4 w-4" aria-hidden />
+          )}
+          {verdict.ctaLabel}
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/src/components/analytics/recent-signs.tsx
+++ b/src/components/analytics/recent-signs.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import type { OwnerSign } from "@/lib/analytics/owner-readout";
+
+const TONE_STYLE: Record<OwnerSign["tone"], { bg: string; border: string; text: string }> = {
+  neutral: { bg: "#f7f4ef", border: "#e8e2d8", text: "#4a463f" },
+  caution: { bg: "rgba(224,164,88,0.14)", border: "rgba(224,164,88,0.4)", text: "#8a4f15" },
+  alert: { bg: "rgba(226,92,92,0.12)", border: "rgba(226,92,92,0.4)", text: "#b23636" },
+};
+
+/**
+ * Plain-language chips summarising the latest check. Replaces the ranked
+ * top-symptoms bar chart with something an owner reads at a glance.
+ */
+export function RecentSigns({
+  signs,
+  asOf,
+}: {
+  signs: OwnerSign[];
+  asOf: string | null;
+}) {
+  if (signs.length === 0) return null;
+
+  return (
+    <section className="rounded-2xl border border-[#e8e2d8] bg-white p-5">
+      <p className="text-xs font-semibold uppercase tracking-wide text-[#8a857a]">
+        What you told us
+      </p>
+      {asOf ? <p className="mt-0.5 text-xs text-[#a8a097]">{asOf}</p> : null}
+      <div className="mt-3 flex flex-wrap gap-2">
+        {signs.map((sign, i) => {
+          const tone = TONE_STYLE[sign.tone];
+          return (
+            <span
+              key={`${sign.label}-${i}`}
+              className="rounded-full border px-3 py-1.5 text-sm font-medium"
+              style={{ background: tone.bg, borderColor: tone.border, color: tone.text }}
+            >
+              {sign.label}
+            </span>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/analytics/recovery-trend-strip.tsx
+++ b/src/components/analytics/recovery-trend-strip.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Line, LineChart, ResponsiveContainer, YAxis } from "recharts";
+import { ArrowDownRight, ArrowRight, ArrowUpRight, Minus } from "lucide-react";
+import type { OwnerTrend, OwnerTrendReadout } from "@/lib/analytics/owner-readout";
+
+const TREND_COLOR: Record<OwnerTrend, string> = {
+  improving: "#00a878",
+  steady: "#7c4dc4",
+  worsening: "#d98b3a",
+  insufficient: "#a8a097",
+};
+
+function TrendIcon({ trend }: { trend: OwnerTrend }) {
+  const cls = "h-4 w-4";
+  if (trend === "improving") return <ArrowUpRight className={cls} aria-hidden />;
+  if (trend === "worsening") return <ArrowDownRight className={cls} aria-hidden />;
+  if (trend === "steady") return <ArrowRight className={cls} aria-hidden />;
+  return <Minus className={cls} aria-hidden />;
+}
+
+/**
+ * The only chart on the page: a minimal wellness sparkline (no axes, no grid)
+ * framed by a plain-language verdict. When there aren't enough check-ins, it
+ * shows a calm text state instead of an empty or misleading chart.
+ */
+export function RecoveryTrendStrip({
+  readout,
+  petName,
+}: {
+  readout: OwnerTrendReadout;
+  petName: string;
+}) {
+  const color = TREND_COLOR[readout.trend];
+  const data = readout.series.map((v, i) => ({ i, v }));
+
+  return (
+    <section className="rounded-2xl border border-[#e8e2d8] bg-white p-5">
+      <p className="text-xs font-semibold uppercase tracking-wide text-[#8a857a]">
+        How {petName} is trending
+      </p>
+      <div className="mt-1 flex items-center gap-2">
+        <span style={{ color }}>
+          <TrendIcon trend={readout.trend} />
+        </span>
+        <h3 className="text-base font-semibold text-[#2c2a26]">
+          {readout.headline}
+        </h3>
+      </div>
+      <p className="mt-1 text-sm leading-relaxed text-[#6b665d]">{readout.detail}</p>
+
+      {readout.showChart && data.length >= 2 ? (
+        <div className="mt-3">
+          <div className="mb-1 flex justify-between text-[11px] text-[#a8a097]">
+            <span>Earlier</span>
+            <span>Today</span>
+          </div>
+          <ResponsiveContainer width="100%" height={56}>
+            <LineChart data={data} margin={{ top: 4, right: 6, left: 6, bottom: 0 }}>
+              <YAxis domain={[20, 100]} hide />
+              <Line
+                type="monotone"
+                dataKey="v"
+                stroke={color}
+                strokeWidth={2.5}
+                dot={false}
+                activeDot={{ r: 4 }}
+                isAnimationActive={false}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/lib/analytics/owner-readout.ts
+++ b/src/lib/analytics/owner-readout.ts
@@ -1,0 +1,337 @@
+import type { SymptomCheckEntry } from "@/components/timeline/types";
+import type {
+  ProductBaselineShiftDirection,
+  ProductIntelligenceSnapshot,
+} from "@/lib/product-intelligence";
+
+/**
+ * Owner-facing analytics readout.
+ *
+ * This module is a *presentation* layer only. It re-phrases the deterministic
+ * triage state (`SymptomCheckEntry.urgency` and the product-intelligence
+ * `baselineShift`) into plain language a worried, non-medical owner can act on.
+ * It never makes a medical decision: the verdict state comes straight from the
+ * latest check's `urgency`, and the trend comes straight from the deterministic
+ * `baselineShift.direction`. Copy here must never diagnose, never give an
+ * all-clear, and must always keep a "contact a vet" path open.
+ */
+
+/** Plain-language verdict states, one-to-one with deterministic `urgency`. */
+export type OwnerVerdictState = "watch" | "schedule" | "urgent" | "emergency";
+
+/** Plain-language recovery trend. */
+export type OwnerTrend = "improving" | "steady" | "worsening" | "insufficient";
+
+/**
+ * How much usable data the owner has. The single-check case is the common case
+ * and must render a real answer, not an empty dashboard.
+ */
+export type OwnerDataState = "empty" | "single" | "building" | "ready";
+
+export interface OwnerVerdict {
+  state: OwnerVerdictState;
+  /** Short headline, e.g. "Watch Bella at home". */
+  headline: string;
+  /** One reassuring, bounded sub-line. Never an all-clear. */
+  subline: string;
+  /** Label for the primary next-action button. */
+  ctaLabel: string;
+  /** True only for the genuinely-urgent state — drives the emphasised vet banner. */
+  emergency: boolean;
+}
+
+export interface OwnerTrendReadout {
+  trend: OwnerTrend;
+  /** Plain-language heading, e.g. "Bella seems to be improving". */
+  headline: string;
+  /** Supporting sentence. */
+  detail: string;
+  /** Wellness points over time (chronological), higher = better. For the sparkline. */
+  series: number[];
+  /** Whether a sparkline should render (needs >= 3 points). */
+  showChart: boolean;
+}
+
+export interface OwnerSign {
+  label: string;
+  tone: "neutral" | "caution" | "alert";
+}
+
+export interface OwnerReadout {
+  dataState: OwnerDataState;
+  petName: string;
+  checkCount: number;
+  /** Null only when there are zero checks. */
+  verdict: OwnerVerdict | null;
+  trend: OwnerTrendReadout;
+  signs: OwnerSign[];
+  /** Plain "as of" line for the latest check, e.g. "Based on today's check". */
+  asOf: string | null;
+}
+
+/** Wellness points by severity (higher = healthier). Mirrors product-intelligence. */
+const WELLNESS_BY_SEVERITY: Record<SymptomCheckEntry["severity"], number> = {
+  mild: 92,
+  moderate: 78,
+  serious: 58,
+  critical: 34,
+};
+
+const SEVERITY_LABEL: Record<SymptomCheckEntry["severity"], string> = {
+  mild: "Mild",
+  moderate: "Moderate",
+  serious: "Serious",
+  critical: "Critical",
+};
+
+const SEVERITY_TONE: Record<SymptomCheckEntry["severity"], OwnerSign["tone"]> = {
+  mild: "neutral",
+  moderate: "caution",
+  serious: "alert",
+  critical: "alert",
+};
+
+const URGENCY_LABEL: Record<SymptomCheckEntry["urgency"], string> = {
+  monitor: "Watch at home",
+  schedule: "Plan a vet visit",
+  urgent: "Call your vet soon",
+  emergency: "Emergency care",
+};
+
+function titleCaseName(name: string | undefined | null): string {
+  const trimmed = (name ?? "").trim();
+  if (!trimmed) return "your dog";
+  return trimmed;
+}
+
+function sortChronological(entries: SymptomCheckEntry[]): SymptomCheckEntry[] {
+  return [...entries].sort(
+    (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+  );
+}
+
+/** "today" / "yesterday" / "Mon 3" style recency for the latest check. */
+function describeRecency(latest: SymptomCheckEntry, now: Date): string {
+  const then = new Date(latest.created_at);
+  const dayMs = 24 * 60 * 60 * 1000;
+  const diffDays = Math.floor(
+    (startOfDay(now).getTime() - startOfDay(then).getTime()) / dayMs,
+  );
+  if (diffDays <= 0) return "Based on today's check";
+  if (diffDays === 1) return "Based on yesterday's check";
+  if (diffDays < 7) return `Based on your check ${diffDays} days ago`;
+  return "Based on your latest check";
+}
+
+function startOfDay(d: Date): Date {
+  const copy = new Date(d);
+  copy.setHours(0, 0, 0, 0);
+  return copy;
+}
+
+/**
+ * Build the 4-state verdict from the latest check's deterministic `urgency`.
+ * One-to-one mapping; no medical inference is added here.
+ */
+function buildVerdict(
+  latest: SymptomCheckEntry,
+  petName: string,
+): OwnerVerdict {
+  switch (latest.urgency) {
+    case "emergency":
+      return {
+        state: "emergency",
+        headline: `${petName} may need urgent care`,
+        subline:
+          "Some signs shouldn't wait. Contact an emergency vet now — it's always okay to call.",
+        ctaLabel: "Get vet help now",
+        emergency: true,
+      };
+    case "urgent":
+      return {
+        state: "urgent",
+        headline: `Call your vet about ${petName} soon`,
+        subline:
+          "These signs are worth a vet's input today. When in doubt, it's always okay to call.",
+        ctaLabel: "Start a symptom check",
+        emergency: false,
+      };
+    case "schedule":
+      return {
+        state: "schedule",
+        headline: `Plan a vet visit for ${petName}`,
+        subline:
+          "This doesn't look like an emergency, but it's worth booking a routine vet visit.",
+        ctaLabel: "Start a symptom check",
+        emergency: false,
+      };
+    case "monitor":
+    default:
+      return {
+        state: "watch",
+        headline: `Watch ${petName} at home`,
+        subline:
+          "This doesn't look like an emergency right now. Keep an eye out, and call your vet if anything changes.",
+        ctaLabel: "Check in again",
+        emergency: false,
+      };
+  }
+}
+
+function trendFromDirection(
+  direction: ProductBaselineShiftDirection,
+): OwnerTrend {
+  switch (direction) {
+    case "improving":
+      return "improving";
+    case "declining":
+    case "urgent_override":
+      return "worsening";
+    case "steady":
+      return "steady";
+    case "unknown":
+    default:
+      return "insufficient";
+  }
+}
+
+function buildTrend(
+  entries: SymptomCheckEntry[],
+  dataState: OwnerDataState,
+  snapshot: ProductIntelligenceSnapshot,
+  petName: string,
+): OwnerTrendReadout {
+  const series = sortChronological(entries).map(
+    (e) => WELLNESS_BY_SEVERITY[e.severity],
+  );
+
+  // Need at least 3 comparable checks before we state a real trend direction.
+  if (dataState !== "ready") {
+    const detail =
+      dataState === "empty"
+        ? `We'll show ${petName}'s trend here once you've done a couple of checks.`
+        : dataState === "single"
+          ? `Trend appears after a few check-ins — you've done 1 so far.`
+          : `Not enough yet to call a trend — keep checking in.`;
+    // Only draw the line once we can state a real direction (3+ checks). A
+    // 2-point line reads as a trend the copy isn't ready to claim.
+    return {
+      trend: "insufficient",
+      headline: `${petName}'s trend`,
+      detail,
+      series,
+      showChart: false,
+    };
+  }
+
+  const trend = trendFromDirection(snapshot.baselineShift.direction);
+  switch (trend) {
+    case "improving":
+      return {
+        trend,
+        headline: `${petName} seems to be improving`,
+        detail:
+          "Recent check-ins are trending back toward normal. Keep going, and finish any vet-prescribed meds.",
+        series,
+        showChart: true,
+      };
+    case "worsening":
+      return {
+        trend,
+        headline: `${petName}'s signs are trending worse`,
+        detail:
+          "Recent check-ins are heading the wrong way. Watch closely and check with your vet.",
+        series,
+        showChart: true,
+      };
+    case "steady":
+      return {
+        trend,
+        headline: `${petName} is holding steady`,
+        detail: "Recent check-ins look about the same. Keep watching for any change.",
+        series,
+        showChart: true,
+      };
+    case "insufficient":
+    default:
+      return {
+        trend: "insufficient",
+        headline: `${petName}'s trend`,
+        detail: "Keep checking in to build a clearer picture over time.",
+        series,
+        showChart: true,
+      };
+  }
+}
+
+/** Plain-language chips from the latest check. Replaces the top-symptoms bar chart. */
+function buildSigns(latest: SymptomCheckEntry): OwnerSign[] {
+  const signs: OwnerSign[] = [];
+  const symptom = (latest.primary_symptom ?? "").trim();
+  if (symptom) {
+    signs.push({ label: symptom, tone: SEVERITY_TONE[latest.severity] });
+  }
+  signs.push({ label: SEVERITY_LABEL[latest.severity], tone: SEVERITY_TONE[latest.severity] });
+  signs.push({
+    label: URGENCY_LABEL[latest.urgency],
+    tone:
+      latest.urgency === "emergency"
+        ? "alert"
+        : latest.urgency === "urgent"
+          ? "caution"
+          : "neutral",
+  });
+  return signs;
+}
+
+function resolveDataState(count: number): OwnerDataState {
+  if (count <= 0) return "empty";
+  if (count === 1) return "single";
+  if (count === 2) return "building";
+  return "ready";
+}
+
+/**
+ * Map filtered symptom checks + the deterministic product-intelligence snapshot
+ * into an owner-facing readout. Pure and side-effect free.
+ */
+export function buildOwnerReadout({
+  entries,
+  snapshot,
+  now = new Date(),
+  fallbackPetName = "your dog",
+}: {
+  entries: SymptomCheckEntry[];
+  snapshot: ProductIntelligenceSnapshot;
+  now?: Date;
+  fallbackPetName?: string;
+}): OwnerReadout {
+  const dataState = resolveDataState(entries.length);
+  const chronological = sortChronological(entries);
+  const latest = chronological[chronological.length - 1] ?? null;
+  const petName = titleCaseName(latest?.pet_name ?? fallbackPetName);
+
+  const trend = buildTrend(entries, dataState, snapshot, petName);
+
+  if (!latest) {
+    return {
+      dataState,
+      petName,
+      checkCount: 0,
+      verdict: null,
+      trend,
+      signs: [],
+      asOf: null,
+    };
+  }
+
+  return {
+    dataState,
+    petName,
+    checkCount: entries.length,
+    verdict: buildVerdict(latest, petName),
+    trend,
+    signs: buildSigns(latest),
+    asOf: describeRecency(latest, now),
+  };
+}

--- a/tests/owner-readout.test.ts
+++ b/tests/owner-readout.test.ts
@@ -1,0 +1,225 @@
+import { buildOwnerReadout } from "@/lib/analytics/owner-readout";
+import type { SymptomCheckEntry } from "@/components/timeline/types";
+import type {
+  ProductBaselineShiftDirection,
+  ProductIntelligenceSnapshot,
+} from "@/lib/product-intelligence";
+
+const NOW = new Date("2026-06-18T12:00:00.000Z");
+
+function entry(overrides: Partial<SymptomCheckEntry> = {}): SymptomCheckEntry {
+  return {
+    id: overrides.id ?? "e1",
+    pet_id: overrides.pet_id ?? "pet-1",
+    pet_name: overrides.pet_name ?? "Bella",
+    created_at: overrides.created_at ?? NOW.toISOString(),
+    primary_symptom: overrides.primary_symptom ?? "Vomiting",
+    severity: overrides.severity ?? "moderate",
+    urgency: overrides.urgency ?? "monitor",
+    top_diagnosis: overrides.top_diagnosis ?? "Upset stomach",
+    confidence: overrides.confidence ?? 0.8,
+    report_summary: overrides.report_summary,
+  };
+}
+
+function snapshot(
+  direction: ProductBaselineShiftDirection,
+): ProductIntelligenceSnapshot {
+  return {
+    state: "stable",
+    confidence: "medium",
+    displayScore: 70,
+    baselineShift: {
+      direction,
+      confidence: "medium",
+      latestScore: 70,
+      baselineScore: 60,
+      delta: 10,
+      evidenceChips: [],
+      missingEvidenceChips: [],
+      ownerSummary: "",
+      deterministicOverride: null,
+    },
+    evidenceCoverage: 1,
+    evidenceChips: [],
+    missingEvidenceChips: [],
+    nextEvidencePrompt: null,
+    deterministicOverride: null,
+    ownerSummary: "",
+    claimGuard: "",
+    persistenceAllowed: true,
+    persistenceBlockedReasons: [],
+  };
+}
+
+describe("buildOwnerReadout", () => {
+  it("returns an empty data state with no verdict when there are no checks", () => {
+    const readout = buildOwnerReadout({
+      entries: [],
+      snapshot: snapshot("unknown"),
+      now: NOW,
+      fallbackPetName: "Rex",
+    });
+
+    expect(readout.dataState).toBe("empty");
+    expect(readout.verdict).toBeNull();
+    expect(readout.checkCount).toBe(0);
+    expect(readout.petName).toBe("Rex");
+    expect(readout.trend.trend).toBe("insufficient");
+    expect(readout.trend.showChart).toBe(false);
+    expect(readout.signs).toHaveLength(0);
+  });
+
+  it("maps each urgency level to the correct plain-language verdict state", () => {
+    const cases: Array<[SymptomCheckEntry["urgency"], string]> = [
+      ["monitor", "watch"],
+      ["schedule", "schedule"],
+      ["urgent", "urgent"],
+      ["emergency", "emergency"],
+    ];
+
+    for (const [urgency, expectedState] of cases) {
+      const readout = buildOwnerReadout({
+        entries: [entry({ urgency })],
+        snapshot: snapshot("unknown"),
+        now: NOW,
+      });
+      expect(readout.verdict?.state).toBe(expectedState);
+    }
+  });
+
+  it("flags emergency=true only for the emergency urgency", () => {
+    const emergency = buildOwnerReadout({
+      entries: [entry({ urgency: "emergency" })],
+      snapshot: snapshot("unknown"),
+      now: NOW,
+    });
+    const monitor = buildOwnerReadout({
+      entries: [entry({ urgency: "monitor" })],
+      snapshot: snapshot("unknown"),
+      now: NOW,
+    });
+
+    expect(emergency.verdict?.emergency).toBe(true);
+    expect(monitor.verdict?.emergency).toBe(false);
+  });
+
+  it("treats a single check as the 'single' data state with a text-only trend", () => {
+    const readout = buildOwnerReadout({
+      entries: [entry({ urgency: "monitor" })],
+      snapshot: snapshot("unknown"),
+      now: NOW,
+    });
+
+    expect(readout.dataState).toBe("single");
+    expect(readout.checkCount).toBe(1);
+    expect(readout.verdict).not.toBeNull();
+    expect(readout.trend.showChart).toBe(false);
+    expect(readout.trend.detail).toContain("1 so far");
+  });
+
+  it("treats two checks as 'building' and still withholds the trend line", () => {
+    const entries = [
+      entry({ id: "a", created_at: "2026-06-14T12:00:00.000Z" }),
+      entry({ id: "b", created_at: "2026-06-16T12:00:00.000Z" }),
+    ];
+    const readout = buildOwnerReadout({
+      entries,
+      snapshot: snapshot("improving"),
+      now: NOW,
+    });
+
+    expect(readout.dataState).toBe("building");
+    expect(readout.trend.trend).toBe("insufficient");
+    // A 2-point line reads as a direction the copy isn't ready to claim.
+    expect(readout.trend.showChart).toBe(false);
+  });
+
+  it("uses the latest check for the verdict, regardless of input order", () => {
+    const older = entry({
+      id: "old",
+      created_at: new Date("2026-06-10T12:00:00.000Z").toISOString(),
+      urgency: "emergency",
+    });
+    const newer = entry({
+      id: "new",
+      created_at: new Date("2026-06-17T12:00:00.000Z").toISOString(),
+      urgency: "monitor",
+    });
+
+    // Pass newest first to ensure sorting, not array position, decides "latest".
+    const readout = buildOwnerReadout({
+      entries: [newer, older],
+      snapshot: snapshot("steady"),
+      now: NOW,
+    });
+
+    expect(readout.verdict?.state).toBe("watch");
+    expect(readout.verdict?.emergency).toBe(false);
+  });
+
+  it("derives a real trend from the deterministic baseline direction once data is ready", () => {
+    const entries = [
+      entry({ id: "a", created_at: "2026-06-10T12:00:00.000Z", severity: "serious" }),
+      entry({ id: "b", created_at: "2026-06-13T12:00:00.000Z", severity: "moderate" }),
+      entry({ id: "c", created_at: "2026-06-16T12:00:00.000Z", severity: "mild" }),
+    ];
+
+    const improving = buildOwnerReadout({
+      entries,
+      snapshot: snapshot("improving"),
+      now: NOW,
+    });
+    expect(improving.dataState).toBe("ready");
+    expect(improving.trend.trend).toBe("improving");
+    expect(improving.trend.showChart).toBe(true);
+    expect(improving.trend.series).toHaveLength(3);
+
+    const worsening = buildOwnerReadout({
+      entries,
+      snapshot: snapshot("declining"),
+      now: NOW,
+    });
+    expect(worsening.trend.trend).toBe("worsening");
+
+    const urgentOverride = buildOwnerReadout({
+      entries,
+      snapshot: snapshot("urgent_override"),
+      now: NOW,
+    });
+    expect(urgentOverride.trend.trend).toBe("worsening");
+
+    const steady = buildOwnerReadout({
+      entries,
+      snapshot: snapshot("steady"),
+      now: NOW,
+    });
+    expect(steady.trend.trend).toBe("steady");
+  });
+
+  it("builds plain-language sign chips from the latest check", () => {
+    const readout = buildOwnerReadout({
+      entries: [entry({ primary_symptom: "Limping", severity: "serious", urgency: "urgent" })],
+      snapshot: snapshot("unknown"),
+      now: NOW,
+    });
+
+    const labels = readout.signs.map((s) => s.label);
+    expect(labels).toContain("Limping");
+    expect(labels).toContain("Serious");
+    // serious severity → alert tone on the symptom chip
+    expect(readout.signs[0]).toEqual({ label: "Limping", tone: "alert" });
+  });
+
+  it("never returns an all-clear: every non-empty verdict keeps a vet path in its copy", () => {
+    for (const urgency of ["monitor", "schedule", "urgent", "emergency"] as const) {
+      const readout = buildOwnerReadout({
+        entries: [entry({ urgency })],
+        snapshot: snapshot("unknown"),
+        now: NOW,
+      });
+      const copy = `${readout.verdict?.subline} ${readout.verdict?.ctaLabel}`.toLowerCase();
+      expect(copy).toMatch(/vet|call|check/);
+    }
+  });
+});


### PR DESCRIPTION
Replaces the 5 confusing analytics widgets with a calming single-column plain-language readout: a 4-state hero verdict, one wellness sparkline framed by words, plain sign chips, and a collapsed accordion preserving all original widgets + persistence. Deterministic triage stays the source of truth. Pure mapper unit-tested 9/9; tsc/eslint clean; build passes; dedicated review verdict SHIP.