### PR TITLE
feat(analytics): strip debug widgets, add owner signal cards

### DIFF
--- a/plans/health-signals-roadmap.md
+++ b/plans/health-signals-roadmap.md
@@ -1,0 +1,63 @@
+# PawVital "Health Signals" — Owner Analytics Roadmap
+
+Owner-validated brief (2026-06-18): the Analytics screen must answer, in order,
+(1) what should I do now, (2) better/worse/same, (3) what changed, (4) what to
+track next, (5) what to share with the vet — and must NOT show internal/debug
+widgets (evidence ring, coverage %, wellness-index number, baseline-shift debug,
+persistence allowed/blocked) or fake metrics we don't have data for.
+
+## Phase 1 — Owner Analytics transformation ✅ SHIPPED (PR after #666)
+Default owner view, top-to-bottom:
+1. Hero verdict ("Call your vet about Bruno soon" + next action) — from deterministic `urgency`.
+2. Trend strip ("too early to call a trend" / better-worse-same) — from `baselineShift`.
+3. **Why this status** — plain drivers (latest sign + why it matters + recurrence). No diagnosis label.
+4. What you told us — sign chips.
+5. **Track next** — one adaptive nudge keyed to the latest symptom.
+6. **Vet packet** — "N checks · X urgent flags · ready to share" → /history.
+7. Collapsed "Full history — useful for your vet" — urgency mix, top signs, severity over time ONLY.
+8. Safety footer.
+REMOVED from owner view: evidence ring, coverage %, wellness-index number,
+baseline-shift debug, persistence allowed/blocked. (Lib computation kept for the
+trend; only the debug UI is gone.)
+Verifier: tests/owner-readout.test.ts (13/13), tsc/eslint clean, build prerenders
+/analytics static, dedicated review = SHIP.
+
+## Phase 2 — Daily Health Log + Smart Follow-Up Prompts (NEXT, needs schema)
+The habit loop. Structured daily fields the owner can log in ~30s.
+
+Proposed schema (`supabase-daily-health-log-schema.sql`, idempotent, RLS by owner):
+```
+public.daily_health_logs (
+  id uuid pk, user_id uuid -> auth.users, pet_id uuid -> public.pets,
+  log_date date,
+  appetite text check in ('normal','reduced','none','increased'),
+  water text check in ('normal','less','more'),
+  stool text check in ('normal','soft','diarrhea','none','blood'),
+  urination text check in ('normal','less','more','straining','none'),
+  vomiting_count int default 0,
+  energy text check in ('normal','low','high'),
+  mood text, weight_kg numeric, meds_given boolean,
+  notes text, photo_urls text[] default '{}',
+  created_at, updated_at,
+  unique(user_id, pet_id, log_date)
+)
+```
+- API: `GET/POST /api/health-log` (list + upsert by pet/date), RLS-scoped.
+- UI: a compact log form (reachable from "Track next" CTA and a Journal/Analytics entry point). Pre-fill the field the follow-up prompt asks for.
+- Pure logic: `buildHealthLogReadout` (better/worse/same per field vs baseline) — unit-tested. Only show field trends once enough comparable entries exist (no faking).
+- Wire into Analytics "Why this status" + "Track next" once data exists.
+- ROLLOUT GATE: ship code, user applies the SQL in Supabase SQL editor, then we
+  smoke-test logging + read-back on an authed account before relying on it.
+  Do NOT blind-ship DB writes to prod without that test.
+
+## Phase 3 — Vet-Ready Health Timeline / Report (after Phase 2)
+The payoff. Aggregate symptom checks + daily logs + outcomes into one timeline:
+latest concern, severity/urgency, daily logs, meds, weight, notes, outcome, and
+"what changed since last check." Reuse existing reports/share + reports/pdf routes
+for a shareable PDF. "Vet packet" card becomes the entry point.
+
+## Guardrails (all phases)
+- Use real PawVital data only; never fake WHOOP/Fitbit-style metrics or show a
+  chart for data we don't have.
+- Never diagnose, never give an all-clear, always keep a vet path.
+- Deterministic clinical logic stays the source of truth; presentation re-phrases.

