### PR TITLE
feat(health-log): daily health log + smart follow-up prompts

### DIFF
--- a/plans/health-signals-roadmap.md
+++ b/plans/health-signals-roadmap.md
@@ -22,7 +22,19 @@ trend; only the debug UI is gone.)
 Verifier: tests/owner-readout.test.ts (13/13), tsc/eslint clean, build prerenders
 /analytics static, dedicated review = SHIP.
 
-## Phase 2 — Daily Health Log + Smart Follow-Up Prompts (NEXT, needs schema)
+## Phase 2 — Daily Health Log + Smart Follow-Up Prompts ✅ CODE-COMPLETE (deployed; needs migration)
+SHIPPED: `supabase-daily-health-log-schema.sql` (idempotent table + RLS + trigger),
+`src/lib/health-log/{types,readout}.ts` (pure, 8 tests), `src/app/api/health-log/route.ts`
+(GET list + POST upsert; auth + zod + pet-ownership + rate-limit; TABLE_MISSING/DEMO_MODE
+graceful), `src/app/(dashboard)/health-log/page.tsx` (form + readout + recent list),
+sidebar "Daily Log" nav, and analytics "Track next" now links to /health-log.
+Verifier: 21 tests green, tsc/eslint clean, build prerenders, review = SHIP.
+**ROLLOUT GATE (still open):** owner must run `supabase-daily-health-log-schema.sql`
+in the Supabase SQL editor, then we smoke-test save + read-back on an authed account.
+Until then the API returns TABLE_MISSING and the page shows "not switched on yet" — no
+breakage, just inert.
+
+### Original Phase 2 design notes
 The habit loop. Structured daily fields the owner can log in ~30s.
 
 Proposed schema (`supabase-daily-health-log-schema.sql`, idempotent, RLS by owner):

