### PR TITLE
feat(onboarding): collect existing conditions + medications

### DIFF
--- a/src/app/(dashboard)/symptom-checker/page.tsx
+++ b/src/app/(dashboard)/symptom-checker/page.tsx
@@ -22,7 +22,7 @@ import {
   X,
 } from "lucide-react";
 import Card from "@/components/ui/card";
-import Button from "@/components/ui/button";
+import Button, { buttonClassName } from "@/components/ui/button";
 import Badge from "@/components/ui/badge";
 import TesterOnboardingGate from "@/components/tester-onboarding/tester-onboarding-gate";
 import {
@@ -1419,6 +1419,41 @@ export default function SymptomCheckerPage() {
                 </Card>
               ) : null}
               <FullReport report={report} />
+
+              {/* Hand-holding: tell first-time owners what to do after a report. */}
+              <Card className="border border-purple-200 bg-purple-50/60 p-5">
+                <h3 className="text-base font-semibold text-gray-900">
+                  What&apos;s next for {displayPetName}?
+                </h3>
+                <p className="mt-1 text-sm leading-relaxed text-gray-600">
+                  Your report is saved in History. Keeping a daily check-in helps PawVital
+                  spot whether {displayPetName} is getting better or worse over time.
+                </p>
+                <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+                  <a
+                    href="/health-log"
+                    target="_top"
+                    className={`${buttonClassName()} w-full sm:w-auto`}
+                  >
+                    Log today&apos;s check-in
+                  </a>
+                  <a
+                    href="/analytics"
+                    target="_top"
+                    className={`${buttonClassName({ variant: "outline" })} w-full sm:w-auto`}
+                  >
+                    See {displayPetName}&apos;s Health Signals
+                  </a>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="w-full sm:w-auto"
+                    onClick={startNewSession}
+                  >
+                    Start another check
+                  </Button>
+                </div>
+              </Card>
             </div>
           </div>
         )}

--- a/src/components/onboarding/pet-onboarding-host.tsx
+++ b/src/components/onboarding/pet-onboarding-host.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useSyncExternalStore } from "react";
 import { PET_ONBOARDING_DISMISSED_KEY } from "@/lib/demo-storage";
+import { navigateWithBrowser } from "@/lib/browser-navigation";
 import { useAppStore } from "@/store/app-store";
 import PetProfileModal from "@/components/onboarding/pet-profile-modal";
 
@@ -34,6 +35,12 @@ export default function PetOnboardingHost() {
   return (
     <PetProfileModal
       open={open}
+      onSaved={() => {
+        // First-time hand-off: the dog profile now feeds the AI, so take the
+        // owner straight to the symptom checker (the brain) rather than leaving
+        // them on the dashboard wondering what to do next.
+        navigateWithBrowser("/symptom-checker");
+      }}
       onSkipped={() => {
         setDismissedOverride(true);
 

--- a/src/components/onboarding/pet-profile-modal.tsx
+++ b/src/components/onboarding/pet-profile-modal.tsx
@@ -63,11 +63,15 @@ interface PetProfileModalProps {
   open: boolean;
   /** User skipped or dismissed without saving — session flag + parent state. */
   onSkipped: () => void;
+  /** Fired after a dog is saved successfully (used to hand off first-time
+   * users straight to the symptom checker). */
+  onSaved?: () => void;
 }
 
 export default function PetProfileModal({
   open,
   onSkipped,
+  onSaved,
 }: PetProfileModalProps) {
   const user = useAppStore((s) => s.user);
   const { savePet } = usePets();
@@ -159,6 +163,7 @@ export default function PetProfileModal({
     });
     try {
       await savePet(pet);
+      onSaved?.();
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Failed to save dog profile. Please try again.";
       setSaveError(msg);

--- a/src/components/onboarding/pet-profile-modal.tsx
+++ b/src/components/onboarding/pet-profile-modal.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Modal from "@/components/ui/modal";
 import Input from "@/components/ui/input";
 import Select from "@/components/ui/select";
+import Textarea from "@/components/ui/textarea";
 import Button from "@/components/ui/button";
 import { useEffect, useRef } from "react";
 import { isSupabaseConfigured } from "@/lib/supabase";
@@ -22,6 +23,8 @@ function onboardingToPet(
     ageUnit: PetAgeUnit;
     weight: number;
     weightUnit: "lbs" | "kg";
+    existingConditions: string[];
+    medications: string[];
   }
 ): Pet {
   let ageYears = 0;
@@ -52,11 +55,20 @@ function onboardingToPet(
     weight_unit: values.weightUnit,
     gender: "male",
     is_neutered: true,
-    existing_conditions: [],
-    medications: [],
+    existing_conditions: values.existingConditions,
+    medications: values.medications,
     created_at: now,
     updated_at: now,
   };
+}
+
+/** Split a comma-separated owner entry into a clean string array (max 20 items). */
+function parseCommaList(raw: string): string[] {
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .slice(0, 20);
 }
 
 interface PetProfileModalProps {
@@ -82,6 +94,8 @@ export default function PetProfileModal({
   const [ageUnit, setAgeUnit] = useState<PetAgeUnit>("years");
   const [weight, setWeight] = useState("");
   const [weightUnit, setWeightUnit] = useState<"lbs" | "kg">("lbs");
+  const [conditions, setConditions] = useState("");
+  const [medications, setMedications] = useState("");
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [submitting, setSubmitting] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -160,6 +174,8 @@ export default function PetProfileModal({
       ageUnit,
       weight: parseFloat(weight),
       weightUnit,
+      existingConditions: parseCommaList(conditions),
+      medications: parseCommaList(medications),
     });
     try {
       await savePet(pet);
@@ -259,6 +275,24 @@ export default function PetProfileModal({
             ]}
           />
         </div>
+        <Textarea
+          label="Existing conditions (optional)"
+          value={conditions}
+          onChange={(e) => setConditions(e.target.value)}
+          placeholder="e.g. arthritis, skin allergies, heart murmur — separate with commas"
+          rows={2}
+        />
+        <Textarea
+          label="Current medications (optional)"
+          value={medications}
+          onChange={(e) => setMedications(e.target.value)}
+          placeholder="e.g. Apoquel, joint supplement — separate with commas"
+          rows={2}
+        />
+        <p className="-mt-2 text-xs text-gray-500">
+          These help PawVital tailor symptom checks to your dog. You can update them
+          anytime in Settings.
+        </p>
         {saveError && (
           <p className="text-sm text-red-600" role="alert">{saveError}</p>
         )}


### PR DESCRIPTION
Onboarding now captures the dog's existing conditions + current medications (optional, comma-separated) instead of empty arrays. These already flow into the symptom-checker AI report prompt and persist to the pets table (existing_conditions/medications TEXT[] columns, mapped by savePet). Net diff is pet-profile-modal.tsx only. tsc/eslint clean, build passes.