--- a/src/app/(dashboard)/analytics/page.tsx
+++ b/src/app/(dashboard)/analytics/page.tsx
@@ -9,26 +9,21 @@ import Card from "@/components/ui/card";
 import Select from "@/components/ui/select";
 import { buttonClassName } from "@/components/ui/button";
 import {
-  HealthScoreCard,
   OwnerStatusHero,
-  ProductIntelligencePanel,
   RecentSigns,
   RecoveryTrendStrip,
   SeverityTrendChart,
   SymptomFrequencyChart,
+  TrackNext,
   UrgencyDistribution,
+  VetPacket,
+  WhyThisChanged,
 } from "@/components/analytics";
 import type { SymptomCheckEntry } from "@/components/timeline/types";
 import { symptomCheckRowToEntry, type SymptomCheckDbRow } from "@/lib/symptom-check-entry-map";
 import { getPrivateTesterQuarantinedSurface } from "@/lib/private-tester-scope";
 import { buildProductIntelligenceSnapshot } from "@/lib/product-intelligence";
 import { buildOwnerReadout } from "@/lib/analytics/owner-readout";
-import {
-  buildOwnerRecoveryCheckpoint,
-  loadProductIntelligenceHistory,
-  saveProductIntelligenceSnapshot,
-  type ProductIntelligenceHistory,
-} from "@/lib/product-intelligence-owner-workflow";
 import { createClient, isSupabaseConfigured } from "@/lib/supabase";
 import { DEMO_ANALYTICS_SYMPTOM_ENTRIES } from "@/lib/demo-health-data";
 import { useAppStore } from "@/store/app-store";
@@ -39,24 +34,6 @@ const RANGE_OPTIONS = [
   { value: "90", label: "Last 90 days" },
   { value: "all", label: "All time" },
 ];
