### PR TITLE
test(clinical-matrix): allowlist session-global additional_context question

### DIFF
--- a/tests/clinical-matrix.test.ts
+++ b/tests/clinical-matrix.test.ts
@@ -220,7 +220,10 @@ describe("FOLLOW_UP_QUESTIONS integrity", () => {
   it("every question should be referenced by at least one symptom", () => {
     // Session-global questions are intentionally not tied to specific symptoms —
     // they are selected by triage-engine via session state, not by the symptom planner.
-    const SESSION_GLOBAL_QUESTIONS = new Set(["condition_progression"]);
+    const SESSION_GLOBAL_QUESTIONS = new Set([
+      "condition_progression",
+      "additional_context",
+    ]);
 
     const referencedQuestions = new Set<string>();
     for (const entry of Object.values(SYMPTOM_MAP)) {
@@ -284,7 +287,10 @@ describe("Cross-reference consistency", () => {
 
   it("no orphaned questions (in FOLLOW_UP_QUESTIONS but never referenced)", () => {
     // Session-global questions are intentionally not in any symptom's follow_up_questions.
-    const SESSION_GLOBAL_QUESTIONS = new Set(["condition_progression"]);
+    const SESSION_GLOBAL_QUESTIONS = new Set([
+      "condition_progression",
+      "additional_context",
+    ]);
 
     const referenced = new Set<string>();
     for (const entry of Object.values(SYMPTOM_MAP)) {


### PR DESCRIPTION
## What
Fixes two failing data-integrity tests in `tests/clinical-matrix.test.ts`:
- FOLLOW_UP_QUESTIONS integrity › every question should be referenced by at least one symptom
- Cross-reference consistency › no orphaned questions

## Root cause
`additional_context` is a **session-global** follow-up question selected by triage-engine via session state (`ADDITIONAL_CONTEXT_QUESTION_ID`), exactly like the already-allowlisted `condition_progression`. It is deliberately not linked to any symptom/disease/urgency mapping. The test's `SESSION_GLOBAL_QUESTIONS` allowlist was stale — it exempted `condition_progression` but was never updated when `additional_context` was added.

## Change
Adds `additional_context` to the allowlist in both affected tests. **No clinical file changed** (`clinical-matrix.ts` / `triage-engine.ts` untouched). No urgency, red-flag, or question-schema semantics altered.

## Verification
- `npx jest clinical-matrix` → 48/48 pass
- `npx tsc --noEmit` → clean
- Full clinical + triage suites → 1653/1653 pass
- clinical-reviewer agent: **APPROVE** (no urgency/red-flag/schema change)

Test-only fix — no user-visible runtime change; no Vercel prod redeploy required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)