### PR TITLE
feat(health-signals): sync daily log into the tab, de-grade ring, drop charts

### DIFF
--- a/src/app/(dashboard)/analytics/page.tsx
+++ b/src/app/(dashboard)/analytics/page.tsx
@@ -1,29 +1,30 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import Link from "next/link";
 import { subDays } from "date-fns";
-import { BarChart3, ChevronDown, Loader2, Stethoscope } from "lucide-react";
+import { Activity, ChevronDown, Loader2, Stethoscope } from "lucide-react";
+import Link from "next/link";
 import { PrivateTesterQuarantinedSurface } from "@/components/private-tester/quarantined-surface";
-import Card from "@/components/ui/card";
-import Select from "@/components/ui/select";
 import { buttonClassName } from "@/components/ui/button";
 import {
+  DailyLogSnapshot,
+  DailySignalsGridView,
   OwnerStatusHero,
   RecentSigns,
   RecoveryTrendStrip,
-  SeverityTrendChart,
-  SymptomFrequencyChart,
+  StatusTimeline,
   TrackNext,
-  UrgencyDistribution,
   VetPacket,
   WhyThisChanged,
 } from "@/components/analytics";
+import Select from "@/components/ui/select";
+import Card from "@/components/ui/card";
 import type { SymptomCheckEntry } from "@/components/timeline/types";
 import { symptomCheckRowToEntry, type SymptomCheckDbRow } from "@/lib/symptom-check-entry-map";
 import { getPrivateTesterQuarantinedSurface } from "@/lib/private-tester-scope";
 import { buildProductIntelligenceSnapshot } from "@/lib/product-intelligence";
 import { buildOwnerReadout } from "@/lib/analytics/owner-readout";
+import type { HealthLog } from "@/lib/health-log/types";
 import { createClient, isSupabaseConfigured } from "@/lib/supabase";
 import { DEMO_ANALYTICS_SYMPTOM_ENTRIES } from "@/lib/demo-health-data";
 import { useAppStore } from "@/store/app-store";
@@ -43,9 +44,10 @@ function inDateRange(entry: SymptomCheckEntry, rangeKey: string, now: Date): boo
   return new Date(entry.created_at) >= cutoff;
 }
 