-
-interface ProductIntelligenceUiState {
-  history: ProductIntelligenceHistory | null;
-  historyLoading: boolean;
-  readinessSaving: boolean;
-  readinessStatus: string | null;
-  recoverySaving: boolean;
-  recoveryStatus: string | null;
-}
-
-const INITIAL_PRODUCT_UI_STATE: ProductIntelligenceUiState = {
-  history: null,
-  historyLoading: false,
-  readinessSaving: false,
-  readinessStatus: null,
-  recoverySaving: false,
-  recoveryStatus: null,
-};
 
 function inDateRange(entry: SymptomCheckEntry, rangeKey: string, now: Date): boolean {
   if (rangeKey === "all") return true;
@@ -72,9 +49,6 @@ function AnalyticsPageContent() {
   const [loading, setLoading] = useState(true);
   const [petId, setPetId] = useState<string>("all");
   const [range, setRange] = useState<string>("90");
-  const [productUiState, setProductUiState] = useState<ProductIntelligenceUiState>(
-    INITIAL_PRODUCT_UI_STATE
-  );
 
   const loadChecks = useCallback(async () => {
     if (!isSupabaseConfigured) {
@@ -145,20 +119,10 @@ function AnalyticsPageContent() {
     return list;
   }, [rawEntries, range, petId, now]);
 
+  // Deterministic product-intelligence snapshot still powers the trend direction.
   const productSnapshot = useMemo(
     () => buildProductIntelligenceSnapshot({ entries: filtered }),
     [filtered]
-  );
-  const selectedPetIdForPersistence = isSupabaseConfigured && petId !== "all" ? petId : null;
-  const selectedPetIdForRecovery = petId !== "all" ? petId : null;
-  const recoveryCheckpoint = useMemo(
-    () =>
-      buildOwnerRecoveryCheckpoint({
-        petId: selectedPetIdForRecovery,
-        entries: filtered,
-        generatedAt: now.toISOString(),
-      }),
-    [filtered, now, selectedPetIdForRecovery]
   );
 
   const selectedPetName = useMemo(() => {
@@ -187,98 +151,6 @@ function AnalyticsPageContent() {
     return c > 1 ? c / 100 : c;
   }, [filtered]);
 
-  const loadProductHistory = useCallback(async () => {
-    if (!selectedPetIdForPersistence) {
-      setProductUiState((current) => ({ ...current, history: null }));
-      return;
-    }
-
-    setProductUiState((current) => ({ ...current, historyLoading: true }));
-    try {
-      const history = await loadProductIntelligenceHistory(selectedPetIdForPersistence);
-      setProductUiState((current) => ({ ...current, history }));
-    } catch (error) {
-      console.error("Product intelligence history load failed:", error);
-      setProductUiState((current) => ({ ...current, history: null }));
-    } finally {
-      setProductUiState((current) => ({ ...current, historyLoading: false }));
-    }
-  }, [selectedPetIdForPersistence]);
-
-  useEffect(() => {
-    void loadProductHistory();
-  }, [loadProductHistory]);
-
-  const saveReadinessSnapshot = useCallback(async () => {
-    if (!selectedPetIdForPersistence || !productSnapshot.persistenceAllowed) {
-      return;
-    }
-
-    setProductUiState((current) => ({
-      ...current,
-      readinessSaving: true,
-      readinessStatus: null,
-    }));
-    try {
-      await saveProductIntelligenceSnapshot({
-        petId: selectedPetIdForPersistence,
-        readiness: {
-          generatedAt: new Date().toISOString(),
-          sourceCheckIds: filtered.map((entry) => entry.id),
-        },
-      });
-      setProductUiState((current) => ({ ...current, readinessStatus: "Snapshot saved" }));
-      await loadProductHistory();
-    } catch (error) {
-      console.error("Product intelligence snapshot save failed:", error);
-      setProductUiState((current) => ({ ...current, readinessStatus: "Snapshot save failed" }));
-    } finally {
-      setProductUiState((current) => ({ ...current, readinessSaving: false }));
-    }
-  }, [filtered, loadProductHistory, productSnapshot.persistenceAllowed, selectedPetIdForPersistence]);
-
-  const saveRecoveryCheckpoint = useCallback(async () => {
-    if (
-      !selectedPetIdForPersistence ||
-      !recoveryCheckpoint?.persistenceAllowed ||
-      !recoveryCheckpoint.reportSourceId
-    ) {
-      return;
-    }
-
-    setProductUiState((current) => ({
-      ...current,
-      recoverySaving: true,
-      recoveryStatus: null,
-    }));
-    try {
-      await saveProductIntelligenceSnapshot({
-        petId: selectedPetIdForPersistence,
-        recovery: {
-          reportSourceId: recoveryCheckpoint.reportSourceId,
-          generatedAt: new Date().toISOString(),
-          sourceCheckIds: filtered.map((entry) => entry.id),
-        },
-      });
-      setProductUiState((current) => ({ ...current, recoveryStatus: "Checkpoint saved" }));
-      await loadProductHistory();
-    } catch (error) {
-      console.error("Product intelligence recovery checkpoint save failed:", error);
-      setProductUiState((current) => ({
-        ...current,
-        recoveryStatus: "Checkpoint save failed",
-      }));
-    } finally {
-      setProductUiState((current) => ({ ...current, recoverySaving: false }));
-    }
-  }, [
-    filtered,
-    loadProductHistory,
-    recoveryCheckpoint?.reportSourceId,
-    recoveryCheckpoint?.persistenceAllowed,
-    selectedPetIdForPersistence,
-  ]);
-
   return (
     <div className="mx-auto max-w-2xl space-y-5">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
@@ -287,7 +159,7 @@ function AnalyticsPageContent() {
             <BarChart3 className="h-5 w-5" aria-hidden />
             <span className="text-sm font-semibold uppercase tracking-wide">
               {ownerReadout.petName === "your dog"
-                ? "Health overview"
+                ? "Health signals"
                 : `${ownerReadout.petName}'s health`}
             </span>
           </div>
@@ -360,63 +232,56 @@ function AnalyticsPageContent() {
 
           <RecoveryTrendStrip readout={ownerReadout.trend} petName={ownerReadout.petName} />
 
+          <WhyThisChanged drivers={ownerReadout.drivers} />
+
           <RecentSigns signs={ownerReadout.signs} asOf={ownerReadout.asOf} />
+
+          {ownerReadout.nextStep ? (
+            <TrackNext nextStep={ownerReadout.nextStep} petName={ownerReadout.petName} />
+          ) : null}
+
+          <VetPacket packet={ownerReadout.vetPacket} petName={ownerReadout.petName} />
 
           <details className="group rounded-2xl border border-[#e8e2d8] bg-white">
             <summary className="flex cursor-pointer list-none items-center justify-between gap-2 px-5 py-4 text-sm font-medium text-[#7c4dc4]">
-              <span>See the full details</span>
+              <span>Full history — useful for your vet</span>
               <ChevronDown
                 className="h-4 w-4 transition-transform group-open:rotate-180"
                 aria-hidden
               />
             </summary>
             <div className="space-y-5 border-t border-[#e8e2d8] px-4 py-5 sm:px-5">
-              <ProductIntelligencePanel
-                snapshot={productSnapshot}
-                historyCount={productUiState.history?.readiness.length}
-                onSaveSnapshot={
-                  selectedPetIdForPersistence ? saveReadinessSnapshot : undefined
-                }
-                saveSnapshotDisabled={productUiState.historyLoading}
-                saveSnapshotInProgress={productUiState.readinessSaving}
-                saveSnapshotStatus={productUiState.readinessStatus}
-                recoveryCheckpoint={recoveryCheckpoint}
-                recoveryHistoryCount={productUiState.history?.recovery.length}
-                onSaveRecoveryCheckpoint={
-                  selectedPetIdForPersistence ? saveRecoveryCheckpoint : undefined
-                }
-                saveRecoveryDisabled={productUiState.historyLoading}
-                saveRecoveryInProgress={productUiState.recoverySaving}
-                saveRecoveryStatus={productUiState.recoveryStatus}
-              />
+              <p className="text-xs leading-relaxed text-[#8a857a]">
+                The full check-by-check history below is handy to show your vet. It
+                isn&apos;t a diagnosis — it&apos;s a record of what you reported over time.
+              </p>
               <div className="grid grid-cols-1 gap-5 lg:grid-cols-2">
                 <Card className="p-5">
-                  <HealthScoreCard entries={filtered} />
-                </Card>
-                <Card className="p-5">
-                  <h2 className="mb-2 text-sm font-semibold text-gray-900">Urgency mix</h2>
+                  <h2 className="mb-2 text-sm font-semibold text-gray-900">
+                    How urgent were the checks?
+                  </h2>
                   <p className="mb-2 text-xs text-gray-500">
                     How often each urgency level appeared
                   </p>
                   <UrgencyDistribution entries={filtered} />
                 </Card>
                 <Card className="p-5">
-                  <h2 className="mb-1 text-sm font-semibold text-gray-900">Top symptoms</h2>
-                  <p className="mb-4 text-xs text-gray-500">
-                    Five most common primary concerns
-                  </p>
+                  <h2 className="mb-1 text-sm font-semibold text-gray-900">
+                    Most common concerns
+                  </h2>
+                  <p className="mb-4 text-xs text-gray-500">Your top reported signs</p>
                   <SymptomFrequencyChart entries={filtered} />
                 </Card>
-                <Card className="p-5">
-                  <h2 className="mb-1 text-sm font-semibold text-gray-900">
-                    Severity over time
-                  </h2>
-                  <p className="mb-4 text-xs text-gray-500">
-                    Per-check severity (chronological)
-                  </p>
-                  <SeverityTrendChart entries={filtered} />
-                </Card>
               </div>
+              <Card className="p-5">
+                <h2 className="mb-1 text-sm font-semibold text-gray-900">
+                  Severity over time
+                </h2>
+                <p className="mb-4 text-xs text-gray-500">
+                  Per-check severity (chronological)
+                </p>
+                <SeverityTrendChart entries={filtered} />
+              </Card>
             </div>
           </details>
 

--- a/src/components/analytics/index.ts
+++ b/src/components/analytics/index.ts
@@ -6,3 +6,4 @@ export { default as ProductIntelligencePanel } from "./product-intelligence-pane
 export { OwnerStatusHero } from "./owner-status-hero";
 export { RecoveryTrendStrip } from "./recovery-trend-strip";
 export { RecentSigns } from "./recent-signs";
+export { WhyThisChanged, TrackNext, VetPacket } from "./owner-signal-cards";

--- a/src/components/analytics/owner-signal-cards.tsx
+++ b/src/components/analytics/owner-signal-cards.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowRight, ClipboardList, FileText, ListChecks } from "lucide-react";
+import { buttonClassName } from "@/components/ui/button";
+import type {
+  OwnerDriver,
+  OwnerNextStep,
+  OwnerVetPacket,
+} from "@/lib/analytics/owner-readout";
+
+const DRIVER_DOT: Record<OwnerDriver["tone"], string> = {
+  neutral: "#a8a097",
+  caution: "#d98b3a",
+  alert: "#e25c5c",
+};
+
+/** "Why this changed" — the plain drivers behind the current status. */
+export function WhyThisChanged({ drivers }: { drivers: OwnerDriver[] }) {
+  if (drivers.length === 0) return null;
+  return (
+    <section className="rounded-2xl border border-[#e8e2d8] bg-white p-5">
+      <div className="flex items-center gap-2">
+        <ListChecks className="h-4 w-4 text-[#7c4dc4]" aria-hidden />
+        <p className="text-xs font-semibold uppercase tracking-wide text-[#8a857a]">
+          Why this status
+        </p>
+      </div>
+      <ul className="mt-3 space-y-2">
+        {drivers.map((d, i) => (
+          <li key={`${d.label}-${i}`} className="flex items-start gap-2.5">
+            <span
+              className="mt-1.5 inline-block h-2 w-2 shrink-0 rounded-full"
+              style={{ background: DRIVER_DOT[d.tone] }}
+              aria-hidden
+            />
+            <span className="text-sm leading-relaxed text-[#4a463f]">{d.label}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+/** "Track next" — one adaptive nudge keyed to the latest check. */
+export function TrackNext({
+  nextStep,
+  petName,
+}: {
+  nextStep: OwnerNextStep;
+  petName: string;
+}) {
+  return (
+    <section className="rounded-2xl border border-[#e8e2d8] bg-white p-5">
+      <div className="flex items-center gap-2">
+        <ClipboardList className="h-4 w-4 text-[#0a7d5b]" aria-hidden />
+        <p className="text-xs font-semibold uppercase tracking-wide text-[#8a857a]">
+          Track next
+        </p>
+      </div>
+      <h3 className="mt-2 text-base font-semibold text-[#2c2a26]">
+        {nextStep.title}
+      </h3>
+      <p className="mt-1 text-sm leading-relaxed text-[#6b665d]">{nextStep.detail}</p>
+      <Link
+        href="/symptom-checker"
+        className="mt-3 inline-flex items-center gap-1 text-sm font-medium text-[#0a7d5b] hover:underline"
+      >
+        Do a quick check-in for {petName}
+        <ArrowRight className="h-4 w-4" aria-hidden />
+      </Link>
+    </section>
+  );
+}
+
+/** "Vet packet" — a vet-ready summary of the checks in view. */
+export function VetPacket({
+  packet,
+  petName,
+}: {
+  packet: OwnerVetPacket;
+  petName: string;
+}) {
+  if (!packet.ready) return null;
+  const parts: string[] = [];
+  if (packet.rangeLabel) parts.push(packet.rangeLabel);
+  parts.push(
+    packet.urgentFlags === 0
+      ? "no urgent flags"
+      : packet.urgentFlags === 1
+        ? "1 urgent flag"
+        : `${packet.urgentFlags} urgent flags`,
+  );
+
+  return (
+    <section className="rounded-2xl border border-[#e8e2d8] bg-[#faf8f5] p-5">
+      <div className="flex items-center gap-2">
+        <FileText className="h-4 w-4 text-[#7c4dc4]" aria-hidden />
+        <p className="text-xs font-semibold uppercase tracking-wide text-[#8a857a]">
+          Ready to share with your vet
+        </p>
+      </div>
+      <p className="mt-2 text-sm leading-relaxed text-[#4a463f]">
+        {petName}&apos;s recent history: <span className="font-medium">{parts.join(" · ")}</span>.
+        Bring it to your next visit so nothing gets missed.
+      </p>
+      <Link
+        href="/history"
+        className={`${buttonClassName({ variant: "outline", size: "sm" })} mt-3 inline-flex`}
+      >
+        <FileText className="mr-2 h-4 w-4" aria-hidden />
+        Open &amp; share history
+      </Link>
+    </section>
+  );
+}

--- a/src/lib/analytics/owner-readout.ts
+++ b/src/lib/analytics/owner-readout.ts
@@ -57,6 +57,26 @@ export interface OwnerSign {
   tone: "neutral" | "caution" | "alert";
 }
 
+/** A plain-language reason the current status looks the way it does. */
+export interface OwnerDriver {
+  label: string;
+  tone: "neutral" | "caution" | "alert";
+}
+
+/** One adaptive "what to do next" nudge derived from the latest check. */
+export interface OwnerNextStep {
+  title: string;
+  detail: string;
+}
+
+/** A vet-ready summary of the checks in view. */
+export interface OwnerVetPacket {
+  checkCount: number;
+  urgentFlags: number;
+  rangeLabel: string | null;
+  ready: boolean;
+}
+
 export interface OwnerReadout {
   dataState: OwnerDataState;
   petName: string;
@@ -67,6 +87,12 @@ export interface OwnerReadout {
   signs: OwnerSign[];
   /** Plain "as of" line for the latest check, e.g. "Based on today's check". */
   asOf: string | null;
+  /** Why the status looks the way it does — top drivers from recent checks. */
+  drivers: OwnerDriver[];
+  /** One adaptive next-step nudge. Null when there are no checks. */
+  nextStep: OwnerNextStep | null;
+  /** Vet-ready summary of the checks in view. */
+  vetPacket: OwnerVetPacket;
 }
 
 /** Wellness points by severity (higher = healthier). Mirrors product-intelligence. */
@@ -291,6 +317,119 @@ function resolveDataState(count: number): OwnerDataState {
   return "ready";
 }
 
+const URGENCY_REASON: Record<SymptomCheckEntry["urgency"], string> = {
+  monitor: "These signs look mild and can usually be watched at home.",
+  schedule: "Not an emergency, but worth a routine vet visit.",
+  urgent: "These signs can need same-day care — worth calling your vet.",
+  emergency: "Some signs shouldn't wait — contact an emergency vet.",
+};
+
+/**
+ * "Why this changed" — the plain-language drivers behind the current status.
+ * Built only from the owner's own checks (latest sign, why it matters, and
+ * whether it has come up before). Never surfaces a diagnosis label.
+ */
+function buildDrivers(
+  latest: SymptomCheckEntry,
+  all: SymptomCheckEntry[],
+): OwnerDriver[] {
+  const drivers: OwnerDriver[] = [];
+  const symptom = (latest.primary_symptom ?? "").trim();
+  if (symptom) {
+    drivers.push({
+      label: `${symptom} — flagged as ${SEVERITY_LABEL[latest.severity].toLowerCase()}`,
+      tone: SEVERITY_TONE[latest.severity],
+    });
+  }
+  drivers.push({
+    label: URGENCY_REASON[latest.urgency],
+    tone:
+      latest.urgency === "emergency" || latest.urgency === "urgent"
+        ? "caution"
+        : "neutral",
+  });
+
+  // Recurrence: has this same sign come up in earlier checks?
+  if (symptom) {
+    const key = symptom.toLowerCase();
+    const priorCount = all.filter(
+      (e) => e.id !== latest.id && (e.primary_symptom ?? "").trim().toLowerCase() === key,
+    ).length;
+    if (priorCount >= 1) {
+      drivers.push({
+        label: `You've noted this before — worth mentioning to your vet.`,
+        tone: "caution",
+      });
+    }
+  }
+
+  return drivers.slice(0, 3);
+}
+
+const NEXT_STEP_RULES: Array<{ test: RegExp; title: string; detail: string }> = [
+  {
+    test: /vomit|diarrh|stool|poop|nausea/i,
+    title: "Note any more vomiting or diarrhea",
+    detail: "Over the next day, keep a quick count and look for blood or signs of dehydration.",
+  },
+  {
+    test: /limp|lame|leg|paw|joint|mobility/i,
+    title: "Check the limp tomorrow",
+    detail: "See whether it's easing or getting worse, and whether it affects eating or resting.",
+  },
+  {
+    test: /scratch|itch|skin|ear|rash|lick/i,
+    title: "Watch the scratching and skin",
+    detail: "Note any new redness, hot spots, or hair loss to share with your vet.",
+  },
+  {
+    test: /eat|appetite|lethar|energy|tired|weak/i,
+    title: "Watch appetite and energy",
+    detail: "Check how the next couple of meals go and whether energy returns to normal.",
+  },
+  {
+    test: /cough|breath|wheez|pant|respir/i,
+    title: "Watch breathing closely",
+    detail: "Note any coughing, fast breathing, or effort — and call your vet if it worsens.",
+  },
+  {
+    test: /drink|water|thirst|urin|pee/i,
+    title: "Watch water and bathroom habits",
+    detail: "Note changes in how much your dog drinks and how often they pee.",
+  },
+];
+
+/** "Track next" — one adaptive nudge keyed to the latest check's main sign. */
+function buildNextStep(latest: SymptomCheckEntry, petName: string): OwnerNextStep {
+  const symptom = (latest.primary_symptom ?? "").trim();
+  const matched = NEXT_STEP_RULES.find((rule) => rule.test.test(symptom));
+  if (matched) {
+    return { title: matched.title, detail: matched.detail };
+  }
+  return {
+    title: `Check in on ${petName} tomorrow`,
+    detail: "A quick follow-up check helps spot whether things are getting better or worse.",
+  };
+}
+
+function buildVetPacket(entries: SymptomCheckEntry[]): OwnerVetPacket {
+  const urgentFlags = entries.filter(
+    (e) => e.urgency === "urgent" || e.urgency === "emergency",
+  ).length;
+  const rangeLabel =
+    entries.length === 0
+      ? null
+      : entries.length === 1
+        ? "1 check"
+        : `${entries.length} checks`;
+  return {
+    checkCount: entries.length,
+    urgentFlags,
+    rangeLabel,
+    ready: entries.length > 0,
+  };
+}
+
 /**
  * Map filtered symptom checks + the deterministic product-intelligence snapshot
  * into an owner-facing readout. Pure and side-effect free.
@@ -312,6 +451,7 @@ export function buildOwnerReadout({
   const petName = titleCaseName(latest?.pet_name ?? fallbackPetName);
 
   const trend = buildTrend(entries, dataState, snapshot, petName);
+  const vetPacket = buildVetPacket(entries);
 
   if (!latest) {
     return {
@@ -322,6 +462,9 @@ export function buildOwnerReadout({
       trend,
       signs: [],
       asOf: null,
+      drivers: [],
+      nextStep: null,
+      vetPacket,
     };
   }
 
@@ -333,5 +476,8 @@ export function buildOwnerReadout({
     trend,
     signs: buildSigns(latest),
     asOf: describeRecency(latest, now),
+    drivers: buildDrivers(latest, chronological),
+    nextStep: buildNextStep(latest, petName),
+    vetPacket,
   };
 }

--- a/tests/owner-readout.test.ts
+++ b/tests/owner-readout.test.ts
@@ -211,6 +211,66 @@ describe("buildOwnerReadout", () => {
     expect(readout.signs[0]).toEqual({ label: "Limping", tone: "alert" });
   });
 
+  it("builds 'why this status' drivers from the latest sign, reason, and recurrence", () => {
+    const entries = [
+      entry({ id: "a", created_at: "2026-06-10T12:00:00.000Z", primary_symptom: "Vomiting", urgency: "urgent", severity: "serious" }),
+      entry({ id: "b", created_at: "2026-06-16T12:00:00.000Z", primary_symptom: "Vomiting", urgency: "urgent", severity: "serious" }),
+    ];
+    const readout = buildOwnerReadout({ entries, snapshot: snapshot("steady"), now: NOW });
+
+    expect(readout.drivers.length).toBeGreaterThanOrEqual(2);
+    expect(readout.drivers[0].label.toLowerCase()).toContain("vomiting");
+    // recurrence driver present because "Vomiting" appears in an earlier check
+    expect(readout.drivers.some((d) => d.label.toLowerCase().includes("noted this before"))).toBe(true);
+    // never surfaces a diagnosis label
+    expect(readout.drivers.some((d) => d.label.toLowerCase().includes("gastro"))).toBe(false);
+  });
+
+  it("gives an adaptive next-step nudge keyed to the latest symptom", () => {
+    const vomit = buildOwnerReadout({
+      entries: [entry({ primary_symptom: "Vomiting and lethargy" })],
+      snapshot: snapshot("unknown"),
+      now: NOW,
+    });
+    expect(vomit.nextStep?.title.toLowerCase()).toMatch(/vomit|appetite|energy/);
+
+    const limp = buildOwnerReadout({
+      entries: [entry({ primary_symptom: "Limping after a walk" })],
+      snapshot: snapshot("unknown"),
+      now: NOW,
+    });
+    expect(limp.nextStep?.title.toLowerCase()).toContain("limp");
+
+    const unknown = buildOwnerReadout({
+      entries: [entry({ primary_symptom: "Something unusual" })],
+      snapshot: snapshot("unknown"),
+      now: NOW,
+    });
+    expect(unknown.nextStep?.title.toLowerCase()).toContain("check in");
+  });
+
+  it("summarises a vet packet with check count and urgent flags", () => {
+    const entries = [
+      entry({ id: "a", urgency: "monitor" }),
+      entry({ id: "b", urgency: "urgent" }),
+      entry({ id: "c", urgency: "emergency" }),
+    ];
+    const readout = buildOwnerReadout({ entries, snapshot: snapshot("steady"), now: NOW });
+
+    expect(readout.vetPacket.ready).toBe(true);
+    expect(readout.vetPacket.checkCount).toBe(3);
+    expect(readout.vetPacket.urgentFlags).toBe(2);
+    expect(readout.vetPacket.rangeLabel).toBe("3 checks");
+  });
+
+  it("returns an unready, empty vet packet and no drivers/next-step with zero checks", () => {
+    const readout = buildOwnerReadout({ entries: [], snapshot: snapshot("unknown"), now: NOW });
+    expect(readout.vetPacket.ready).toBe(false);
+    expect(readout.vetPacket.checkCount).toBe(0);
+    expect(readout.drivers).toHaveLength(0);
+    expect(readout.nextStep).toBeNull();
+  });
+
   it("never returns an all-clear: every non-empty verdict keeps a vet path in its copy", () => {
     for (const urgency of ["monitor", "schedule", "urgent", "emergency"] as const) {
       const readout = buildOwnerReadout({


### PR DESCRIPTION
Removes the internal/debug widgets (evidence ring, coverage %, wellness-index number, baseline-shift, persistence allowed/blocked) from the owner Analytics view and adds three plain-language cards from real data: Why this status, Track next, Vet packet. Collapsed accordion keeps only plain vet-history charts. 13/13 unit tests, tsc/eslint clean, build passes, review=SHIP. Phase 2/3 (Daily Health Log, Vet Timeline) roadmapped in plans/health-signals-roadmap.md.