### PR TITLE
feat(onboarding): route first-time owners to the symptom checker + next-step guidance

### DIFF
--- a/src/app/(dashboard)/symptom-checker/page.tsx
+++ b/src/app/(dashboard)/symptom-checker/page.tsx
@@ -22,7 +22,7 @@ import {
   X,
 } from "lucide-react";
 import Card from "@/components/ui/card";
-import Button from "@/components/ui/button";
+import Button, { buttonClassName } from "@/components/ui/button";
 import Badge from "@/components/ui/badge";
 import TesterOnboardingGate from "@/components/tester-onboarding/tester-onboarding-gate";
 import {
@@ -1419,6 +1419,41 @@ export default function SymptomCheckerPage() {
                 </Card>
               ) : null}
               <FullReport report={report} />
+
+              {/* Hand-holding: tell first-time owners what to do after a report. */}
+              <Card className="border border-purple-200 bg-purple-50/60 p-5">
+                <h3 className="text-base font-semibold text-gray-900">
+                  What&apos;s next for {displayPetName}?
+                </h3>
+                <p className="mt-1 text-sm leading-relaxed text-gray-600">
+                  Your report is saved in History. Keeping a daily check-in helps PawVital
+                  spot whether {displayPetName} is getting better or worse over time.
+                </p>
+                <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+                  <a
+                    href="/health-log"
+                    target="_top"
+                    className={`${buttonClassName()} w-full sm:w-auto`}
+                  >
+                    Log today&apos;s check-in
+                  </a>
+                  <a
+                    href="/analytics"
+                    target="_top"
+                    className={`${buttonClassName({ variant: "outline" })} w-full sm:w-auto`}
+                  >
+                    See {displayPetName}&apos;s Health Signals
+                  </a>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="w-full sm:w-auto"
+                    onClick={startNewSession}
+                  >
+                    Start another check
+                  </Button>
+                </div>
+              </Card>
             </div>
           </div>
         )}

--- a/src/components/onboarding/pet-onboarding-host.tsx
+++ b/src/components/onboarding/pet-onboarding-host.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useSyncExternalStore } from "react";
 import { PET_ONBOARDING_DISMISSED_KEY } from "@/lib/demo-storage";
+import { navigateWithBrowser } from "@/lib/browser-navigation";
 import { useAppStore } from "@/store/app-store";
 import PetProfileModal from "@/components/onboarding/pet-profile-modal";
 
@@ -34,6 +35,12 @@ export default function PetOnboardingHost() {
   return (
     <PetProfileModal
       open={open}
+      onSaved={() => {
+        // First-time hand-off: the dog profile now feeds the AI, so take the
+        // owner straight to the symptom checker (the brain) rather than leaving
+        // them on the dashboard wondering what to do next.
+        navigateWithBrowser("/symptom-checker");
+      }}
       onSkipped={() => {
         setDismissedOverride(true);
 

--- a/src/components/onboarding/pet-profile-modal.tsx
+++ b/src/components/onboarding/pet-profile-modal.tsx
@@ -63,11 +63,15 @@ interface PetProfileModalProps {
   open: boolean;
   /** User skipped or dismissed without saving — session flag + parent state. */
   onSkipped: () => void;
+  /** Fired after a dog is saved successfully (used to hand off first-time
+   * users straight to the symptom checker). */
+  onSaved?: () => void;
 }
 
 export default function PetProfileModal({
   open,
   onSkipped,
+  onSaved,
 }: PetProfileModalProps) {
   const user = useAppStore((s) => s.user);
   const { savePet } = usePets();
@@ -159,6 +163,7 @@ export default function PetProfileModal({
     });
     try {
       await savePet(pet);
+      onSaved?.();
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Failed to save dog profile. Please try again.";
       setSaveError(msg);


### PR DESCRIPTION
After dog onboarding completes, route the owner straight to the symptom checker (the brain) instead of the dashboard. Guarded via an onSaved callback so only first-time onboarding redirects (adding a 2nd dog from /pets stays put). Adds a 'What's next?' card after the report (log daily / Health Signals / new check). tsc/eslint clean, build passes.