-function AnalyticsPageContent() {
-  const { pets } = useAppStore();
+function HealthSignalsContent() {
+  const { pets, activePet } = useAppStore();
   const [rawEntries, setRawEntries] = useState<SymptomCheckEntry[]>([]);
+  const [logs, setLogs] = useState<HealthLog[]>([]);
   const [loading, setLoading] = useState(true);
   const [petId, setPetId] = useState<string>("all");
   const [range, setRange] = useState<string>("90");
@@ -56,34 +58,28 @@ function AnalyticsPageContent() {
       setLoading(false);
       return;
     }
-
     if (pets.length === 0) {
       setRawEntries([]);
       setLoading(false);
       return;
     }
-
     setLoading(true);
     try {
       const supabase = createClient();
       const petIds = pets.map((p) => p.id);
       const petNameById = new Map(pets.map((p) => [p.id, p.name] as const));
-
       const { data, error } = await supabase
         .from("symptom_checks")
         .select("id, pet_id, symptoms, ai_response, severity, recommendation, created_at")
         .in("pet_id", petIds)
         .order("created_at", { ascending: false });
-
       if (error) throw error;
-
       const rows = (data ?? []) as SymptomCheckDbRow[];
-      const mapped = rows.map((row) =>
-        symptomCheckRowToEntry(row, petNameById.get(row.pet_id) ?? "Dog")
+      setRawEntries(
+        rows.map((row) => symptomCheckRowToEntry(row, petNameById.get(row.pet_id) ?? "Dog")),
       );
-      setRawEntries(mapped);
     } catch (e) {
-      console.error("Analytics load failed:", e);
+      console.error("Health signals load failed:", e);
       setRawEntries([]);
     } finally {
       setLoading(false);
@@ -94,6 +90,32 @@ function AnalyticsPageContent() {
     void loadChecks();
   }, [loadChecks]);
 
+  // Resolve which pet the daily-log sections describe (selected, else active).
+  const resolvedPetId = useMemo(() => {
+    if (petId !== "all") return petId;
+    return activePet?.id ?? pets[0]?.id ?? null;
+  }, [petId, activePet?.id, pets]);
+
+  const loadLogs = useCallback(async () => {
+    if (!isSupabaseConfigured || !resolvedPetId) {
+      setLogs([]);
+      return;
+    }
+    try {
+      const res = await fetch(`/api/health-log?pet_id=${encodeURIComponent(resolvedPetId)}`, {
+        credentials: "include",
+      });
+      const json = await res.json().catch(() => ({}));
+      setLogs(res.ok && Array.isArray(json.data) ? json.data : []);
+    } catch {
+      setLogs([]);
+    }
+  }, [resolvedPetId]);
+
+  useEffect(() => {
+    void loadLogs();
+  }, [loadLogs]);
+
   const petOptions = useMemo(() => {
     const base = [{ value: "all", label: "All dogs" }];
     if (!isSupabaseConfigured && pets.length === 0) {
@@ -101,9 +123,7 @@ function AnalyticsPageContent() {
       for (const e of DEMO_ANALYTICS_SYMPTOM_ENTRIES) {
         if (!seen.has(e.pet_id)) seen.set(e.pet_id, e.pet_name);
       }
-      for (const [id, name] of seen) {
-        base.push({ value: id, label: name });
-      }
+      for (const [id, name] of seen) base.push({ value: id, label: name });
       return base;
     }
     return [...base, ...pets.map((p) => ({ value: p.id, label: p.name }))];
@@ -113,21 +133,18 @@ function AnalyticsPageContent() {
 
   const filtered = useMemo(() => {
     let list = rawEntries.filter((e) => inDateRange(e, range, now));
-    if (petId !== "all") {
-      list = list.filter((e) => e.pet_id === petId);
-    }
+    if (petId !== "all") list = list.filter((e) => e.pet_id === petId);
     return list;
   }, [rawEntries, range, petId, now]);
 
-  // Deterministic product-intelligence snapshot still powers the trend direction.
   const productSnapshot = useMemo(
     () => buildProductIntelligenceSnapshot({ entries: filtered }),
-    [filtered]
+    [filtered],
   );
 
   const selectedPetName = useMemo(() => {
     if (petId === "all") return undefined;
-    return petOptions.find((option) => option.value === petId)?.label;
+    return petOptions.find((o) => o.value === petId)?.label;
   }, [petId, petOptions]);
 
   const ownerReadout = useMemo(
@@ -136,27 +153,35 @@ function AnalyticsPageContent() {
         entries: filtered,
         snapshot: productSnapshot,
         now,
-        fallbackPetName: selectedPetName ?? "your dog",
+        fallbackPetName: selectedPetName ?? activePet?.name ?? "your dog",
       }),
-    [filtered, productSnapshot, now, selectedPetName]
+    [filtered, productSnapshot, now, selectedPetName, activePet?.name],
   );
 
-  // Latest check's confidence drives the hero ring fill (0..1).
   const latestConfidence = useMemo(() => {
     if (filtered.length === 0) return 0.5;
     const latest = [...filtered].sort(
-      (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+      (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
     )[0];
     const c = latest?.confidence ?? 0.5;
     return c > 1 ? c / 100 : c;
   }, [filtered]);
+
+  const latestLog = useMemo(() => {
+    if (logs.length === 0) return null;
+    return [...logs].sort(
+      (a, b) => new Date(b.log_date).getTime() - new Date(a.log_date).getTime(),
+    )[0];
+  }, [logs]);
+
+  const noChecks = ownerReadout.checkCount === 0 || !ownerReadout.verdict;
 
   return (
     <div className="mx-auto max-w-2xl space-y-5">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <div className="mb-1 flex items-center gap-2 text-[#00a878]">
-            <BarChart3 className="h-5 w-5" aria-hidden />
+            <Activity className="h-5 w-5" aria-hidden />
             <span className="text-sm font-semibold uppercase tracking-wide">
               {ownerReadout.petName === "your dog"
                 ? "Health signals"
@@ -165,26 +190,16 @@ function AnalyticsPageContent() {
           </div>
           <h1 className="text-2xl font-bold text-[#2c2a26]">How is your dog doing?</h1>
           <p className="mt-1 text-sm text-[#6b665d]">
-            A plain-language read on your recent symptom checks
+            A plain-language read on your recent checks and daily logs
             {!isSupabaseConfigured ? " (demo data)" : ""}.
           </p>
         </div>
         <div className="flex flex-col gap-3 sm:flex-row">
           <div className="w-full sm:w-40">
-            <Select
-              label="Dog"
-              options={petOptions}
-              value={petId}
-              onChange={(e) => setPetId(e.target.value)}
-            />
+            <Select label="Dog" options={petOptions} value={petId} onChange={(e) => setPetId(e.target.value)} />
           </div>
           <div className="w-full sm:w-40">
-            <Select
-              label="Time"
-              options={RANGE_OPTIONS}
-              value={range}
-              onChange={(e) => setRange(e.target.value)}
-            />
+            <Select label="Time" options={RANGE_OPTIONS} value={range} onChange={(e) => setRange(e.target.value)} />
           </div>
         </div>
       </div>
@@ -198,97 +213,78 @@ function AnalyticsPageContent() {
         <Card className="p-10 text-center text-[#6b665d]">
           <p>Add a dog profile to start tracking how your dog is doing.</p>
         </Card>
-      ) : ownerReadout.checkCount === 0 || !ownerReadout.verdict ? (
-        <section className="rounded-3xl border border-[#e8e2d8] bg-white p-8 text-center shadow-sm">
-          <div
-            className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl"
-            style={{ background: "rgba(0,168,120,0.12)", color: "#0a7d5b" }}
-          >
-            <Stethoscope className="h-7 w-7" aria-hidden />
-          </div>
-          <h2 className="mt-4 text-xl font-bold text-[#2c2a26]">
-            Let&apos;s get to know {ownerReadout.petName}
-          </h2>
-          <p className="mx-auto mt-2 max-w-sm text-sm leading-relaxed text-[#6b665d]">
-            Do a quick symptom check and we&apos;ll show you how {ownerReadout.petName}
-            {" "}is doing — in plain language, with what to watch for.
-          </p>
-          <Link
-            href="/symptom-checker"
-            className={`${buttonClassName()} mt-5 inline-flex`}
-          >
-            <Stethoscope className="mr-2 h-4 w-4" aria-hidden />
-            Start a quick check
-          </Link>
-        </section>
       ) : (
         <>
-          <OwnerStatusHero
-            verdict={ownerReadout.verdict}
-            petName={ownerReadout.petName}
-            asOf={ownerReadout.asOf}
-            confidence={latestConfidence}
-          />
+          {noChecks ? (
+            <section className="rounded-3xl border border-[#e8e2d8] bg-white p-8 text-center shadow-sm">
+              <div
+                className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl"
+                style={{ background: "rgba(0,168,120,0.12)", color: "#0a7d5b" }}
+              >
+                <Stethoscope className="h-7 w-7" aria-hidden />
+              </div>
+              <h2 className="mt-4 text-xl font-bold text-[#2c2a26]">
+                Let&apos;s get to know {ownerReadout.petName}
+              </h2>
+              <p className="mx-auto mt-2 max-w-sm text-sm leading-relaxed text-[#6b665d]">
+                Do a quick symptom check and we&apos;ll show you how {ownerReadout.petName}
+                {" "}is doing — in plain language, with what to watch for.
+              </p>
+              <Link href="/symptom-checker" className={`${buttonClassName()} mt-5 inline-flex`}>
+                <Stethoscope className="mr-2 h-4 w-4" aria-hidden />
+                Start a quick check
+              </Link>
+            </section>
+          ) : (
+            <>
+              <OwnerStatusHero
+                verdict={ownerReadout.verdict!}
+                petName={ownerReadout.petName}
+                asOf={ownerReadout.asOf}
+                confidence={latestConfidence}
+              />
+              <RecoveryTrendStrip readout={ownerReadout.trend} petName={ownerReadout.petName} />
+              <WhyThisChanged drivers={ownerReadout.drivers} />
+              <RecentSigns signs={ownerReadout.signs} asOf={ownerReadout.asOf} />
+            </>
+          )}
 
-          <RecoveryTrendStrip readout={ownerReadout.trend} petName={ownerReadout.petName} />
+          {/* Daily Log sync — always shown so the loop is visible even before a check */}
+          <DailyLogSnapshot latest={latestLog} petName={ownerReadout.petName} />
+          <DailySignalsGridView logs={logs} now={now} />
 
-          <WhyThisChanged drivers={ownerReadout.drivers} />
-
-          <RecentSigns signs={ownerReadout.signs} asOf={ownerReadout.asOf} />
-
-          {ownerReadout.nextStep ? (
+          {!noChecks && ownerReadout.nextStep ? (
             <TrackNext nextStep={ownerReadout.nextStep} petName={ownerReadout.petName} />
           ) : null}
 
-          <VetPacket packet={ownerReadout.vetPacket} petName={ownerReadout.petName} />
+          {!noChecks ? (
+            <VetPacket
+              packet={ownerReadout.vetPacket}
+              petName={ownerReadout.petName}
+              dailyLogCount={logs.length}
+            />
+          ) : null}
 
-          <details className="group rounded-2xl border border-[#e8e2d8] bg-white">
-            <summary className="flex cursor-pointer list-none items-center justify-between gap-2 px-5 py-4 text-sm font-medium text-[#7c4dc4]">
-              <span>Full history — useful for your vet</span>
-              <ChevronDown
-                className="h-4 w-4 transition-transform group-open:rotate-180"
-                aria-hidden
-              />
-            </summary>
-            <div className="space-y-5 border-t border-[#e8e2d8] px-4 py-5 sm:px-5">
-              <p className="text-xs leading-relaxed text-[#8a857a]">
-                The full check-by-check history below is handy to show your vet. It
-                isn&apos;t a diagnosis — it&apos;s a record of what you reported over time.
-              </p>
-              <div className="grid grid-cols-1 gap-5 lg:grid-cols-2">
-                <Card className="p-5">
-                  <h2 className="mb-2 text-sm font-semibold text-gray-900">
-                    How urgent were the checks?
-                  </h2>
-                  <p className="mb-2 text-xs text-gray-500">
-                    How often each urgency level appeared
-                  </p>
-                  <UrgencyDistribution entries={filtered} />
-                </Card>
-                <Card className="p-5">
-                  <h2 className="mb-1 text-sm font-semibold text-gray-900">
-                    Most common concerns
-                  </h2>
-                  <p className="mb-4 text-xs text-gray-500">Your top reported signs</p>
-                  <SymptomFrequencyChart entries={filtered} />
-                </Card>
-              </div>
-              <Card className="p-5">
-                <h2 className="mb-1 text-sm font-semibold text-gray-900">
-                  Severity over time
-                </h2>
-                <p className="mb-4 text-xs text-gray-500">
-                  Per-check severity (chronological)
+          {!noChecks ? (
+            <details className="group rounded-2xl border border-[#e8e2d8] bg-white">
+              <summary className="flex cursor-pointer list-none items-center justify-between gap-2 px-5 py-4 text-sm font-medium text-[#7c4dc4]">
+                <span>The story over time</span>
+                <ChevronDown className="h-4 w-4 transition-transform group-open:rotate-180" aria-hidden />
+              </summary>
+              <div className="space-y-4 border-t border-[#e8e2d8] px-4 py-5 sm:px-5">
+                <p className="text-xs leading-relaxed text-[#8a857a]">
+                  A simple history of your checks — handy to show your vet. It isn&apos;t a
+                  diagnosis, just a record of what you reported over time.
                 </p>
-                <SeverityTrendChart entries={filtered} />
-              </Card>
-            </div>
-          </details>
+                <StatusTimeline entries={filtered} />
+              </div>
+            </details>
+          ) : null}
 
           <p className="px-2 pb-4 pt-1 text-center text-xs leading-relaxed text-[#8a857a]">
-            PawVital helps you understand your dog&apos;s signs — it&apos;s not a
-            diagnosis and doesn&apos;t replace a vet. If you&apos;re worried or things
-            get worse, contact your vet. In an emergency, call an emergency vet right away.
+            PawVital helps you understand your dog&apos;s signs — it&apos;s not a diagnosis and
+            doesn&apos;t replace a vet. If you&apos;re worried or things get worse, contact your
+            vet. In an emergency, call an emergency vet right away.
           </p>
         </>
       )}
@@ -298,10 +294,8 @@ function AnalyticsPageContent() {
 
 export default function AnalyticsPage() {
   const quarantinedSurface = getPrivateTesterQuarantinedSurface("/analytics");
-
   if (quarantinedSurface) {
     return <PrivateTesterQuarantinedSurface {...quarantinedSurface} />;
   }
-
-  return <AnalyticsPageContent />;
+  return <HealthSignalsContent />;
 }

--- a/src/components/analytics/daily-signals.tsx
+++ b/src/components/analytics/daily-signals.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import Link from "next/link";
+import { ClipboardList } from "lucide-react";
+import type { HealthLog } from "@/lib/health-log/types";
+import { SELECT_FIELDS } from "@/lib/health-log/types";
+import {
+  buildDailySignalsGrid,
+  buildStatusTimeline,
+  type CellState,
+  type SignalTone,
+} from "@/lib/analytics/health-signals";
+import type { SymptomCheckEntry } from "@/components/timeline/types";
+
+const TONE_BG: Record<SignalTone, string> = {
+  good: "rgba(0,168,120,0.12)",
+  watch: "rgba(224,164,88,0.18)",
+  alert: "rgba(226,92,92,0.14)",
+};
+const TONE_TEXT: Record<SignalTone, string> = {
+  good: "#0a7d5b",
+  watch: "#9a6b1f",
+  alert: "#b23636",
+};
+
+const CELL_STYLE: Record<CellState, { bg: string; title: string }> = {
+  normal: { bg: "#00a878", title: "Normal" },
+  changed: { bg: "#d98b3a", title: "Changed" },
+  missing: { bg: "#e8e2d8", title: "Not logged" },
+};
+
+function fieldLabel(key: string, value: string): string {
+  const def = SELECT_FIELDS.find((f) => f.key === key);
+  return def?.options.find((o) => o.value === value)?.label ?? value;
+}
+
+function fieldTone(key: string, value: string): SignalTone {
+  const def = SELECT_FIELDS.find((f) => f.key === key);
+  return (def?.options.find((o) => o.value === value)?.tone as SignalTone) ?? "good";
+}
+
+/** Snapshot of the most recent daily log, synced from the Daily Log. */
+export function DailyLogSnapshot({
+  latest,
+  petName,
+}: {
+  latest: HealthLog | null;
+  petName: string;
+}) {
+  if (!latest) {
+    return (
+      <section className="rounded-2xl border border-[#e8e2d8] bg-white p-5">
+        <div className="flex items-center gap-2">
+          <ClipboardList className="h-4 w-4 text-[#0a7d5b]" aria-hidden />
+          <p className="text-xs font-semibold uppercase tracking-wide text-[#8a857a]">
+            Recent daily signals
+          </p>
+        </div>
+        <p className="mt-2 text-sm leading-relaxed text-[#6b665d]">
+          No daily check-ins logged yet. A 30-second daily log helps you spot whether
+          {" "}{petName} is getting better or worse.
+        </p>
+        <Link
+          href="/health-log"
+          className="mt-3 inline-flex items-center gap-1 text-sm font-medium text-[#0a7d5b] hover:underline"
+        >
+          Log today&apos;s check-in →
+        </Link>
+      </section>
+    );
+  }
+
+  const tiles: { label: string; value: string; tone: SignalTone }[] = SELECT_FIELDS.map(
+    (f) => {
+      const value = (latest as unknown as Record<string, string>)[f.key];
+      return { label: f.label, value: fieldLabel(f.key, value), tone: fieldTone(f.key, value) };
+    },
+  );
+  tiles.push({
+    label: "Vomiting",
+    value: latest.vomiting_count === 0 ? "None" : `${latest.vomiting_count}×`,
+    tone: latest.vomiting_count === 0 ? "good" : latest.vomiting_count > 2 ? "alert" : "watch",
+  });
+
+  return (
+    <section className="rounded-2xl border border-[#e8e2d8] bg-white p-5">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <ClipboardList className="h-4 w-4 text-[#0a7d5b]" aria-hidden />
+          <p className="text-xs font-semibold uppercase tracking-wide text-[#8a857a]">
+            Recent daily signals
+          </p>
+        </div>
+        <span className="text-xs text-[#a8a097]">{latest.log_date}</span>
+      </div>
+      <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-3">
+        {tiles.map((t) => (
+          <div
+            key={t.label}
+            className="rounded-xl px-3 py-2"
+            style={{ background: TONE_BG[t.tone] }}
+          >
+            <p className="text-[11px] font-medium uppercase tracking-wide" style={{ color: TONE_TEXT[t.tone] }}>
+              {t.label}
+            </p>
+            <p className="text-sm font-semibold" style={{ color: TONE_TEXT[t.tone] }}>
+              {t.value}
+            </p>
+          </div>
+        ))}
+        {latest.meds_given ? (
+          <div className="rounded-xl bg-[#f7f4ef] px-3 py-2">
+            <p className="text-[11px] font-medium uppercase tracking-wide text-[#6b665d]">Meds</p>
+            <p className="text-sm font-semibold text-[#4a463f]">Given ✓</p>
+          </div>
+        ) : null}
+      </div>
+
+      <Link
+        href="/health-log"
+        className="mt-3 inline-flex items-center gap-1 text-sm font-medium text-[#0a7d5b] hover:underline"
+      >
+        Update today&apos;s log →
+      </Link>
+    </section>
+  );
+}
+
+/** 7-day grid of daily signals (appetite / water / bathroom / energy / vomiting). */
+export function DailySignalsGridView({
+  logs,
+  now,
+}: {
+  logs: HealthLog[];
+  now: Date;
+}) {
+  const grid = buildDailySignalsGrid(logs, now, 7);
+  if (!grid.hasData) return null;
+
+  return (
+    <section className="rounded-2xl border border-[#e8e2d8] bg-white p-5">
+      <p className="text-xs font-semibold uppercase tracking-wide text-[#8a857a]">
+        Last 7 days
+      </p>
+      <div className="mt-3 space-y-2">
+        {grid.rows.map((row) => (
+          <div key={row.key} className="flex items-center gap-3">
+            <span className="w-20 shrink-0 text-xs text-[#6b665d]">{row.label}</span>
+            <div className="flex flex-1 gap-1.5">
+              {row.cells.map((cell) => (
+                <span
+                  key={cell.date}
+                  className="h-5 flex-1 rounded"
+                  style={{ background: CELL_STYLE[cell.state].bg }}
+                  title={`${cell.date}: ${CELL_STYLE[cell.state].title}`}
+                  role="img"
+                  aria-label={`${row.label} ${cell.date}: ${CELL_STYLE[cell.state].title}`}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="mt-3 flex items-center gap-3 text-[11px] text-[#8a857a]">
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-2.5 w-2.5 rounded" style={{ background: "#00a878" }} /> Normal
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-2.5 w-2.5 rounded" style={{ background: "#d98b3a" }} /> Changed
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-2.5 w-2.5 rounded" style={{ background: "#e8e2d8" }} /> Not logged
+        </span>
+      </div>
+    </section>
+  );
+}
+
+/** Simple status story over time from symptom checks (Monitor → Call vet → …). */
+export function StatusTimeline({ entries }: { entries: SymptomCheckEntry[] }) {
+  const steps = buildStatusTimeline(entries, 6);
+  if (steps.length === 0) return null;
+
+  return (
+    <section className="rounded-2xl border border-[#e8e2d8] bg-white p-5">
+      <p className="text-xs font-semibold uppercase tracking-wide text-[#8a857a]">
+        The story so far
+      </p>
+      <div className="mt-3 flex flex-wrap items-center gap-x-1.5 gap-y-2">
+        {steps.map((step, i) => (
+          <span key={`${step.date}-${i}`} className="flex items-center gap-1.5">
+            <span
+              className="rounded-full px-2.5 py-1 text-xs font-medium"
+              style={{ background: TONE_BG[step.tone], color: TONE_TEXT[step.tone] }}
+              title={step.date}
+            >
+              {step.label}
+            </span>
+            {i < steps.length - 1 ? (
+              <span className="text-[#c9c1b5]" aria-hidden>→</span>
+            ) : null}
+          </span>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/analytics/index.ts
+++ b/src/components/analytics/index.ts
@@ -7,3 +7,8 @@ export { OwnerStatusHero } from "./owner-status-hero";
 export { RecoveryTrendStrip } from "./recovery-trend-strip";
 export { RecentSigns } from "./recent-signs";
 export { WhyThisChanged, TrackNext, VetPacket } from "./owner-signal-cards";
+export {
+  DailyLogSnapshot,
+  DailySignalsGridView,
+  StatusTimeline,
+} from "./daily-signals";

--- a/src/components/analytics/owner-signal-cards.tsx
+++ b/src/components/analytics/owner-signal-cards.tsx
@@ -77,11 +77,14 @@ export function TrackNext({
 export function VetPacket({
   packet,
   petName,
+  dailyLogCount = 0,
 }: {
   packet: OwnerVetPacket;
   petName: string;
+  /** Number of daily logs in view, surfaced in the summary line. */
+  dailyLogCount?: number;
 }) {
-  if (!packet.ready) return null;
+  if (!packet.ready && dailyLogCount === 0) return null;
   const parts: string[] = [];
   if (packet.rangeLabel) parts.push(packet.rangeLabel);
   parts.push(
@@ -91,6 +94,9 @@ export function VetPacket({
         ? "1 urgent flag"
         : `${packet.urgentFlags} urgent flags`,
   );
+  if (dailyLogCount > 0) {
+    parts.push(dailyLogCount === 1 ? "1 daily log" : `${dailyLogCount} daily logs`);
+  }
 
   return (
     <section className="rounded-2xl border border-[#e8e2d8] bg-[#faf8f5] p-5">

--- a/src/components/analytics/owner-status-hero.tsx
+++ b/src/components/analytics/owner-status-hero.tsx
@@ -1,9 +1,23 @@
 "use client";
 
 import Link from "next/link";
-import { AlertCircle, PawPrint, Phone, Stethoscope } from "lucide-react";
+import {
+  AlertCircle,
+  AlertTriangle,
+  HeartPulse,
+  Phone,
+  ShieldCheck,
+  Stethoscope,
+} from "lucide-react";
 import { buttonClassName } from "@/components/ui/button";
 import type { OwnerVerdict, OwnerVerdictState } from "@/lib/analytics/owner-readout";
+
+const STATE_ICON: Record<OwnerVerdictState, typeof HeartPulse> = {
+  watch: ShieldCheck,
+  schedule: HeartPulse,
+  urgent: AlertCircle,
+  emergency: AlertTriangle,
+};
 
 type StateStyle = {
   ring: string;
@@ -52,11 +66,11 @@ const STATE_STYLES: Record<OwnerVerdictState, StateStyle> = {
 function StatusRing({
   color,
   fill,
-  petName,
+  state,
 }: {
   color: string;
   fill: number;
-  petName: string;
+  state: OwnerVerdictState;
 }) {
   const size = 150;
   const stroke = 12;
@@ -64,7 +78,7 @@ function StatusRing({
   const circumference = 2 * Math.PI * radius;
   const clamped = Math.max(0.08, Math.min(1, fill));
   const dash = circumference * clamped;
-  const initial = petName.trim().charAt(0).toUpperCase() || "🐾";
+  const Icon = STATE_ICON[state];
 
   return (
     <div className="relative shrink-0" style={{ width: size, height: size }}>
@@ -88,12 +102,12 @@ function StatusRing({
           strokeDasharray={`${dash} ${circumference}`}
         />
       </svg>
-      <div className="absolute inset-0 flex flex-col items-center justify-center">
+      <div className="absolute inset-0 flex items-center justify-center">
         <div
-          className="flex h-11 w-11 items-center justify-center rounded-full text-lg font-bold"
+          className="flex h-12 w-12 items-center justify-center rounded-full"
           style={{ background: "rgba(0,0,0,0.04)", color }}
         >
-          {initial === "🐾" ? <PawPrint className="h-5 w-5" /> : initial}
+          <Icon className="h-6 w-6" aria-hidden />
         </div>
       </div>
     </div>
@@ -124,7 +138,7 @@ export function OwnerStatusHero({
       aria-label="Current status"
     >
       <div className="flex flex-col items-center gap-5 text-center sm:flex-row sm:items-center sm:gap-7 sm:text-left">
-        <StatusRing color={style.ring} fill={confidence} petName={petName} />
+        <StatusRing color={style.ring} fill={confidence} state={verdict.state} />
         <div className="min-w-0 flex-1">
           <span
             className="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold"

--- a/src/components/dashboard/sidebar.tsx
+++ b/src/components/dashboard/sidebar.tsx
@@ -30,7 +30,7 @@ const navItems = [
   { href: "/symptom-checker", icon: Stethoscope, label: "Symptom Checker" },
   { href: "/health-log", icon: ClipboardList, label: "Daily Log" },
   { href: "/history", icon: Clock, label: "History" },
-  { href: "/analytics", icon: BarChart3, label: "Analytics" },
+  { href: "/analytics", icon: BarChart3, label: "Health Signals" },
   { href: "/supplements", icon: Pill, label: "Supplements" },
   { href: "/reminders", icon: Bell, label: "Reminders" },
   { href: "/journal", icon: BookOpen, label: "Journal" },

--- a/src/lib/analytics/health-signals.ts
+++ b/src/lib/analytics/health-signals.ts
@@ -1,0 +1,106 @@
+import type { SymptomCheckEntry } from "@/components/timeline/types";
+import type { HealthLog } from "@/lib/health-log/types";
+
+/**
+ * Pure builders for the Health Signals tab — a status timeline from symptom
+ * checks and a 7-day daily-signals grid from daily logs. Plain owner language;
+ * never diagnostic.
+ */
+
+export type SignalTone = "good" | "watch" | "alert";
+
+export interface TimelineStep {
+  date: string;
+  label: string;
+  tone: SignalTone;
+}
+
+const URGENCY_STEP: Record<
+  SymptomCheckEntry["urgency"],
+  { label: string; tone: SignalTone }
+> = {
+  monitor: { label: "Monitor", tone: "good" },
+  schedule: { label: "Plan vet", tone: "watch" },
+  urgent: { label: "Call vet", tone: "watch" },
+  emergency: { label: "Emergency", tone: "alert" },
+};
+
+/** Simple "the story so far" — urgency of each check over time, oldest→newest. */
+export function buildStatusTimeline(
+  entries: SymptomCheckEntry[],
+  max = 6,
+): TimelineStep[] {
+  return [...entries]
+    .sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())
+    .slice(-max)
+    .map((e) => ({
+      date: e.created_at.slice(0, 10),
+      label: URGENCY_STEP[e.urgency].label,
+      tone: URGENCY_STEP[e.urgency].tone,
+    }));
+}
+
+export type CellState = "normal" | "changed" | "missing";
+
+export interface SignalRow {
+  key: string;
+  label: string;
+  cells: { date: string; state: CellState }[];
+}
+
+export interface DailySignalsGrid {
+  dates: string[];
+  rows: SignalRow[];
+  /** True when at least one day in the window has a log. */
+  hasData: boolean;
+}
+
+const SIGNAL_DEFS = [
+  { key: "appetite", label: "Appetite" },
+  { key: "water", label: "Water" },
+  { key: "bathroom", label: "Bathroom" },
+  { key: "energy", label: "Energy" },
+  { key: "vomiting", label: "Vomiting" },
+] as const;
+
+function localDateString(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function isOff(log: HealthLog, key: string): boolean {
+  if (key === "bathroom") return log.stool !== "normal" || log.urination !== "normal";
+  if (key === "vomiting") return log.vomiting_count > 0;
+  return (log as unknown as Record<string, string>)[key] !== "normal";
+}
+
+/** 7-day (default) grid of daily signals: each cell is normal / changed / missing. */
+export function buildDailySignalsGrid(
+  logs: HealthLog[],
+  now: Date,
+  days = 7,
+): DailySignalsGrid {
+  const dates: string[] = [];
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(now);
+    d.setDate(d.getDate() - i);
+    dates.push(localDateString(d));
+  }
+
+  const byDate = new Map(logs.map((l) => [l.log_date, l] as const));
+  const hasData = dates.some((d) => byDate.has(d));
+
+  const rows: SignalRow[] = SIGNAL_DEFS.map((def) => ({
+    key: def.key,
+    label: def.label,
+    cells: dates.map((date) => {
+      const log = byDate.get(date);
+      if (!log) return { date, state: "missing" as CellState };
+      return { date, state: isOff(log, def.key) ? "changed" : "normal" };
+    }),
+  }));
+
+  return { dates, rows, hasData };
+}

--- a/tests/health-signals.test.ts
+++ b/tests/health-signals.test.ts
@@ -1,0 +1,99 @@
+import {
+  buildDailySignalsGrid,
+  buildStatusTimeline,
+} from "@/lib/analytics/health-signals";
+import type { SymptomCheckEntry } from "@/components/timeline/types";
+import type { HealthLog } from "@/lib/health-log/types";
+
+function entry(o: Partial<SymptomCheckEntry> = {}): SymptomCheckEntry {
+  return {
+    id: o.id ?? "e1",
+    pet_id: "p1",
+    pet_name: "Bruno",
+    created_at: o.created_at ?? "2026-06-18T10:00:00.000Z",
+    primary_symptom: o.primary_symptom ?? "Vomiting",
+    severity: o.severity ?? "moderate",
+    urgency: o.urgency ?? "monitor",
+    top_diagnosis: "x",
+    confidence: 0.8,
+  };
+}
+
+function log(o: Partial<HealthLog> = {}): HealthLog {
+  return {
+    id: o.id ?? "l1",
+    user_id: "u1",
+    pet_id: "p1",
+    log_date: o.log_date ?? "2026-06-18",
+    appetite: o.appetite ?? "normal",
+    water: o.water ?? "normal",
+    stool: o.stool ?? "normal",
+    urination: o.urination ?? "normal",
+    vomiting_count: o.vomiting_count ?? 0,
+    energy: o.energy ?? "normal",
+    weight_kg: o.weight_kg ?? null,
+    meds_given: o.meds_given ?? false,
+    notes: null,
+    photo_urls: [],
+    created_at: "2026-06-18T08:00:00.000Z",
+    updated_at: "2026-06-18T08:00:00.000Z",
+  };
+}
+
+describe("buildStatusTimeline", () => {
+  it("orders oldest→newest and maps urgency to plain labels", () => {
+    const steps = buildStatusTimeline([
+      entry({ id: "b", created_at: "2026-06-17T10:00:00.000Z", urgency: "urgent" }),
+      entry({ id: "a", created_at: "2026-06-10T10:00:00.000Z", urgency: "monitor" }),
+    ]);
+    expect(steps.map((s) => s.label)).toEqual(["Monitor", "Call vet"]);
+    expect(steps[0].tone).toBe("good");
+    expect(steps[1].tone).toBe("watch");
+  });
+
+  it("caps at the max most-recent steps", () => {
+    const entries = Array.from({ length: 10 }, (_, i) =>
+      entry({ id: `e${i}`, created_at: `2026-06-${String(i + 1).padStart(2, "0")}T10:00:00.000Z` }),
+    );
+    expect(buildStatusTimeline(entries, 6)).toHaveLength(6);
+  });
+
+  it("returns empty for no entries", () => {
+    expect(buildStatusTimeline([])).toHaveLength(0);
+  });
+});
+
+describe("buildDailySignalsGrid", () => {
+  const now = new Date("2026-06-18T12:00:00");
+
+  it("builds a 7-day window ending today with missing cells where no log", () => {
+    const grid = buildDailySignalsGrid([], now, 7);
+    expect(grid.dates).toHaveLength(7);
+    expect(grid.dates[6]).toBe("2026-06-18");
+    expect(grid.hasData).toBe(false);
+    expect(grid.rows.every((r) => r.cells.every((c) => c.state === "missing"))).toBe(true);
+  });
+
+  it("marks normal vs changed per signal", () => {
+    const logs = [
+      log({ log_date: "2026-06-18", appetite: "reduced", vomiting_count: 2 }),
+      log({ id: "l2", log_date: "2026-06-17" }),
+    ];
+    const grid = buildDailySignalsGrid(logs, now, 7);
+    expect(grid.hasData).toBe(true);
+
+    const appetite = grid.rows.find((r) => r.key === "appetite")!;
+    expect(appetite.cells.find((c) => c.date === "2026-06-18")!.state).toBe("changed");
+    expect(appetite.cells.find((c) => c.date === "2026-06-17")!.state).toBe("normal");
+
+    const vomiting = grid.rows.find((r) => r.key === "vomiting")!;
+    expect(vomiting.cells.find((c) => c.date === "2026-06-18")!.state).toBe("changed");
+  });
+
+  it("treats bathroom as changed when stool OR urination is off", () => {
+    const logs = [log({ log_date: "2026-06-18", urination: "straining" })];
+    const grid = buildDailySignalsGrid(logs, now, 7);
+    const bathroom = grid.rows.find((r) => r.key === "bathroom")!;
+    expect(bathroom.cells.find((c) => c.date === "2026-06-18")!.state).toBe("changed");
+  });
+});


### PR DESCRIPTION
Restructures Analytics into Health Signals: renames the tab, replaces the grade-looking hero ring (B) with a state icon, syncs the Daily Log in (snapshot + 7-day signals grid), counts daily logs in the vet packet, and replaces donut/bar/scatter with a plain Status Timeline. New pure logic (6 tests); 34 tests green; tsc/eslint clean; build passes; review=SHIP.