### PR TITLE
VET-DOG-BRAIN gap closure + reviewed stale-test fixes

### DIFF
--- a/plans/VET-DOG-BRAIN-photo-medication-followups.md
+++ b/plans/VET-DOG-BRAIN-photo-medication-followups.md
@@ -1,0 +1,54 @@
+# VET-DOG-BRAIN — Photo & Medication follow-up decisions
+
+Decisions for the two "next step" gaps from the goal. Both are deliberately
+deferred to scoped follow-up tickets rather than half-built now, because each is
+a real feature with storage/schema surface that shouldn't be rushed into the
+clinical-adjacent path. The current code is honest about its MVP state (no fake
+"upload", medication kept as structured daily-log fields).
+
+## Task 5 — Health Log photos: DEFER to a real-upload ticket (do not pretend)
+
+**Current state (honest MVP):** `src/app/(dashboard)/health-log/page.tsx:510-527` shows a
+single URL text field labelled *"Full photo upload coming soon. For now you can
+paste a cloud photo URL"*. The route schema accepts `photo_urls: z.array(z.string().url())`.
+So the app does NOT claim URL paste is a real upload — it's explicitly a fallback.
+
+**Decision: ticket a real upload, reuse the journal convention.** The project
+already has a working image-upload path that Health Log can mirror almost 1:1:
+- Server: `src/app/api/journal/upload/route.ts` — validates the file, uploads to
+  Supabase Storage `journal-photos` via `supabase.storage.from(...).upload(objectPath, buffer)`
+  with path `${user.id}/${Date.now()}-${name}.${ext}`, returns `{ path }`.
+- Client: `journal/page.tsx` `onFilesSelected` — `FormData` with `file` → POST
+  the upload route → collect paths → store array.
+
+**Follow-up ticket scope (small):**
+1. Add `POST /api/health-log/upload` mirroring the journal upload route (or
+   extract the shared validation + a `health-log-photos` bucket; reusing
+   `journal-photos` is acceptable for MVP since both are owner-scoped by `user.id/` path).
+2. Replace the URL text field with the journal's file-picker upload component.
+3. Keep `photo_urls` as the persisted shape (already wired into the Dog Brain
+   photo count + vet packet).
+Not started here — no misleading code shipped.
+
+## Task 6 — Medication: KEEP structured daily-log medication as MVP + ticket events
+
+**Current state (MVP):** medication is captured as a structured `context_signals.medication`
+pack on the daily log (name, time_given, missed_late, dose_notes, side_effect_notes)
+and surfaced as **history only** in the Dog Brain context and vet packet
+("history only, not dosing advice" — asserted by tests). This is sufficient for
+the triage/vet-handoff use case: it gives the vet a record of what was given.
+
+**Decision: keep the daily-log medication MVP; ticket `medication_events` separately.**
+A full `medication_events` entity (own table, schedules, adherence streaks,
+reminders integration) is a distinct feature, not a gap in the current path. The
+MVP already feeds the report context safely and is the right granularity for a
+daily check-in.
+
+**Follow-up ticket scope:** dedicated `medication_events` table (med, dose, route,
+schedule, given/missed timestamps), an API, adherence rollups, and reminders
+linkage — only if product wants medication management beyond the daily log.
+
+## Guardrail (applies to both)
+No medication dosing guidance and no fabricated clinical findings — medication
+stays "history only", photos stay owner-supplied references. Deterministic
+clinical logic remains authoritative.