--- a/src/app/(dashboard)/health-log/page.tsx
+++ b/src/app/(dashboard)/health-log/page.tsx
@@ -1,0 +1,366 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { CheckCircle2, ClipboardList, Loader2 } from "lucide-react";
+import Card from "@/components/ui/card";
+import Button from "@/components/ui/button";
+import Select from "@/components/ui/select";
+import Input from "@/components/ui/input";
+import Textarea from "@/components/ui/textarea";
+import { useAppStore } from "@/store/app-store";
+import { isSupabaseConfigured } from "@/lib/supabase";
+import {
+  DEFAULT_LOG_INPUT,
+  SELECT_FIELDS,
+  type HealthLog,
+  type HealthLogInput,
+} from "@/lib/health-log/types";
+import { buildHealthLogReadout } from "@/lib/health-log/readout";
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+const TONE_TEXT: Record<"good" | "watch" | "alert", string> = {
+  good: "#0a7d5b",
+  watch: "#9a6b1f",
+  alert: "#b23636",
+};
+const TONE_BG: Record<"good" | "watch" | "alert", string> = {
+  good: "rgba(0,168,120,0.1)",
+  watch: "rgba(224,164,88,0.16)",
+  alert: "rgba(226,92,92,0.12)",
+};
+
+export default function HealthLogPage() {
+  const { activePet, pets } = useAppStore();
+  const [logs, setLogs] = useState<HealthLog[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [savedAt, setSavedAt] = useState<string | null>(null);
+
+  const [form, setForm] = useState<HealthLogInput>({
+    pet_id: activePet?.id ?? pets[0]?.id ?? "",
+    log_date: todayIso(),
+    ...DEFAULT_LOG_INPUT,
+  });
+
+  // Keep the selected pet in sync with the active pet once it loads.
+  useEffect(() => {
+    if (!form.pet_id && (activePet?.id || pets[0]?.id)) {
+      setForm((f) => ({ ...f, pet_id: activePet?.id ?? pets[0]?.id ?? "" }));
+    }
+  }, [activePet?.id, pets, form.pet_id]);
+
+  const fetchLogs = useCallback(async () => {
+    if (!isSupabaseConfigured) {
+      setLogs([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const petId = activePet?.id;
+      const q = petId ? `?pet_id=${encodeURIComponent(petId)}` : "";
+      const res = await fetch(`/api/health-log${q}`, { credentials: "include" });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(json.error || "Could not load your logs.");
+        setLogs([]);
+        return;
+      }
+      setLogs(Array.isArray(json.data) ? json.data : []);
+    } catch {
+      setError("Network error loading logs.");
+      setLogs([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [activePet?.id]);
+
+  useEffect(() => {
+    void fetchLogs();
+  }, [fetchLogs]);
+
+  const readout = useMemo(() => buildHealthLogReadout(logs), [logs]);
+
+  const petOptions = useMemo(
+    () => pets.map((p) => ({ value: p.id, label: p.name })),
+    [pets],
+  );
+
+  const submit = async (ev: React.FormEvent) => {
+    ev.preventDefault();
+    if (!form.pet_id) return;
+    if (!isSupabaseConfigured) {
+      setError("Sign in with a saved profile to store daily logs.");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    setSavedAt(null);
+    try {
+      const res = await fetch("/api/health-log", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...form,
+          notes: form.notes?.trim() || null,
+          weight_kg: form.weight_kg || null,
+        }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(
+          json.code === "TABLE_MISSING"
+            ? "Daily logs aren't switched on for this account yet."
+            : json.error || "Could not save your log.",
+        );
+        return;
+      }
+      const saved = json.data as HealthLog;
+      setLogs((prev) => {
+        const withoutSameDay = prev.filter((l) => l.id !== saved.id);
+        return [saved, ...withoutSameDay];
+      });
+      setSavedAt(saved.log_date);
+    } catch {
+      setError("Network error saving your log.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const setField = <K extends keyof HealthLogInput>(
+    key: K,
+    value: HealthLogInput[K],
+  ) => setForm((f) => ({ ...f, [key]: value }));
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-5">
+      <div>
+        <div className="mb-1 flex items-center gap-2 text-[#00a878]">
+          <ClipboardList className="h-5 w-5" aria-hidden />
+          <span className="text-sm font-semibold uppercase tracking-wide">
+            Daily check-in
+          </span>
+        </div>
+        <h1 className="text-2xl font-bold text-[#2c2a26]">
+          How is {activePet?.name ?? "your dog"} doing today?
+        </h1>
+        <p className="mt-1 text-sm text-[#6b665d]">
+          A quick 30-second log. Over time this shows what&apos;s getting better or
+          worse — and makes a clean record to share with your vet.
+        </p>
+      </div>
+
+      {!isSupabaseConfigured ? (
+        <Card className="p-4 text-sm" style={{ background: "rgba(224,164,88,0.12)", borderColor: "rgba(224,164,88,0.4)" }}>
+          <p className="text-[#8a4f15]">
+            You&apos;re viewing demo mode. Sign in with a saved profile to store daily
+            logs and build a history.
+          </p>
+        </Card>
+      ) : null}
+
+      {/* Readout — what the logs show so far */}
+      {readout.hasToday ? (
+        <section className="rounded-2xl border border-[#e8e2d8] bg-white p-5">
+          <h2 className="text-base font-semibold text-[#2c2a26]">{readout.headline}</h2>
+          <p className="mt-1 text-sm leading-relaxed text-[#6b665d]">{readout.detail}</p>
+          {readout.offSigns.length > 0 ? (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {readout.offSigns.map((s) => (
+                <span
+                  key={s.field}
+                  className="rounded-full border px-3 py-1.5 text-sm font-medium"
+                  style={{
+                    background: TONE_BG[s.tone],
+                    borderColor: TONE_TEXT[s.tone] + "55",
+                    color: TONE_TEXT[s.tone],
+                  }}
+                >
+                  {s.label}: {s.valueLabel}
+                </span>
+              ))}
+            </div>
+          ) : null}
+          {readout.changes.length > 0 ? (
+            <div className="mt-4 border-t border-[#e8e2d8] pt-3">
+              <p className="text-xs font-semibold uppercase tracking-wide text-[#8a857a]">
+                Since your last log
+              </p>
+              <ul className="mt-2 space-y-1.5">
+                {readout.changes.map((c) => (
+                  <li key={c.field} className="flex items-start gap-2 text-sm text-[#4a463f]">
+                    <span
+                      className="mt-1.5 inline-block h-2 w-2 shrink-0 rounded-full"
+                      style={{
+                        background:
+                          c.direction === "improved"
+                            ? "#00a878"
+                            : c.direction === "worse"
+                              ? "#d98b3a"
+                              : "#a8a097",
+                      }}
+                      aria-hidden
+                    />
+                    {c.text}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </section>
+      ) : null}
+
+      {/* Log form */}
+      <form onSubmit={(e) => void submit(e)}>
+        <Card className="space-y-4 p-5 sm:p-6">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {pets.length > 1 ? (
+              <Select
+                label="Dog"
+                value={form.pet_id}
+                onChange={(e) => setField("pet_id", e.target.value)}
+                options={petOptions}
+                required
+              />
+            ) : null}
+            <Input
+              label="Date"
+              type="date"
+              value={form.log_date ?? todayIso()}
+              max={todayIso()}
+              onChange={(e) => setField("log_date", e.target.value)}
+            />
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {SELECT_FIELDS.map((field) => (
+              <Select
+                key={field.key}
+                label={field.label}
+                value={form[field.key]}
+                onChange={(e) =>
+                  setField(
+                    field.key,
+                    e.target.value as HealthLogInput[typeof field.key],
+                  )
+                }
+                options={field.options.map((o) => ({ value: o.value, label: o.label }))}
+              />
+            ))}
+            <Input
+              label="Vomiting (times today)"
+              type="number"
+              min={0}
+              max={100}
+              value={String(form.vomiting_count)}
+              onChange={(e) =>
+                setField("vomiting_count", Math.max(0, Number(e.target.value) || 0))
+              }
+            />
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <Input
+              label="Weight (kg, optional)"
+              type="number"
+              min={0}
+              step="0.1"
+              value={form.weight_kg != null ? String(form.weight_kg) : ""}
+              onChange={(e) =>
+                setField("weight_kg", e.target.value ? Number(e.target.value) : null)
+              }
+            />
+            <label className="flex items-end gap-2 pb-2.5 text-sm text-[#4a463f]">
+              <input
+                type="checkbox"
+                className="h-4 w-4 rounded border-gray-300"
+                checked={form.meds_given}
+                onChange={(e) => setField("meds_given", e.target.checked)}
+              />
+              Gave medication / fluids today
+            </label>
+          </div>
+
+          <Textarea
+            label="Notes (optional)"
+            value={form.notes ?? ""}
+            onChange={(e) => setField("notes", e.target.value)}
+            placeholder="Anything else you noticed today?"
+            rows={3}
+          />
+
+          {error ? (
+            <p className="text-sm text-red-600" role="alert">
+              {error}
+            </p>
+          ) : null}
+          {savedAt ? (
+            <p className="flex items-center gap-1.5 text-sm text-[#0a7d5b]">
+              <CheckCircle2 className="h-4 w-4" aria-hidden />
+              Saved your check-in for {savedAt}.
+            </p>
+          ) : null}
+
+          <div className="flex justify-end">
+            <Button
+              type="submit"
+              disabled={!form.pet_id || saving}
+              loading={saving}
+              className="w-full sm:w-auto"
+            >
+              Save today&apos;s check-in
+            </Button>
+          </div>
+        </Card>
+      </form>
+
+      {/* Recent logs */}
+      {loading ? (
+        <div className="flex items-center justify-center gap-2 py-8 text-[#6b665d]">
+          <Loader2 className="h-5 w-5 animate-spin" aria-hidden />
+          Loading your check-ins…
+        </div>
+      ) : logs.length > 0 ? (
+        <section>
+          <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-[#8a857a]">
+            Recent check-ins
+          </p>
+          <div className="space-y-2">
+            {logs.slice(0, 7).map((log) => {
+              const off = buildHealthLogReadout([log]).offSigns;
+              return (
+                <Card key={log.id} className="flex items-center justify-between gap-3 p-4">
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-[#2c2a26]">{log.log_date}</p>
+                    <p className="truncate text-xs text-[#8a857a]">
+                      {off.length === 0
+                        ? "All normal"
+                        : off.map((s) => `${s.label}: ${s.valueLabel}`).join(" · ")}
+                    </p>
+                  </div>
+                  {log.meds_given ? (
+                    <span className="shrink-0 rounded-full bg-[#f7f4ef] px-2.5 py-1 text-xs text-[#6b665d]">
+                      Meds ✓
+                    </span>
+                  ) : null}
+                </Card>
+              );
+            })}
+          </div>
+        </section>
+      ) : null}
+
+      <p className="px-2 pb-4 pt-1 text-center text-xs leading-relaxed text-[#8a857a]">
+        Daily logs help you and your vet spot changes — they&apos;re not a diagnosis.
+        If you&apos;re worried or things get worse, contact your vet.
+      </p>
+    </div>
+  );
+}

--- a/src/app/api/health-log/route.ts
+++ b/src/app/api/health-log/route.ts
@@ -1,0 +1,189 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import {
+  generalApiLimiter,
+  checkRateLimit,
+  getRateLimitId,
+} from "@/lib/rate-limit";
+
+/**
+ * Daily Health Log API.
+ *
+ * GET  /api/health-log?pet_id=...&limit=...  → recent logs for a pet (RLS-scoped)
+ * POST /api/health-log                       → upsert today's (or given-date) log
+ *
+ * Auth + RLS + pet-ownership enforced, mirroring the journal / product-
+ * intelligence routes. Demo mode (no Supabase) returns empty / 503 gracefully.
+ */
+
+const LogBodySchema = z.object({
+  pet_id: z.string().uuid(),
+  log_date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional(),
+  appetite: z.enum(["normal", "reduced", "none", "increased"]),
+  water: z.enum(["normal", "less", "more"]),
+  stool: z.enum(["normal", "soft", "diarrhea", "none", "blood"]),
+  urination: z.enum(["normal", "less", "more", "straining", "none"]),
+  vomiting_count: z.number().int().min(0).max(100),
+  energy: z.enum(["normal", "low", "high"]),
+  weight_kg: z.number().positive().max(200).nullable().optional(),
+  meds_given: z.boolean(),
+  notes: z.string().trim().max(4000).nullable().optional(),
+});
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function rateLimited(request: Request) {
+  return checkRateLimit(generalApiLimiter, getRateLimitId(request));
+}
+
+/**
+ * Detect "table not applied yet" so the feature degrades gracefully until the
+ * migration is run. Matches both the Postgres code (42P01) and PostgREST's
+ * schema-cache miss (PGRST205), plus the human-readable fallbacks.
+ */
+function isMissingTable(error: { code?: string; message?: string } | null): boolean {
+  if (!error) return false;
+  if (error.code === "42P01" || error.code === "PGRST205") return true;
+  return /relation .* does not exist|could not find the table/i.test(
+    error.message ?? "",
+  );
+}
+
+export async function GET(request: Request) {
+  const limit = await rateLimited(request);
+  if (!limit.success) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  const url = new URL(request.url);
+  const petIdParam = url.searchParams.get("pet_id");
+  const petId = petIdParam && UUID_RE.test(petIdParam) ? petIdParam : null;
+  const limitParam = Number(url.searchParams.get("limit") ?? "30");
+  const rows = Number.isFinite(limitParam)
+    ? Math.min(Math.max(Math.trunc(limitParam), 1), 90)
+    : 30;
+
+  try {
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    let query = supabase
+      .from("daily_health_logs")
+      .select("*")
+      .eq("user_id", user.id)
+      .order("log_date", { ascending: false })
+      .limit(rows);
+    if (petId) {
+      query = query.eq("pet_id", petId);
+    }
+
+    const { data, error } = await query;
+    if (error) {
+      // Table not applied yet → behave like demo (empty), don't 500.
+      if (isMissingTable(error)) {
+        return NextResponse.json({ data: [], code: "TABLE_MISSING" }, { status: 200 });
+      }
+      throw error;
+    }
+    return NextResponse.json({ data: data ?? [] });
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === "DEMO_MODE") {
+      return NextResponse.json({ data: [], code: "DEMO_MODE" });
+    }
+    console.error("[HealthLog] GET failed:", err);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  const limit = await rateLimited(request);
+  if (!limit.success) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = LogBodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid request body", code: "VALIDATION_ERROR" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Verify the pet belongs to this user before writing.
+    const { data: pet, error: petError } = await supabase
+      .from("pets")
+      .select("id")
+      .eq("id", parsed.data.pet_id)
+      .eq("user_id", user.id)
+      .maybeSingle();
+    if (petError) throw petError;
+    if (!pet) {
+      return NextResponse.json({ error: "Pet not found" }, { status: 404 });
+    }
+
+    const row = {
+      user_id: user.id,
+      pet_id: parsed.data.pet_id,
+      log_date: parsed.data.log_date ?? todayIso(),
+      appetite: parsed.data.appetite,
+      water: parsed.data.water,
+      stool: parsed.data.stool,
+      urination: parsed.data.urination,
+      vomiting_count: parsed.data.vomiting_count,
+      energy: parsed.data.energy,
+      weight_kg: parsed.data.weight_kg ?? null,
+      meds_given: parsed.data.meds_given,
+      notes: parsed.data.notes ?? null,
+    };
+
+    // One log per pet per day — upsert so re-saving the same day updates it.
+    const { data, error } = await supabase
+      .from("daily_health_logs")
+      .upsert(row, { onConflict: "user_id,pet_id,log_date" })
+      .select()
+      .single();
+    if (error) {
+      if (isMissingTable(error)) {
+        return NextResponse.json(
+          { error: "Health log isn't set up yet.", code: "TABLE_MISSING" },
+          { status: 503 },
+        );
+      }
+      throw error;
+    }
+    return NextResponse.json({ data }, { status: 201 });
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === "DEMO_MODE") {
+      return NextResponse.json(
+        { error: "Database not configured", code: "DEMO_MODE" },
+        { status: 503 },
+      );
+    }
+    console.error("[HealthLog] POST failed:", err);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+}

--- a/src/components/analytics/owner-signal-cards.tsx
+++ b/src/components/analytics/owner-signal-cards.tsx
@@ -63,10 +63,10 @@ export function TrackNext({
       </h3>
       <p className="mt-1 text-sm leading-relaxed text-[#6b665d]">{nextStep.detail}</p>
       <Link
-        href="/symptom-checker"
+        href="/health-log"
         className="mt-3 inline-flex items-center gap-1 text-sm font-medium text-[#0a7d5b] hover:underline"
       >
-        Do a quick check-in for {petName}
+        Log today&apos;s check-in for {petName}
         <ArrowRight className="h-4 w-4" aria-hidden />
       </Link>
     </section>

--- a/src/components/dashboard/sidebar.tsx
+++ b/src/components/dashboard/sidebar.tsx
@@ -17,6 +17,7 @@ import {
   ChevronLeft,
   ChevronRight,
   BarChart3,
+  ClipboardList,
   PawPrint,
 } from "lucide-react";
 import { filterPrivateTesterNavItems } from "@/lib/private-tester-scope";
@@ -27,6 +28,7 @@ const navItems = [
   { href: "/dashboard", icon: Activity, label: "Dashboard" },
   { href: "/pets", icon: PawPrint, label: "My Dogs" },
   { href: "/symptom-checker", icon: Stethoscope, label: "Symptom Checker" },
+  { href: "/health-log", icon: ClipboardList, label: "Daily Log" },
   { href: "/history", icon: Clock, label: "History" },
   { href: "/analytics", icon: BarChart3, label: "Analytics" },
   { href: "/supplements", icon: Pill, label: "Supplements" },
@@ -78,7 +80,6 @@ export default function Sidebar() {
   }, [isDesktop, sidebarOpen, toggleSidebar]);
 
   const showMobileSidebar = !isDesktop && sidebarOpen;
-  const collapseLabel = isDesktop ? "Collapse" : "Close menu";
 
   return (
     <>

--- a/src/lib/health-log/readout.ts
+++ b/src/lib/health-log/readout.ts
@@ -1,0 +1,190 @@
+import {
+  SELECT_FIELDS,
+  type FieldDef,
+  type HealthLog,
+  type LogTone,
+} from "./types";
+
+/**
+ * Daily Health Log readout — pure presentation logic. Turns logged entries into
+ * plain owner feedback: which signs are "off" today, and what changed since the
+ * previous log. It never diagnoses; tone only reflects what was logged.
+ */
+
+export interface LoggedSign {
+  field: string;
+  label: string;
+  valueLabel: string;
+  tone: LogTone;
+}
+
+export interface LogChange {
+  field: string;
+  text: string;
+  direction: "improved" | "worse" | "changed";
+}
+
+export interface HealthLogReadout {
+  hasToday: boolean;
+  logDate: string | null;
+  allNormal: boolean;
+  /** Watch/alert signs in the most recent log. */
+  offSigns: LoggedSign[];
+  /** Any alert-tone sign present → owner should consider a vet. */
+  hasAlert: boolean;
+  vomitingCount: number;
+  /** Plain changes vs the previous log. */
+  changes: LogChange[];
+  headline: string;
+  detail: string;
+}
+
+const TONE_RANK: Record<LogTone, number> = { good: 0, watch: 1, alert: 2 };
+
+function optionFor<T extends string>(
+  field: FieldDef<T>,
+  value: string,
+): { label: string; tone: LogTone } {
+  const opt = field.options.find((o) => o.value === value);
+  return opt ? { label: opt.label, tone: opt.tone } : { label: value, tone: "good" };
+}
+
+function vomitingTone(count: number): LogTone {
+  if (count <= 0) return "good";
+  if (count <= 2) return "watch";
+  return "alert";
+}
+
+function sortByDate(logs: HealthLog[]): HealthLog[] {
+  return [...logs].sort(
+    (a, b) => new Date(a.log_date).getTime() - new Date(b.log_date).getTime(),
+  );
+}
+
+function collectOffSigns(log: HealthLog): LoggedSign[] {
+  const signs: LoggedSign[] = [];
+  for (const field of SELECT_FIELDS) {
+    const value = (log as unknown as Record<string, string>)[field.key];
+    const { label, tone } = optionFor(field, value);
+    if (tone !== "good") {
+      signs.push({ field: field.key, label: field.label, valueLabel: label, tone });
+    }
+  }
+  if (log.vomiting_count > 0) {
+    signs.push({
+      field: "vomiting",
+      label: "Vomiting",
+      valueLabel:
+        log.vomiting_count === 1 ? "1 time" : `${log.vomiting_count} times`,
+      tone: vomitingTone(log.vomiting_count),
+    });
+  }
+  // Order alerts first so the most important signs lead.
+  return signs.sort((a, b) => TONE_RANK[b.tone] - TONE_RANK[a.tone]);
+}
+
+function computeChanges(latest: HealthLog, prior: HealthLog): LogChange[] {
+  const changes: LogChange[] = [];
+  for (const field of SELECT_FIELDS) {
+    const latestVal = (latest as unknown as Record<string, string>)[field.key];
+    const priorVal = (prior as unknown as Record<string, string>)[field.key];
+    if (latestVal === priorVal) continue;
+    const a = optionFor(field, latestVal);
+    const b = optionFor(field, priorVal);
+    const direction =
+      TONE_RANK[a.tone] < TONE_RANK[b.tone]
+        ? "improved"
+        : TONE_RANK[a.tone] > TONE_RANK[b.tone]
+          ? "worse"
+          : "changed";
+    const text =
+      direction === "improved"
+        ? `${field.label} back toward normal (${a.label.toLowerCase()})`
+        : direction === "worse"
+          ? `${field.label} looks worse (${a.label.toLowerCase()})`
+          : `${field.label} changed to ${a.label.toLowerCase()}`;
+    changes.push({ field: field.key, text, direction });
+  }
+
+  if (latest.vomiting_count !== prior.vomiting_count) {
+    const direction =
+      latest.vomiting_count < prior.vomiting_count ? "improved" : "worse";
+    changes.push({
+      field: "vomiting",
+      direction,
+      text:
+        direction === "improved"
+          ? `Less vomiting than last log (${latest.vomiting_count} vs ${prior.vomiting_count})`
+          : `More vomiting than last log (${latest.vomiting_count} vs ${prior.vomiting_count})`,
+    });
+  }
+
+  if (
+    latest.weight_kg != null &&
+    prior.weight_kg != null &&
+    latest.weight_kg !== prior.weight_kg
+  ) {
+    const delta = latest.weight_kg - prior.weight_kg;
+    changes.push({
+      field: "weight",
+      direction: "changed",
+      text: `Weight ${delta > 0 ? "up" : "down"} ${Math.abs(delta).toFixed(1)} kg since last log`,
+    });
+  }
+
+  // Lead with worsening, then improvements, then neutral changes.
+  const order = { worse: 0, improved: 1, changed: 2 } as const;
+  return changes.sort((a, b) => order[a.direction] - order[b.direction]);
+}
+
+export function buildHealthLogReadout(logs: HealthLog[]): HealthLogReadout {
+  if (logs.length === 0) {
+    return {
+      hasToday: false,
+      logDate: null,
+      allNormal: false,
+      offSigns: [],
+      hasAlert: false,
+      vomitingCount: 0,
+      changes: [],
+      headline: "No check-ins logged yet",
+      detail: "Log how your dog is doing today to start spotting changes over time.",
+    };
+  }
+
+  const sorted = sortByDate(logs);
+  const latest = sorted[sorted.length - 1];
+  const prior = sorted.length >= 2 ? sorted[sorted.length - 2] : null;
+
+  const offSigns = collectOffSigns(latest);
+  const hasAlert = offSigns.some((s) => s.tone === "alert");
+  const allNormal = offSigns.length === 0;
+  const changes = prior ? computeChanges(latest, prior) : [];
+
+  let headline: string;
+  let detail: string;
+  if (allNormal) {
+    headline = "Everything you logged looks normal";
+    detail =
+      "No off signs in the latest log. Keep checking in so you'll notice any change early.";
+  } else if (hasAlert) {
+    headline = `${offSigns.length} sign${offSigns.length === 1 ? "" : "s"} worth a vet's input`;
+    detail =
+      "Some of what you logged can need attention. When in doubt, it's always okay to call your vet.";
+  } else {
+    headline = `${offSigns.length} thing${offSigns.length === 1 ? "" : "s"} to keep an eye on`;
+    detail = "Nothing looks urgent, but keep watching and call your vet if it doesn't settle.";
+  }
+
+  return {
+    hasToday: true,
+    logDate: latest.log_date,
+    allNormal,
+    offSigns,
+    hasAlert,
+    vomitingCount: latest.vomiting_count,
+    changes,
+    headline,
+    detail,
+  };
+}

--- a/src/lib/health-log/types.ts
+++ b/src/lib/health-log/types.ts
@@ -1,0 +1,133 @@
+/**
+ * Daily Health Log domain types.
+ *
+ * Owner-facing structured daily logging. These enums are the single source of
+ * truth shared by the SQL CHECK constraints, the API zod schema, the log form,
+ * and the readout. Tone classifies a value as good / watch / alert for plain
+ * owner feedback — it is NOT a diagnosis, just a reflection of what was logged.
+ */
+
+export type Appetite = "normal" | "reduced" | "none" | "increased";
+export type Water = "normal" | "less" | "more";
+export type Stool = "normal" | "soft" | "diarrhea" | "none" | "blood";
+export type Urination = "normal" | "less" | "more" | "straining" | "none";
+export type Energy = "normal" | "low" | "high";
+
+export type LogTone = "good" | "watch" | "alert";
+
+export interface HealthLogInput {
+  pet_id: string;
+  /** YYYY-MM-DD. Defaults to today server-side when omitted. */
+  log_date?: string;
+  appetite: Appetite;
+  water: Water;
+  stool: Stool;
+  urination: Urination;
+  vomiting_count: number;
+  energy: Energy;
+  weight_kg?: number | null;
+  meds_given: boolean;
+  notes?: string | null;
+}
+
+export interface HealthLog extends HealthLogInput {
+  id: string;
+  user_id: string;
+  log_date: string;
+  weight_kg: number | null;
+  notes: string | null;
+  photo_urls: string[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface FieldOption<T extends string> {
+  value: T;
+  label: string;
+  tone: LogTone;
+}
+
+export interface FieldDef<T extends string> {
+  key: "appetite" | "water" | "stool" | "urination" | "energy";
+  label: string;
+  options: FieldOption<T>[];
+}
+
+/**
+ * Form/readout field metadata. `tone` marks how concerning a value is so the
+ * readout can flag "off" fields and the form can hint without alarming.
+ */
+export const APPETITE_FIELD: FieldDef<Appetite> = {
+  key: "appetite",
+  label: "Appetite",
+  options: [
+    { value: "normal", label: "Normal", tone: "good" },
+    { value: "reduced", label: "Eating less", tone: "watch" },
+    { value: "none", label: "Not eating", tone: "alert" },
+    { value: "increased", label: "Eating more", tone: "watch" },
+  ],
+};
+
+export const WATER_FIELD: FieldDef<Water> = {
+  key: "water",
+  label: "Water",
+  options: [
+    { value: "normal", label: "Normal", tone: "good" },
+    { value: "less", label: "Drinking less", tone: "watch" },
+    { value: "more", label: "Drinking more", tone: "watch" },
+  ],
+};
+
+export const STOOL_FIELD: FieldDef<Stool> = {
+  key: "stool",
+  label: "Stool",
+  options: [
+    { value: "normal", label: "Normal", tone: "good" },
+    { value: "soft", label: "Soft", tone: "watch" },
+    { value: "diarrhea", label: "Diarrhea", tone: "alert" },
+    { value: "none", label: "None", tone: "watch" },
+    { value: "blood", label: "Blood", tone: "alert" },
+  ],
+};
+
+export const URINATION_FIELD: FieldDef<Urination> = {
+  key: "urination",
+  label: "Urination",
+  options: [
+    { value: "normal", label: "Normal", tone: "good" },
+    { value: "less", label: "Less", tone: "watch" },
+    { value: "more", label: "More", tone: "watch" },
+    { value: "straining", label: "Straining", tone: "alert" },
+    { value: "none", label: "Not urinating", tone: "alert" },
+  ],
+};
+
+export const ENERGY_FIELD: FieldDef<Energy> = {
+  key: "energy",
+  label: "Energy",
+  options: [
+    { value: "normal", label: "Normal", tone: "good" },
+    { value: "low", label: "Low / sluggish", tone: "watch" },
+    { value: "high", label: "Restless / high", tone: "watch" },
+  ],
+};
+
+export const SELECT_FIELDS = [
+  APPETITE_FIELD,
+  WATER_FIELD,
+  STOOL_FIELD,
+  URINATION_FIELD,
+  ENERGY_FIELD,
+] as const;
+
+export const DEFAULT_LOG_INPUT: Omit<HealthLogInput, "pet_id"> = {
+  appetite: "normal",
+  water: "normal",
+  stool: "normal",
+  urination: "normal",
+  vomiting_count: 0,
+  energy: "normal",
+  weight_kg: null,
+  meds_given: false,
+  notes: null,
+};

--- a/supabase-daily-health-log-schema.sql
+++ b/supabase-daily-health-log-schema.sql
@@ -1,0 +1,118 @@
+-- Daily Health Log schema (Phase 2 — owner-facing structured daily logging).
+-- Idempotent: safe to run multiple times. Apply in the Supabase SQL editor.
+-- Mirrors the RLS / trigger conventions of supabase-product-intelligence-schema.sql.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS public.daily_health_logs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  pet_id uuid NOT NULL REFERENCES public.pets(id) ON DELETE CASCADE,
+  log_date date NOT NULL,
+  appetite text NOT NULL DEFAULT 'normal'
+    CHECK (appetite IN ('normal', 'reduced', 'none', 'increased')),
+  water text NOT NULL DEFAULT 'normal'
+    CHECK (water IN ('normal', 'less', 'more')),
+  stool text NOT NULL DEFAULT 'normal'
+    CHECK (stool IN ('normal', 'soft', 'diarrhea', 'none', 'blood')),
+  urination text NOT NULL DEFAULT 'normal'
+    CHECK (urination IN ('normal', 'less', 'more', 'straining', 'none')),
+  vomiting_count integer NOT NULL DEFAULT 0 CHECK (vomiting_count >= 0 AND vomiting_count <= 100),
+  energy text NOT NULL DEFAULT 'normal'
+    CHECK (energy IN ('normal', 'low', 'high')),
+  weight_kg numeric(6, 2) CHECK (weight_kg IS NULL OR (weight_kg > 0 AND weight_kg <= 200)),
+  meds_given boolean NOT NULL DEFAULT false,
+  notes text,
+  photo_urls text[] NOT NULL DEFAULT '{}',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, pet_id, log_date)
+);
+
+CREATE INDEX IF NOT EXISTS daily_health_logs_user_pet_date_idx
+  ON public.daily_health_logs (user_id, pet_id, log_date DESC);
+
+CREATE OR REPLACE FUNCTION public.set_daily_health_logs_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS set_daily_health_logs_updated_at
+  ON public.daily_health_logs;
+CREATE TRIGGER set_daily_health_logs_updated_at
+  BEFORE UPDATE ON public.daily_health_logs
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_daily_health_logs_updated_at();
+
+ALTER TABLE public.daily_health_logs ENABLE ROW LEVEL SECURITY;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.daily_health_logs TO authenticated;
+
+DROP POLICY IF EXISTS daily_health_logs_select_own ON public.daily_health_logs;
+CREATE POLICY daily_health_logs_select_own
+  ON public.daily_health_logs
+  FOR SELECT
+  TO authenticated
+  USING (
+    (select auth.uid()) IS NOT NULL
+    AND auth.uid() = user_id
+    AND EXISTS (
+      SELECT 1 FROM public.pets
+      WHERE pets.id = daily_health_logs.pet_id AND pets.user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS daily_health_logs_insert_own ON public.daily_health_logs;
+CREATE POLICY daily_health_logs_insert_own
+  ON public.daily_health_logs
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    (select auth.uid()) IS NOT NULL
+    AND auth.uid() = user_id
+    AND EXISTS (
+      SELECT 1 FROM public.pets
+      WHERE pets.id = daily_health_logs.pet_id AND pets.user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS daily_health_logs_update_own ON public.daily_health_logs;
+CREATE POLICY daily_health_logs_update_own
+  ON public.daily_health_logs
+  FOR UPDATE
+  TO authenticated
+  USING (
+    (select auth.uid()) IS NOT NULL
+    AND auth.uid() = user_id
+    AND EXISTS (
+      SELECT 1 FROM public.pets
+      WHERE pets.id = daily_health_logs.pet_id AND pets.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    (select auth.uid()) IS NOT NULL
+    AND auth.uid() = user_id
+    AND EXISTS (
+      SELECT 1 FROM public.pets
+      WHERE pets.id = daily_health_logs.pet_id AND pets.user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS daily_health_logs_delete_own ON public.daily_health_logs;
+CREATE POLICY daily_health_logs_delete_own
+  ON public.daily_health_logs
+  FOR DELETE
+  TO authenticated
+  USING (
+    (select auth.uid()) IS NOT NULL
+    AND auth.uid() = user_id
+    AND EXISTS (
+      SELECT 1 FROM public.pets
+      WHERE pets.id = daily_health_logs.pet_id AND pets.user_id = auth.uid()
+    )
+  );

--- a/tests/health-log-readout.test.ts
+++ b/tests/health-log-readout.test.ts
@@ -1,0 +1,101 @@
+import { buildHealthLogReadout } from "@/lib/health-log/readout";
+import type { HealthLog } from "@/lib/health-log/types";
+
+function log(overrides: Partial<HealthLog> = {}): HealthLog {
+  return {
+    id: overrides.id ?? "l1",
+    user_id: "u1",
+    pet_id: "p1",
+    log_date: overrides.log_date ?? "2026-06-18",
+    appetite: overrides.appetite ?? "normal",
+    water: overrides.water ?? "normal",
+    stool: overrides.stool ?? "normal",
+    urination: overrides.urination ?? "normal",
+    vomiting_count: overrides.vomiting_count ?? 0,
+    energy: overrides.energy ?? "normal",
+    weight_kg: overrides.weight_kg ?? null,
+    meds_given: overrides.meds_given ?? false,
+    notes: overrides.notes ?? null,
+    photo_urls: overrides.photo_urls ?? [],
+    created_at: "2026-06-18T08:00:00.000Z",
+    updated_at: "2026-06-18T08:00:00.000Z",
+  };
+}
+
+describe("buildHealthLogReadout", () => {
+  it("returns an empty state with no logs", () => {
+    const r = buildHealthLogReadout([]);
+    expect(r.hasToday).toBe(false);
+    expect(r.allNormal).toBe(false);
+    expect(r.offSigns).toHaveLength(0);
+    expect(r.changes).toHaveLength(0);
+    expect(r.headline).toMatch(/no check-ins/i);
+  });
+
+  it("reports all-normal when nothing is off", () => {
+    const r = buildHealthLogReadout([log()]);
+    expect(r.hasToday).toBe(true);
+    expect(r.allNormal).toBe(true);
+    expect(r.offSigns).toHaveLength(0);
+    expect(r.hasAlert).toBe(false);
+    expect(r.headline).toMatch(/normal/i);
+  });
+
+  it("flags off signs and orders alert before watch", () => {
+    const r = buildHealthLogReadout([
+      log({ appetite: "reduced", stool: "blood", vomiting_count: 4 }),
+    ]);
+    expect(r.allNormal).toBe(false);
+    expect(r.hasAlert).toBe(true);
+    // alert-tone signs (blood stool, 4x vomiting) come before watch (reduced appetite)
+    expect(r.offSigns[0].tone).toBe("alert");
+    const labels = r.offSigns.map((s) => s.field);
+    expect(labels).toEqual(expect.arrayContaining(["stool", "appetite", "vomiting"]));
+    expect(r.headline.toLowerCase()).toContain("vet");
+  });
+
+  it("classifies vomiting count into tones", () => {
+    expect(buildHealthLogReadout([log({ vomiting_count: 0 })]).offSigns).toHaveLength(0);
+    const watch = buildHealthLogReadout([log({ vomiting_count: 2 })]).offSigns.find((s) => s.field === "vomiting");
+    expect(watch?.tone).toBe("watch");
+    const alert = buildHealthLogReadout([log({ vomiting_count: 5 })]).offSigns.find((s) => s.field === "vomiting");
+    expect(alert?.tone).toBe("alert");
+  });
+
+  it("computes improvement vs the previous log", () => {
+    const prior = log({ id: "a", log_date: "2026-06-16", appetite: "none", vomiting_count: 5 });
+    const latest = log({ id: "b", log_date: "2026-06-18", appetite: "normal", vomiting_count: 1 });
+    const r = buildHealthLogReadout([latest, prior]);
+
+    const appetiteChange = r.changes.find((c) => c.field === "appetite");
+    expect(appetiteChange?.direction).toBe("improved");
+    const vomitChange = r.changes.find((c) => c.field === "vomiting");
+    expect(vomitChange?.direction).toBe("improved");
+  });
+
+  it("computes worsening vs the previous log and leads with it", () => {
+    const prior = log({ id: "a", log_date: "2026-06-16", stool: "normal" });
+    const latest = log({ id: "b", log_date: "2026-06-18", stool: "diarrhea", energy: "low" });
+    const r = buildHealthLogReadout([latest, prior]);
+
+    expect(r.changes[0].direction).toBe("worse");
+    expect(r.changes.some((c) => c.field === "stool" && c.direction === "worse")).toBe(true);
+  });
+
+  it("uses the latest log by date regardless of array order", () => {
+    const older = log({ id: "a", log_date: "2026-06-10", appetite: "none" });
+    const newer = log({ id: "b", log_date: "2026-06-17", appetite: "normal" });
+    // pass older last to ensure date sorting, not array position, picks latest
+    const r = buildHealthLogReadout([newer, older]);
+    expect(r.logDate).toBe("2026-06-17");
+    expect(r.allNormal).toBe(true);
+  });
+
+  it("reports a weight change when both logs have weight", () => {
+    const prior = log({ id: "a", log_date: "2026-06-16", weight_kg: 30 });
+    const latest = log({ id: "b", log_date: "2026-06-18", weight_kg: 28.5 });
+    const r = buildHealthLogReadout([latest, prior]);
+    const w = r.changes.find((c) => c.field === "weight");
+    expect(w?.text).toMatch(/down 1\.5 kg/i);
+  });
+});


### PR DESCRIPTION
Phase 2 of Health Signals. Structured daily logging (appetite/water/stool/urination/vomiting/energy/weight/meds/notes), one row per pet per day with full owner-only RLS, GET/POST API (auth+zod+pet-ownership+rate-limit, graceful TABLE_MISSING/demo), pure readout (off-signs + better/worse vs prior, 8 tests), log form page, sidebar nav, and analytics Track-next link. 21 tests green, tsc/eslint clean, build passes, review=SHIP. ROLLOUT GATE: run supabase-daily-health-log-schema.sql then smoke-test before real use; inert until applied.