### PR TITLE
feat(symptom-chat): feed daily health logs into the report AI as context

### DIFF
--- a/plans/health-signals-roadmap.md
+++ b/plans/health-signals-roadmap.md
@@ -34,6 +34,23 @@ in the Supabase SQL editor, then we smoke-test save + read-back on an authed acc
 Until then the API returns TABLE_MISSING and the page shows "not switched on yet" — no
 breakage, just inert.
 
+### Phase 2b — Daily logs → AI brain ✅ SHIPPED
+The symptom-checker REPORT is now history-aware. On `action === "generate_report"`,
+the route fetches the pet's recent daily logs and injects a compact owner-reported
+summary into the report LLM prompt as SUPPORTIVE context only.
+- NEW `src/lib/health-log/context.ts` (`summarizeDailyLogsForContext`, 7 tests) +
+  `server-context.ts` (`loadDailyLogContext`, RLS-scoped, graceful null, injects
+  only when the name maps to exactly one pet).
+- `case_memory.daily_log_context` added to StructuredCaseMemory; preserved across
+  compression/recovery beside `vet_record_context`.
+- Read ONLY in `buildNarrativeReportPrompt` (LLM narrative). NEVER touches
+  deterministic urgency / red flags / matrix / readiness — injected AFTER the
+  blocking checks. Clinical-reviewer verdict: SHIP ("daily_log_context touches
+  deterministic clinical logic? NO; fencing adequate? YES").
+- Verifier: 441 route+health-log tests green, tsc/eslint clean, build passes.
+- Follow-ups (non-blocking, from review): prefer pet-id over name match if a
+  stable id reaches the route; consider an Objective-section clause.
+
 ### Original Phase 2 design notes
 The habit loop. Structured daily fields the owner can log in ~30s.
 

--- a/src/app/api/ai/symptom-chat/route.ts
+++ b/src/app/api/ai/symptom-chat/route.ts
@@ -166,6 +166,7 @@ import { shouldPromptVetRecordUpload } from "@/lib/symptom-chat/vet-record-promp
 import { orchestrateNextQuestion } from "@/lib/symptom-chat/next-question-orchestration";
 import { buildQuestionResponseFlow } from "@/lib/symptom-chat/question-response-flow";
 import { resolveVerifiedUserId } from "@/lib/symptom-chat/server-identity";
+import { loadDailyLogContext } from "@/lib/health-log/server-context";
 import {
   isAsyncWorkerReplay,
   maybeOffloadSymptomChatTurn,
@@ -1583,6 +1584,22 @@ export async function POST(request: Request) {
           },
           { status: 409 }
         );
+      }
+
+      // Enrich the report with the owner's recent at-home daily logs as
+      // SUPPORTIVE narrative context. Best-effort: never blocks report
+      // generation, and never feeds deterministic urgency / red-flag logic
+      // (it is read in buildNarrativeReportPrompt only). See loadDailyLogContext.
+      const dailyLogContext = await loadDailyLogContext({
+        userId: verifiedUserId,
+        petName: effectivePet.name,
+      });
+      if (dailyLogContext) {
+        const memory = ensureStructuredCaseMemory(session);
+        session = {
+          ...session,
+          case_memory: { ...memory, daily_log_context: dailyLogContext },
+        };
       }
 
       return await generateReport({

--- a/src/lib/health-log/context.ts
+++ b/src/lib/health-log/context.ts
@@ -1,0 +1,81 @@
+import { SELECT_FIELDS, type HealthLog } from "./types";
+
+/**
+ * Summarize recent daily health logs into a compact, owner-reported context
+ * string for the symptom-checker AI. This is *supportive narrative context*
+ * only — it must never be fed into deterministic urgency / red-flag logic, and
+ * the summary explicitly labels itself as owner-reported and non-overriding.
+ *
+ * Pure and side-effect free.
+ */
+
+const MAX_LOGS = 14;
+
+function field<T extends string>(log: HealthLog, key: string): T {
+  return (log as unknown as Record<string, T>)[key];
+}
+
+export function summarizeDailyLogsForContext(
+  logs: HealthLog[],
+  petName: string,
+): string {
+  if (logs.length === 0) return "";
+
+  const newestFirst = [...logs]
+    .sort((a, b) => new Date(b.log_date).getTime() - new Date(a.log_date).getTime())
+    .slice(0, MAX_LOGS);
+  const chronological = [...newestFirst].reverse();
+  const days = newestFirst.length;
+  const newest = newestFirst[0].log_date;
+  const oldest = chronological[0].log_date;
+  const dayWord = (n: number) => (n === 1 ? "day" : "days");
+
+  const parts: string[] = [];
+
+  for (const def of SELECT_FIELDS) {
+    const offDays = newestFirst.filter((l) => field(l, def.key) !== "normal");
+    if (offDays.length > 0) {
+      const values = Array.from(new Set(offDays.map((l) => field<string>(l, def.key))));
+      parts.push(
+        `${def.label.toLowerCase()} off on ${offDays.length} of ${days} ${dayWord(days)} (${values.join(", ")})`,
+      );
+    }
+  }
+
+  const vomitDays = newestFirst.filter((l) => l.vomiting_count > 0);
+  if (vomitDays.length > 0) {
+    const total = vomitDays.reduce((sum, l) => sum + l.vomiting_count, 0);
+    parts.push(
+      `vomiting reported on ${vomitDays.length} ${dayWord(vomitDays.length)} (${total} episode${total === 1 ? "" : "s"} total)`,
+    );
+  }
+
+  const weighed = chronological.filter((l) => l.weight_kg != null);
+  if (weighed.length >= 2) {
+    const first = weighed[0].weight_kg as number;
+    const last = weighed[weighed.length - 1].weight_kg as number;
+    const delta = last - first;
+    if (Math.abs(delta) >= 0.1) {
+      parts.push(
+        `weight ${delta > 0 ? "up" : "down"} ${Math.abs(delta).toFixed(1)} kg over the period (now ${last.toFixed(1)} kg)`,
+      );
+    }
+  } else if (weighed.length === 1) {
+    parts.push(`weight ${(weighed[0].weight_kg as number).toFixed(1)} kg`);
+  }
+
+  const medDays = newestFirst.filter((l) => l.meds_given).length;
+  if (medDays > 0) {
+    parts.push(`medication/fluids given on ${medDays} ${dayWord(medDays)}`);
+  }
+
+  const window =
+    days === 1 ? "the latest day" : `the last ${days} ${dayWord(days)} (${oldest} to ${newest})`;
+  const disclaimer =
+    "Owner-reported observations, not clinical measurements; supportive context only — do not override clinical assessment.";
+
+  if (parts.length === 0) {
+    return `Owner's daily check-ins for ${petName} over ${window}: all signs logged as normal. (${disclaimer})`;
+  }
+  return `Owner's daily check-ins for ${petName} over ${window}: ${parts.join("; ")}. (${disclaimer})`;
+}

--- a/src/lib/health-log/server-context.ts
+++ b/src/lib/health-log/server-context.ts
@@ -1,0 +1,50 @@
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import type { HealthLog } from "./types";
+import { summarizeDailyLogsForContext } from "./context";
+
+/**
+ * Load a compact owner-reported daily-log summary for the symptom-checker AI.
+ *
+ * Best-effort and fully graceful: returns null in demo mode, when the table
+ * isn't applied, when the pet can't be resolved, or on any error — the symptom
+ * checker must never fail because logs are unavailable. RLS still scopes the
+ * read to the authenticated owner; we also filter by user_id + pet_id.
+ */
+export async function loadDailyLogContext({
+  userId,
+  petName,
+}: {
+  userId: string | null;
+  petName: string;
+}): Promise<string | null> {
+  if (!userId || !petName.trim()) return null;
+  try {
+    const supabase = await createServerSupabaseClient();
+
+    // Resolve the pet by name. Only inject when the name maps to EXACTLY one
+    // pet — if the owner has two same-named pets we skip rather than risk
+    // mixing a sibling's logs into another pet's report.
+    const { data: pets } = await supabase
+      .from("pets")
+      .select("id")
+      .eq("user_id", userId)
+      .eq("name", petName)
+      .limit(2);
+    if (!pets || pets.length !== 1) return null;
+    const petId = pets[0].id as string;
+
+    const { data: logs, error } = await supabase
+      .from("daily_health_logs")
+      .select("*")
+      .eq("user_id", userId)
+      .eq("pet_id", petId)
+      .order("log_date", { ascending: false })
+      .limit(14);
+    if (error || !logs || logs.length === 0) return null;
+
+    const summary = summarizeDailyLogsForContext(logs as HealthLog[], petName);
+    return summary || null;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/symptom-chat/report-pipeline.ts
+++ b/src/lib/symptom-chat/report-pipeline.ts
@@ -512,6 +512,7 @@ ${input.referenceImageContext ? `REFERENCE IMAGE RETRIEVAL (similar corpus cases
 ${input.clinicalCaseContext ? `SIMILAR CLINICAL CASES (CSV corpus; use as supplementary case-similarity evidence, not a replacement for matrix ranking):\n${input.clinicalCaseContext}\n` : ""}
 
 ${input.session.vision_analysis ? `VISUAL ANALYSIS FROM PET PHOTO (analyzed by the NVIDIA 11B/90B vision stack):\n${input.session.vision_analysis}\n\nIMPORTANT: Incorporate the visual findings above into your differential diagnoses and clinical notes. Reference what was observed in the image (e.g., wound characteristics, skin condition, eye appearance). The visual analysis should heavily influence your report.\n` : ""}
+${input.session.case_memory?.daily_log_context ? `OWNER-LOGGED DAILY HEALTH TRENDS (the owner's own at-home daily check-ins — supportive background context only; do NOT use this to override the matrix-determined urgency or red flags, and do NOT treat owner-reported values as clinical measurements. Use it to enrich the timeline/history and tailor home-care and warning-sign guidance):\n${input.session.case_memory.daily_log_context}\n` : ""}
 YOUR TASK: Write the clinical report using the matrix's disease ranking as your primary guide. Do NOT reorder the differentials unless you have strong clinical reasoning to do so. The matrix has already applied breed multipliers, age factors, and symptom-specific modifiers.
 
 For each differential diagnosis, provide:

--- a/src/lib/symptom-memory.ts
+++ b/src/lib/symptom-memory.ts
@@ -320,6 +320,7 @@ export function mergeCompressionResult(
       clinical_case_state: caseMemory.clinical_case_state,
       asking_because: caseMemory.asking_because,
       vet_record_context: caseMemory.vet_record_context,
+      daily_log_context: caseMemory.daily_log_context,
       // Only these fields come from compression
       compressed_summary: compressed.summary.replace(/\s+/g, " ").trim(),
       compression_model: compressed.model,
@@ -610,6 +611,7 @@ export function ensureStructuredCaseMemory(
     clinical_case_state: existing?.clinical_case_state,
     asking_because: existing?.asking_because,
     vet_record_context: existing?.vet_record_context,
+    daily_log_context: existing?.daily_log_context,
   };
 }
 

--- a/src/lib/triage-engine.ts
+++ b/src/lib/triage-engine.ts
@@ -101,6 +101,12 @@ export interface StructuredCaseMemory {
   asking_because?: string;
   /** Doc Intel vet record summary when uploaded */
   vet_record_context?: string;
+  /**
+   * Owner-reported daily health-log summary (recent trends). Supportive
+   * narrative context for the LLM report only — never feeds deterministic
+   * urgency / red-flag logic.
+   */
+  daily_log_context?: string;
 }
 
 export interface PetProfile {

--- a/tests/health-log-context.test.ts
+++ b/tests/health-log-context.test.ts
@@ -1,0 +1,93 @@
+import { summarizeDailyLogsForContext } from "@/lib/health-log/context";
+import type { HealthLog } from "@/lib/health-log/types";
+
+function log(overrides: Partial<HealthLog> = {}): HealthLog {
+  return {
+    id: overrides.id ?? "l1",
+    user_id: "u1",
+    pet_id: "p1",
+    log_date: overrides.log_date ?? "2026-06-18",
+    appetite: overrides.appetite ?? "normal",
+    water: overrides.water ?? "normal",
+    stool: overrides.stool ?? "normal",
+    urination: overrides.urination ?? "normal",
+    vomiting_count: overrides.vomiting_count ?? 0,
+    energy: overrides.energy ?? "normal",
+    weight_kg: overrides.weight_kg ?? null,
+    meds_given: overrides.meds_given ?? false,
+    notes: overrides.notes ?? null,
+    photo_urls: overrides.photo_urls ?? [],
+    created_at: "2026-06-18T08:00:00.000Z",
+    updated_at: "2026-06-18T08:00:00.000Z",
+  };
+}
+
+describe("summarizeDailyLogsForContext", () => {
+  it("returns empty string for no logs", () => {
+    expect(summarizeDailyLogsForContext([], "Bruno")).toBe("");
+  });
+
+  it("says all-normal when nothing is off, and always carries the non-override disclaimer", () => {
+    const out = summarizeDailyLogsForContext([log()], "Bruno");
+    expect(out).toContain("Bruno");
+    expect(out.toLowerCase()).toContain("all signs logged as normal");
+    expect(out.toLowerCase()).toContain("do not override clinical assessment");
+  });
+
+  it("summarizes off signs with counts and values", () => {
+    const out = summarizeDailyLogsForContext(
+      [
+        log({ id: "a", log_date: "2026-06-16", appetite: "reduced" }),
+        log({ id: "b", log_date: "2026-06-17", appetite: "reduced", stool: "diarrhea" }),
+        log({ id: "c", log_date: "2026-06-18", appetite: "normal" }),
+      ],
+      "Bruno",
+    );
+    expect(out.toLowerCase()).toContain("appetite off on 2 of 3 days");
+    expect(out.toLowerCase()).toContain("reduced");
+    expect(out.toLowerCase()).toContain("stool off on 1 of 3 days");
+  });
+
+  it("aggregates vomiting episodes across days", () => {
+    const out = summarizeDailyLogsForContext(
+      [
+        log({ id: "a", log_date: "2026-06-17", vomiting_count: 1 }),
+        log({ id: "b", log_date: "2026-06-18", vomiting_count: 2 }),
+      ],
+      "Bruno",
+    );
+    expect(out.toLowerCase()).toContain("vomiting reported on 2 days");
+    expect(out.toLowerCase()).toContain("3 episodes total");
+  });
+
+  it("reports a weight trend over the period", () => {
+    const out = summarizeDailyLogsForContext(
+      [
+        log({ id: "a", log_date: "2026-06-12", weight_kg: 30 }),
+        log({ id: "b", log_date: "2026-06-18", weight_kg: 28.5 }),
+      ],
+      "Bruno",
+    );
+    expect(out.toLowerCase()).toContain("weight down 1.5 kg over the period");
+    expect(out.toLowerCase()).toContain("now 28.5 kg");
+  });
+
+  it("labels itself owner-reported and never claims a diagnosis", () => {
+    const out = summarizeDailyLogsForContext(
+      [log({ appetite: "none", stool: "blood", vomiting_count: 4 })],
+      "Bruno",
+    );
+    expect(out.toLowerCase()).toContain("owner-reported observations");
+    expect(out.toLowerCase()).toContain("not clinical measurements");
+    // no diagnostic language
+    expect(out.toLowerCase()).not.toMatch(/diagnos|likely (has|disease)|gastro/);
+  });
+
+  it("caps at 14 logs and frames the window with the date range", () => {
+    const many: HealthLog[] = Array.from({ length: 20 }, (_, i) =>
+      log({ id: `l${i}`, log_date: `2026-06-${String(i + 1).padStart(2, "0")}` }),
+    );
+    const out = summarizeDailyLogsForContext(many, "Bruno");
+    expect(out).toContain("last 14 days");
+  });
+});


### PR DESCRIPTION
Makes the triage report history-aware. On report generation, the symptom checker pulls the pet's recent daily logs and injects a compact owner-reported summary into the report LLM prompt as SUPPORTIVE context only. Never touches deterministic urgency/red-flags/matrix (injected after the blocking gates; read only in buildNarrativeReportPrompt). Fenced + non-diagnostic + graceful. 441 tests green (incl. full route suite), tsc/eslint clean, build passes, clinical-reviewer = SHIP.