--- a/src/app/api/ai/symptom-chat/route.ts
+++ b/src/app/api/ai/symptom-chat/route.ts
@@ -1593,6 +1593,9 @@ export async function POST(request: Request) {
       const dailyLogContext = await loadDogBrainContext({
         userId: verifiedUserId,
         petName: effectivePet.name,
+        // Stable DB pet id when the client sent it — skips the ambiguous
+        // name lookup. Falls back to name resolution when absent.
+        petId: effectivePet.id,
       });
       if (dailyLogContext) {
         const memory = ensureStructuredCaseMemory(session);

--- a/src/app/api/health-log/route.ts
+++ b/src/app/api/health-log/route.ts
@@ -6,6 +6,7 @@ import {
   checkRateLimit,
   getRateLimitId,
 } from "@/lib/rate-limit";
+import { ContextSignalsSchema } from "@/lib/health-log/context-signals-schema";
 
 /**
  * Daily Health Log API.
@@ -15,65 +16,10 @@ import {
  *
  * Auth + RLS + pet-ownership enforced, mirroring the journal / product-
  * intelligence routes. Demo mode (no Supabase) returns empty / 503 gracefully.
+ *
+ * The context_signals schema lives in a shared module so the route and tests
+ * validate against the exact same contract.
  */
-
-const ContextSignalsSchema = z
-  .object({
-    gi: z
-      .object({
-        blood_in_stool: z.boolean().optional(),
-        straining: z.boolean().optional(),
-        change_note: z.string().max(500).optional(),
-      })
-      .optional(),
-    urinary: z
-      .object({
-        accidents: z.boolean().optional(),
-        color_change: z.boolean().optional(),
-        increased_thirst: z.boolean().optional(),
-      })
-      .optional(),
-    mobility: z
-      .object({
-        limping: z.boolean().optional(),
-        limb: z.string().max(50).optional(),
-        reluctance_to_move: z.boolean().optional(),
-      })
-      .optional(),
-    skin_ear: z
-      .object({
-        scratching: z.boolean().optional(),
-        head_shaking: z.boolean().optional(),
-        odor: z.boolean().optional(),
-        hot_spot: z.boolean().optional(),
-      })
-      .optional(),
-    breathing: z
-      .object({
-        coughing: z.boolean().optional(),
-        labored: z.boolean().optional(),
-        exercise_intolerance: z.boolean().optional(),
-      })
-      .optional(),
-    seizure: z
-      .object({
-        occurred: z.boolean(),
-        duration_sec: z.number().int().min(0).max(7200).optional(),
-        recovery_note: z.string().max(500).optional(),
-      })
-      .optional(),
-    medication: z
-      .object({
-        name: z.string().max(200).optional(),
-        time_given: z.string().max(20).optional(),
-        missed_late: z.boolean().optional(),
-        dose_notes: z.string().max(500).optional(),
-        side_effect_notes: z.string().max(500).optional(),
-      })
-      .optional(),
-  })
-  .optional()
-  .nullable();
 
 const LogBodySchema = z.object({
   pet_id: z.string().uuid(),

--- a/src/app/api/health-log/route.ts
+++ b/src/app/api/health-log/route.ts
@@ -118,6 +118,20 @@ function isMissingTable(error: { code?: string; message?: string } | null): bool
   );
 }
 
+/**
+ * Detect a missing COLUMN (Postgres 42703 / PostgREST PGRST204 schema-cache
+ * miss). `context_signals` lives behind a migration that may not be applied to
+ * the live DB yet — when that's the case we drop the field and retry so an
+ * otherwise-valid daily log still saves instead of 500-ing.
+ */
+function isMissingColumn(error: { code?: string; message?: string } | null): boolean {
+  if (!error) return false;
+  if (error.code === "42703" || error.code === "PGRST204") return true;
+  return /column .* does not exist|could not find the .* column/i.test(
+    error.message ?? "",
+  );
+}
+
 export async function GET(request: Request) {
   const limit = await rateLimited(request);
   if (!limit.success) {
@@ -205,7 +219,7 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Pet not found" }, { status: 404 });
     }
 
-    const row = {
+    const baseRow = {
       user_id: user.id,
       pet_id: parsed.data.pet_id,
       log_date: parsed.data.log_date ?? todayIso(),
@@ -219,15 +233,28 @@ export async function POST(request: Request) {
       meds_given: parsed.data.meds_given,
       notes: parsed.data.notes ?? null,
       photo_urls: parsed.data.photo_urls ?? [],
-      context_signals: parsed.data.context_signals ?? null,
     };
+    // `context_signals` lives behind a migration that may not be applied to the
+    // live DB yet. Only send the column when the owner actually logged signals,
+    // and retry without it if the column is missing — so core daily logging keeps
+    // working pre-migration instead of 500-ing.
+    const row: Record<string, unknown> =
+      parsed.data.context_signals != null
+        ? { ...baseRow, context_signals: parsed.data.context_signals }
+        : baseRow;
+
+    const upsert = (r: Record<string, unknown>) =>
+      supabase
+        .from("daily_health_logs")
+        .upsert(r, { onConflict: "user_id,pet_id,log_date" })
+        .select()
+        .single();
 
     // One log per pet per day — upsert so re-saving the same day updates it.
-    const { data, error } = await supabase
-      .from("daily_health_logs")
-      .upsert(row, { onConflict: "user_id,pet_id,log_date" })
-      .select()
-      .single();
+    let { data, error } = await upsert(row);
+    if (error && isMissingColumn(error) && "context_signals" in row) {
+      ({ data, error } = await upsert(baseRow));
+    }
     if (error) {
       if (isMissingTable(error)) {
         return NextResponse.json(

--- a/src/lib/health-log/context-signals-schema.ts
+++ b/src/lib/health-log/context-signals-schema.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+import type { ContextSignals } from "./types";
+
+/**
+ * Shared zod schema for daily-log `context_signals`.
+ *
+ * Single source of truth used by BOTH the /api/health-log route and the test
+ * suites — previously this schema was duplicated in the route and in
+ * tests/vet-dog-brain-gaps.test.ts, which let them drift. Keep this in sync with
+ * the `ContextSignals` TypeScript type in ./types.ts (the compile-time guard at
+ * the bottom fails the build if they diverge structurally).
+ */
+export const ContextSignalsSchema = z
+  .object({
+    gi: z
+      .object({
+        blood_in_stool: z.boolean().optional(),
+        straining: z.boolean().optional(),
+        change_note: z.string().max(500).optional(),
+      })
+      .optional(),
+    urinary: z
+      .object({
+        accidents: z.boolean().optional(),
+        color_change: z.boolean().optional(),
+        increased_thirst: z.boolean().optional(),
+      })
+      .optional(),
+    mobility: z
+      .object({
+        limping: z.boolean().optional(),
+        limb: z.string().max(50).optional(),
+        reluctance_to_move: z.boolean().optional(),
+      })
+      .optional(),
+    skin_ear: z
+      .object({
+        scratching: z.boolean().optional(),
+        head_shaking: z.boolean().optional(),
+        odor: z.boolean().optional(),
+        hot_spot: z.boolean().optional(),
+      })
+      .optional(),
+    breathing: z
+      .object({
+        coughing: z.boolean().optional(),
+        labored: z.boolean().optional(),
+        exercise_intolerance: z.boolean().optional(),
+      })
+      .optional(),
+    seizure: z
+      .object({
+        occurred: z.boolean(),
+        duration_sec: z.number().int().min(0).max(7200).optional(),
+        recovery_note: z.string().max(500).optional(),
+      })
+      .optional(),
+    medication: z
+      .object({
+        name: z.string().max(200).optional(),
+        time_given: z.string().max(20).optional(),
+        missed_late: z.boolean().optional(),
+        dose_notes: z.string().max(500).optional(),
+        side_effect_notes: z.string().max(500).optional(),
+      })
+      .optional(),
+  })
+  .optional()
+  .nullable();
+
+export type ContextSignalsSchemaInput = z.infer<typeof ContextSignalsSchema>;
+
+// Compile-time guard: the parsed schema output must be assignable to the
+// hand-written ContextSignals type (null/undefined allowed). If the two drift,
+// this assignment fails `tsc` and the build breaks — forcing them back in sync.
+const _schemaTypeGuard: ContextSignals | null | undefined =
+  undefined as ContextSignalsSchemaInput;
+void _schemaTypeGuard;

--- a/src/lib/triage-engine.ts
+++ b/src/lib/triage-engine.ts
@@ -110,6 +110,13 @@ export interface StructuredCaseMemory {
 }
 
 export interface PetProfile {
+  /**
+   * Stable DB pet id when known (the client sends the active pet, which carries
+   * it). Optional and purely carried through — deterministic clinical logic
+   * never reads it. Used only to give the Dog Brain report context an exact
+   * pet_id and skip the ambiguous name lookup.
+   */
+  id?: string;
   name: string;
   species?: string;
   breed: string;

--- a/tests/dog-brain-report-context.integration.test.ts
+++ b/tests/dog-brain-report-context.integration.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Integration tests for the Dog Brain → symptom-report context path.
+ *
+ * Proves two contract guarantees:
+ *  1. When a stable petId is available, the report context is built from the
+ *     dog's PRIOR logs/checks/journal and skips the ambiguous name lookup.
+ *  2. The deterministic red-flag urgency floor is never lowered by report
+ *     context — the final-safety verifier rejects any LLM urgency downgrade,
+ *     regardless of supportive Dog Brain context.
+ */
+
+import { jest } from "@jest/globals";
+import { parseFinalSafetyVerifierResponse } from "@/lib/symptom-chat/final-safety-verifier";
+import type { FinalSafetyVerifierInput } from "@/lib/symptom-chat/final-safety-verifier";
+
+const mockCreateServerSupabaseClient = jest.fn<() => Promise<unknown>>();
+jest.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: () => mockCreateServerSupabaseClient(),
+}));
+
+// A thenable query chain: select/eq/order return the chain; limit resolves to
+// { data, error } (matching how loadDogBrainContext awaits each source).
+function tableChain(rows: unknown[]) {
+  const chain: Record<string, unknown> = {};
+  chain.select = () => chain;
+  chain.eq = () => chain;
+  chain.order = () => chain;
+  chain.limit = async () => ({ data: rows, error: null });
+  return chain;
+}
+
+function buildSupabase(
+  tableData: Record<string, unknown[]>,
+  petsResult: unknown[] | null = null,
+) {
+  const fromCalls: string[] = [];
+  const supabase = {
+    auth: { getUser: async () => ({ data: { user: { id: "u1" } }, error: null }) },
+    from: (table: string) => {
+      fromCalls.push(table);
+      if (table === "pets") return tableChain(petsResult ?? []);
+      return tableChain(tableData[table] ?? []);
+    },
+  };
+  return { supabase, fromCalls };
+}
+
+const PRIOR_LOGS = [
+  {
+    id: "l1",
+    user_id: "u1",
+    pet_id: "pet-1",
+    log_date: "2026-06-17",
+    appetite: "reduced",
+    water: "normal",
+    stool: "normal",
+    urination: "normal",
+    vomiting_count: 2,
+    energy: "low",
+    weight_kg: null,
+    meds_given: false,
+    notes: null,
+    photo_urls: [],
+    context_signals: null,
+    created_at: "2026-06-17T08:00:00.000Z",
+    updated_at: "2026-06-17T08:00:00.000Z",
+  },
+];
+const PRIOR_CHECKS = [
+  { id: "c1", created_at: "2026-06-16T10:00:00.000Z", symptoms: "vomiting twice", severity: "moderate" },
+];
+const PRIOR_JOURNAL = [
+  { entry_date: "2026-06-15", mood: "low", notes: "seemed tired after walk", photo_urls: [] },
+];
+
+async function loadContext(args: { userId: string | null; petName: string; petId?: string }) {
+  const { loadDogBrainContext } = await import("@/lib/health-log/dog-brain-context");
+  return loadDogBrainContext(args);
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("Dog Brain report context — uses prior dog logs when petId is available", () => {
+  it("builds context from prior logs/checks/journal and SKIPS the name lookup", async () => {
+    const { supabase, fromCalls } = buildSupabase({
+      daily_health_logs: PRIOR_LOGS,
+      symptom_checks: PRIOR_CHECKS,
+      journal_entries: PRIOR_JOURNAL,
+    });
+    mockCreateServerSupabaseClient.mockResolvedValue(supabase);
+
+    const ctx = await loadContext({ userId: "u1", petName: "Bruno", petId: "pet-1" });
+
+    expect(ctx).not.toBeNull();
+    // Pulls the prior daily-log trend.
+    expect(ctx!.toLowerCase()).toContain("daily check-ins");
+    // Pulls prior symptom checks and journal.
+    expect(ctx!.toLowerCase()).toContain("prior symptom checks");
+    expect(ctx!.toLowerCase()).toContain("seemed tired after walk");
+    // Always carries the non-override disclaimer.
+    expect(ctx!.toLowerCase()).toContain("do not override clinical assessment");
+    // petId shortcut: the pets name-lookup was never queried.
+    expect(fromCalls).not.toContain("pets");
+    expect(fromCalls).toEqual(expect.arrayContaining(["daily_health_logs", "symptom_checks", "journal_entries"]));
+  });
+
+  it("falls back to the name lookup when no petId is given", async () => {
+    const { supabase, fromCalls } = buildSupabase(
+      { daily_health_logs: PRIOR_LOGS, symptom_checks: [], journal_entries: [] },
+      [{ id: "pet-1" }], // exactly one pet matches the name
+    );
+    mockCreateServerSupabaseClient.mockResolvedValue(supabase);
+
+    const ctx = await loadContext({ userId: "u1", petName: "Bruno" });
+
+    expect(ctx).not.toBeNull();
+    expect(fromCalls[0]).toBe("pets"); // name lookup happened first
+  });
+
+  it("returns null (skips context) when the name is ambiguous", async () => {
+    const { supabase } = buildSupabase(
+      { daily_health_logs: PRIOR_LOGS },
+      [{ id: "pet-1" }, { id: "pet-2" }], // two same-named pets
+    );
+    mockCreateServerSupabaseClient.mockResolvedValue(supabase);
+
+    const ctx = await loadContext({ userId: "u1", petName: "Bruno" });
+    expect(ctx).toBeNull();
+  });
+
+  it("returns null when there is no user (no context for anonymous)", async () => {
+    const ctx = await loadContext({ userId: null, petName: "Bruno", petId: "pet-1" });
+    expect(ctx).toBeNull();
+    expect(mockCreateServerSupabaseClient).not.toHaveBeenCalled();
+  });
+});
+
+describe("Red-flag urgency floor — never lowered by report context", () => {
+  function input(overrides: Partial<FinalSafetyVerifierInput> = {}): FinalSafetyVerifierInput {
+    return {
+      deterministicUrgency: "emergency",
+      deterministicRedFlags: ["collapse"],
+      explicitOwnerAnswers: {},
+      unresolvedCriticalUnknowns: [],
+      // Benign Dog Brain-style owner context present in the draft.
+      ownerFacingSummaryDraft:
+        "Owner's daily check-ins: mostly normal. Owner-reported observations, not clinical measurements.",
+      vetHandoffDraft: "Owner reports collapse episode.",
+      ...overrides,
+    };
+  }
+
+  function verifierResponse(recommended: string): string {
+    return JSON.stringify({
+      unsafeDowngradeDetected: false,
+      safeToShow: true,
+      missedRedFlags: [],
+      diagnosisOrTreatmentClaims: [],
+      vetHandoffNotes: [],
+      recommendedUrgencyLanguage: recommended,
+    });
+  }
+
+  it("REJECTS an LLM downgrade below the deterministic emergency floor", () => {
+    const result = parseFinalSafetyVerifierResponse(verifierResponse("monitor"), input());
+    expect(result.status).toBe("rejected");
+    if (result.status === "rejected") {
+      expect(result.reason).toBe("unsafe_downgrade");
+    }
+  });
+
+  it("also rejects a same-day downgrade when deterministic is emergency", () => {
+    const result = parseFinalSafetyVerifierResponse(verifierResponse("same_day"), input());
+    expect(result.status).toBe("rejected");
+  });
+
+  it("ACCEPTS an equal (emergency) recommendation — context does not block correct urgency", () => {
+    const result = parseFinalSafetyVerifierResponse(verifierResponse("emergency"), input());
+    expect(result.status).toBe("accepted");
+  });
+});

--- a/tests/health-log.route.test.ts
+++ b/tests/health-log.route.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Route-level tests for /api/health-log POST — exercising the ACTUAL handler
+ * (real zod validation + the missing-column retry), with Supabase + rate-limit
+ * mocked. Covers:
+ *  - every context_signals pack is accepted by the real route schema (201)
+ *  - a missing context_signals column retries WITHOUT the field (core save survives)
+ *  - photo_urls persists when context_signals is absent
+ */
+
+import { jest } from "@jest/globals";
+
+const mockCheckRateLimit = jest.fn<() => Promise<{ success: boolean; reset: number }>>();
+const mockCreateServerSupabaseClient = jest.fn<() => Promise<unknown>>();
+
+jest.mock("@/lib/rate-limit", () => ({
+  generalApiLimiter: {},
+  checkRateLimit: () => mockCheckRateLimit(),
+  getRateLimitId: () => "test:rate-id",
+}));
+
+jest.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: () => mockCreateServerSupabaseClient(),
+}));
+
+type UpsertResult = { data: unknown; error: { code?: string; message?: string } | null };
+
+/**
+ * Build a Supabase mock. `pets` resolves ownership; `daily_health_logs` records
+ * each upsert row and returns the configured results in order (so we can force a
+ * missing-column error on the first call and success on the retry).
+ */
+function buildSupabase(upsertResults: UpsertResult[]) {
+  const upsertRows: Record<string, unknown>[] = [];
+  let idx = 0;
+
+  const petsChain: Record<string, unknown> = {};
+  petsChain.select = () => petsChain;
+  petsChain.eq = () => petsChain;
+  petsChain.maybeSingle = async () => ({ data: { id: "pet-1" }, error: null });
+
+  const dailyChain: Record<string, unknown> = {};
+  dailyChain.upsert = (row: Record<string, unknown>) => {
+    upsertRows.push(row);
+    return dailyChain;
+  };
+  dailyChain.select = () => dailyChain;
+  dailyChain.single = async () =>
+    upsertResults[Math.min(idx++, upsertResults.length - 1)];
+
+  const supabase = {
+    auth: { getUser: async () => ({ data: { user: { id: "user-1" } }, error: null }) },
+    from: (table: string) => {
+      if (table === "pets") return petsChain;
+      if (table === "daily_health_logs") return dailyChain;
+      throw new Error(`Unexpected table in mock: ${table}`);
+    },
+  };
+
+  return { supabase, upsertRows };
+}
+
+function baseBody(extra: Record<string, unknown> = {}) {
+  return {
+    pet_id: "11111111-1111-4111-8111-111111111111",
+    appetite: "normal",
+    water: "normal",
+    stool: "normal",
+    urination: "normal",
+    vomiting_count: 0,
+    energy: "normal",
+    meds_given: false,
+    ...extra,
+  };
+}
+
+function postRequest(body: unknown): Request {
+  return new Request("http://localhost/api/health-log", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function callPost(body: unknown) {
+  const { POST } = await import("@/app/api/health-log/route");
+  return POST(postRequest(body));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCheckRateLimit.mockResolvedValue({ success: true, reset: Date.now() + 60_000 });
+});
+
+describe("POST /api/health-log — context_signals packs accepted by the real schema", () => {
+  const packs: Array<[string, Record<string, unknown>]> = [
+    ["gi", { gi: { blood_in_stool: true, straining: false, change_note: "loose" } }],
+    ["urinary", { urinary: { increased_thirst: true, accidents: false } }],
+    ["mobility", { mobility: { limping: true, limb: "front left" } }],
+    ["skin_ear", { skin_ear: { scratching: true, hot_spot: true } }],
+    ["breathing", { breathing: { coughing: true, labored: false } }],
+    ["seizure", { seizure: { occurred: true, duration_sec: 45 } }],
+    [
+      "medication",
+      { medication: { name: "Apoquel", time_given: "08:30", side_effect_notes: "drowsy" } },
+    ],
+  ];
+
+  it.each(packs)("accepts the %s pack (201)", async (_name, signals) => {
+    const { supabase, upsertRows } = buildSupabase([
+      { data: { id: "log-1", context_signals: signals }, error: null },
+    ]);
+    mockCreateServerSupabaseClient.mockResolvedValue(supabase);
+
+    const res = await callPost(baseBody({ context_signals: signals }));
+
+    expect(res.status).toBe(201);
+    // The pack was sent to the DB on the first (only) upsert.
+    expect(upsertRows[0].context_signals).toEqual(signals);
+  });
+
+  it("rejects an invalid body (400 VALIDATION_ERROR) — schema is real", async () => {
+    const { supabase } = buildSupabase([{ data: null, error: null }]);
+    mockCreateServerSupabaseClient.mockResolvedValue(supabase);
+    // seizure.occurred is required boolean; pass a non-boolean to trip the schema.
+    const res = await callPost(baseBody({ context_signals: { seizure: { occurred: "yes" } } }));
+    const json = await res.json();
+    expect(res.status).toBe(400);
+    expect(json.code).toBe("VALIDATION_ERROR");
+  });
+});
+
+describe("POST /api/health-log — missing context_signals column retries without breaking the save", () => {
+  it("retries WITHOUT context_signals and still saves (201)", async () => {
+    const { supabase, upsertRows } = buildSupabase([
+      { data: null, error: { code: "42703", message: "column context_signals does not exist" } },
+      { data: { id: "log-1" }, error: null },
+    ]);
+    mockCreateServerSupabaseClient.mockResolvedValue(supabase);
+
+    const res = await callPost(
+      baseBody({ context_signals: { gi: { blood_in_stool: true } } }),
+    );
+
+    expect(res.status).toBe(201);
+    // First attempt included the field; the retry dropped it so core logging survives.
+    expect(upsertRows).toHaveLength(2);
+    expect(upsertRows[0]).toHaveProperty("context_signals");
+    expect(upsertRows[1]).not.toHaveProperty("context_signals");
+    // Core fields still present on the surviving save.
+    expect(upsertRows[1].appetite).toBe("normal");
+  });
+
+  it("does not send context_signals at all when none are logged (no wasted column write)", async () => {
+    const { supabase, upsertRows } = buildSupabase([{ data: { id: "log-1" }, error: null }]);
+    mockCreateServerSupabaseClient.mockResolvedValue(supabase);
+
+    const res = await callPost(baseBody());
+
+    expect(res.status).toBe(201);
+    expect(upsertRows).toHaveLength(1);
+    expect(upsertRows[0]).not.toHaveProperty("context_signals");
+  });
+});
+
+describe("POST /api/health-log — photo_urls persists independently of context_signals", () => {
+  it("writes photo_urls when context_signals is absent", async () => {
+    const { supabase, upsertRows } = buildSupabase([
+      { data: { id: "log-1" }, error: null },
+    ]);
+    mockCreateServerSupabaseClient.mockResolvedValue(supabase);
+
+    const photos = ["https://example.com/a.jpg", "https://example.com/b.jpg"];
+    const res = await callPost(baseBody({ photo_urls: photos }));
+
+    expect(res.status).toBe(201);
+    expect(upsertRows[0].photo_urls).toEqual(photos);
+    expect(upsertRows[0]).not.toHaveProperty("context_signals");
+  });
+});

--- a/tests/private-tester-scope-ui.test.ts
+++ b/tests/private-tester-scope-ui.test.ts
@@ -159,7 +159,8 @@ describe("private tester scope UI", () => {
 
     render(React.createElement(Sidebar));
 
-    expect(screen.getByText("Analytics")).toBeTruthy();
+    // The analytics nav item was renamed "Analytics" → "Health Signals".
+    expect(screen.getByText("Health Signals")).toBeTruthy();
     expect(screen.getByText("Supplements")).toBeTruthy();
     expect(screen.getByText("Reminders")).toBeTruthy();
     expect(screen.getByText("Journal")).toBeTruthy();

--- a/tests/security-headers-config.test.ts
+++ b/tests/security-headers-config.test.ts
@@ -20,7 +20,9 @@ describe("security header config", () => {
         "style-src 'self' 'unsafe-inline' https:",
         "img-src 'self' data: blob: https:",
         "font-src 'self' data: https:",
-        "connect-src 'self' https:",
+        // connect-src allows the Azure Speech (STT) + Web PubSub WSS origins so the
+        // symptom-checker microphone and live-update sockets work (see next.config.ts).
+        "connect-src 'self' https: wss://centralus.stt.speech.microsoft.com wss://*.webpubsub.azure.com",
         "frame-ancestors 'none'",
         "object-src 'none'",
         "base-uri 'self'",
@@ -47,8 +49,10 @@ describe("security header config", () => {
     );
     expect(headers.get("X-Content-Type-Options")).toBe("nosniff");
     expect(headers.get("X-Frame-Options")).toBe("DENY");
+    // microphone=(self) so the symptom-checker speech-to-text can request the mic
+    // on our own origin (camera + geolocation stay fully disabled).
     expect(headers.get("Permissions-Policy")).toBe(
-      "camera=(), geolocation=(), microphone=()",
+      "camera=(), geolocation=(), microphone=(self)",
     );
     expect(headers.get("Strict-Transport-Security")).toBe(
       "max-age=63072000; includeSubDomains; preload",

--- a/tests/vet-dog-brain-gaps.test.ts
+++ b/tests/vet-dog-brain-gaps.test.ts
@@ -12,7 +12,7 @@
  *  - formatVetPacketText produces a valid vet packet
  */
 
-import { z } from "zod";
+import { ContextSignalsSchema } from "@/lib/health-log/context-signals-schema";
 import type { ContextSignals, HealthLog } from "@/lib/health-log/types";
 import {
   buildVetTimeline,
@@ -78,28 +78,8 @@ function journal(overrides: Partial<JournalEntry> = {}): JournalEntry {
   };
 }
 
-// ── ContextSignals Zod schema (mirrors the API) ───────────────────────────────
-
-const MedicationSchema = z.object({
-  name: z.string().max(200).optional(),
-  time_given: z.string().max(20).optional(),
-  missed_late: z.boolean().optional(),
-  dose_notes: z.string().max(500).optional(),
-  side_effect_notes: z.string().max(500).optional(),
-});
-
-const ContextSignalsSchema = z
-  .object({
-    gi: z.object({ blood_in_stool: z.boolean().optional(), straining: z.boolean().optional(), change_note: z.string().max(500).optional() }).optional(),
-    urinary: z.object({ accidents: z.boolean().optional(), color_change: z.boolean().optional(), increased_thirst: z.boolean().optional() }).optional(),
-    mobility: z.object({ limping: z.boolean().optional(), limb: z.string().max(50).optional(), reluctance_to_move: z.boolean().optional() }).optional(),
-    skin_ear: z.object({ scratching: z.boolean().optional(), head_shaking: z.boolean().optional(), odor: z.boolean().optional(), hot_spot: z.boolean().optional() }).optional(),
-    breathing: z.object({ coughing: z.boolean().optional(), labored: z.boolean().optional(), exercise_intolerance: z.boolean().optional() }).optional(),
-    seizure: z.object({ occurred: z.boolean(), duration_sec: z.number().int().min(0).max(7200).optional(), recovery_note: z.string().max(500).optional() }).optional(),
-    medication: MedicationSchema.optional(),
-  })
-  .optional()
-  .nullable();
+// ContextSignalsSchema is imported from the shared module — the SAME schema the
+// API route validates against (no duplication / drift).
 
 // ── Each pack parses cleanly ─────────────────────────────────────────────────
 


### PR DESCRIPTION
petId wiring into Dog Brain report context (additive PetProfile.id), shared ContextSignalsSchema (de-dup route+tests), real route-level + integration tests (incl. red-flag urgency floor never lowered), and two stale-test fixes (CSP/mic + Analytics→Health Signals rename) for already-shipped behavior. Brain deep-reviewed: sound, RLS-secure, never touches deterministic logic. Gates: tsc clean, symptom-chat.route 413, dog-brain/health-log/integration 60, security+private-tester now green. Clinical-reviewer + thermo-review: SHIP/APPROVE.