### PR TITLE
feat(health-log): photo thumbnails on upload

### DIFF
--- a/src/app/(dashboard)/health-log/page.tsx
+++ b/src/app/(dashboard)/health-log/page.tsx
@@ -68,6 +68,8 @@ export default function HealthLogPage() {
   const [saving, setSaving] = useState(false);
   const [savedAt, setSavedAt] = useState<string | null>(null);
   const [photoUploading, setPhotoUploading] = useState(false);
+  // Display-only signed URLs (parallel to form.photo_urls paths) for thumbnails.
+  const [photoPreviews, setPhotoPreviews] = useState<string[]>([]);
 
   const [form, setForm] = useState<HealthLogInput>({
     pet_id: activePet?.id ?? pets[0]?.id ?? "",
@@ -186,6 +188,7 @@ export default function HealthLogPage() {
     setPhotoUploading(true);
     setError(null);
     const uploaded: string[] = [];
+    const previews: string[] = [];
     try {
       for (let i = 0; i < files.length && uploaded.length < 6; i++) {
         const fd = new FormData();
@@ -200,13 +203,17 @@ export default function HealthLogPage() {
           setError(json.error || "Photo upload failed.");
           break;
         }
-        if (typeof json.path === "string") uploaded.push(json.path);
+        if (typeof json.path === "string") {
+          uploaded.push(json.path);
+          previews.push(typeof json.signedUrl === "string" ? json.signedUrl : "");
+        }
       }
       if (uploaded.length > 0) {
         setForm((f) => ({
           ...f,
           photo_urls: [...(f.photo_urls ?? []), ...uploaded].slice(0, 6),
         }));
+        setPhotoPreviews((prev) => [...prev, ...previews].slice(0, 6));
       }
     } catch {
       setError("Photo upload failed.");
@@ -588,13 +595,31 @@ export default function HealthLogPage() {
                   <button
                     type="button"
                     className="ml-2 text-xs font-medium text-[#b23636] hover:underline"
-                    onClick={() => setField("photo_urls", null)}
+                    onClick={() => {
+                      setField("photo_urls", null);
+                      setPhotoPreviews([]);
+                    }}
                   >
                     Clear
                   </button>
                 </span>
               ) : null}
             </div>
+            {photoPreviews.some(Boolean) ? (
+              <div className="mt-2 flex flex-wrap gap-2">
+                {photoPreviews.map((url, i) =>
+                  url ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      key={i}
+                      src={url}
+                      alt="Attached health-log photo"
+                      className="h-16 w-16 rounded-lg border border-[#e8e2d8] object-cover"
+                    />
+                  ) : null,
+                )}
+              </div>
+            ) : null}
             <p className="mt-1 text-xs text-[#8a857a]">
               JPG, PNG, or WebP up to 5MB each (max 6). Stored privately for your vet records.
             </p>

--- a/src/app/(dashboard)/health-log/page.tsx
+++ b/src/app/(dashboard)/health-log/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { CheckCircle2, ClipboardList, Loader2, ChevronDown } from "lucide-react";
 import Card from "@/components/ui/card";
-import Button from "@/components/ui/button";
+import Button, { buttonClassName } from "@/components/ui/button";
 import Select from "@/components/ui/select";
 import Input from "@/components/ui/input";
 import Textarea from "@/components/ui/textarea";
@@ -67,6 +67,7 @@ export default function HealthLogPage() {
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [savedAt, setSavedAt] = useState<string | null>(null);
+  const [photoUploading, setPhotoUploading] = useState(false);
 
   const [form, setForm] = useState<HealthLogInput>({
     pet_id: activePet?.id ?? pets[0]?.id ?? "",
@@ -170,6 +171,52 @@ export default function HealthLogPage() {
     key: K,
     value: HealthLogInput[K],
   ) => setForm((f) => ({ ...f, [key]: value }));
+
+  // Real file upload (mirrors the journal convention): each file POSTs to
+  // /api/health-log/upload, which stores it in owner-scoped Supabase Storage and
+  // returns a path we persist in photo_urls. Up to 6 photos per log.
+  const onPhotoFiles = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files?.length) return;
+    if (!isSupabaseConfigured) {
+      setError("Sign in with a saved profile to attach photos.");
+      e.target.value = "";
+      return;
+    }
+    setPhotoUploading(true);
+    setError(null);
+    const uploaded: string[] = [];
+    try {
+      for (let i = 0; i < files.length && uploaded.length < 6; i++) {
+        const fd = new FormData();
+        fd.append("file", files[i]);
+        const res = await fetch("/api/health-log/upload", {
+          method: "POST",
+          credentials: "include",
+          body: fd,
+        });
+        const json = await res.json().catch(() => ({}));
+        if (!res.ok) {
+          setError(json.error || "Photo upload failed.");
+          break;
+        }
+        if (typeof json.path === "string") uploaded.push(json.path);
+      }
+      if (uploaded.length > 0) {
+        setForm((f) => ({
+          ...f,
+          photo_urls: [...(f.photo_urls ?? []), ...uploaded].slice(0, 6),
+        }));
+      }
+    } catch {
+      setError("Photo upload failed.");
+    } finally {
+      setPhotoUploading(false);
+      e.target.value = ""; // allow re-selecting the same file
+    }
+  };
+
+  const photoCount = form.photo_urls?.length ?? 0;
 
   return (
     <div className="mx-auto max-w-2xl space-y-5">
@@ -507,23 +554,49 @@ export default function HealthLogPage() {
             rows={3}
           />
 
-          {/* Photo URLs — text fallback until a file-upload component is wired in */}
+          {/* Photo upload — real file upload to owner-scoped Supabase Storage */}
           <div>
             <label className="block text-sm font-medium text-[#4a463f]">
-              Photo link <span className="text-xs font-normal text-[#8a857a]">(optional — paste a URL to attach)</span>
+              Photos <span className="text-xs font-normal text-[#8a857a]">(optional)</span>
             </label>
-            <input
-              type="url"
-              className="mt-1 w-full rounded-lg border border-[#e8e2d8] bg-white px-3 py-2 text-sm text-[#2c2a26] placeholder-[#b0aaa0] focus:border-[#7c4dc4] focus:outline-none"
-              placeholder="https://..."
-              value={form.photo_urls?.[0] ?? ""}
-              onChange={(e) => {
-                const val = e.target.value.trim();
-                setField("photo_urls", val ? [val] : null);
-              }}
-            />
+            <div className="mt-1 flex flex-wrap items-center gap-3">
+              <label
+                className={`${buttonClassName({ variant: "outline", size: "sm" })} cursor-pointer ${
+                  photoUploading || !isSupabaseConfigured ? "pointer-events-none opacity-50" : ""
+                }`}
+              >
+                {photoUploading ? (
+                  <>
+                    <Loader2 className="mr-1.5 h-4 w-4 animate-spin" aria-hidden />
+                    Uploading…
+                  </>
+                ) : (
+                  "Add photos"
+                )}
+                <input
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp"
+                  multiple
+                  className="hidden"
+                  disabled={photoUploading || !isSupabaseConfigured}
+                  onChange={(e) => void onPhotoFiles(e)}
+                />
+              </label>
+              {photoCount > 0 ? (
+                <span className="text-sm text-[#4a463f]">
+                  {photoCount} photo{photoCount === 1 ? "" : "s"} attached
+                  <button
+                    type="button"
+                    className="ml-2 text-xs font-medium text-[#b23636] hover:underline"
+                    onClick={() => setField("photo_urls", null)}
+                  >
+                    Clear
+                  </button>
+                </span>
+              ) : null}
+            </div>
             <p className="mt-1 text-xs text-[#8a857a]">
-              Full photo upload coming soon. For now you can paste a cloud photo URL (Google Photos share link, etc).
+              JPG, PNG, or WebP up to 5MB each (max 6). Stored privately for your vet records.
             </p>
           </div>
 

--- a/src/app/api/health-log/route.ts
+++ b/src/app/api/health-log/route.ts
@@ -36,7 +36,9 @@ const LogBodySchema = z.object({
   weight_kg: z.number().positive().max(200).nullable().optional(),
   meds_given: z.boolean(),
   notes: z.string().trim().max(4000).nullable().optional(),
-  photo_urls: z.array(z.string().url()).max(10).optional().nullable(),
+  // Storage object paths (from /api/health-log/upload) or pasted URLs — both
+  // accepted, mirroring the journal photo convention.
+  photo_urls: z.array(z.string().min(1).max(1024)).max(10).optional().nullable(),
   context_signals: ContextSignalsSchema,
 });
 

--- a/src/app/api/health-log/upload/route.ts
+++ b/src/app/api/health-log/upload/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from "next/server";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import {
+  generalApiLimiter,
+  checkRateLimit,
+  getRateLimitId,
+} from "@/lib/rate-limit";
+import {
+  MAX_JOURNAL_UPLOAD_BYTES,
+  validateJournalUploadFile,
+} from "@/app/api/journal/upload/validation";
+
+/**
+ * Daily Health Log photo upload.
+ *
+ * POST /api/health-log/upload  (multipart: file) → { path }
+ *
+ * Mirrors the journal upload convention: same shared image validator, same
+ * owner-scoped Supabase Storage bucket (`journal-photos`) keyed under the
+ * authenticated user's id, so it's protected by the same storage RLS policy.
+ * The returned `path` is persisted in daily_health_logs.photo_urls.
+ */
+
+const MAX_UPLOAD_MB = Math.floor(MAX_JOURNAL_UPLOAD_BYTES / (1024 * 1024));
+
+function safeFileStem(name: string): string {
+  const base = name.split(/[/\\]/).pop() || "photo";
+  return base.replace(/[^a-zA-Z0-9._-]+/g, "_").slice(0, 120) || "photo";
+}
+
+export async function POST(request: Request) {
+  const rateLimit = await checkRateLimit(generalApiLimiter, getRateLimitId(request));
+  if (!rateLimit.success) {
+    return NextResponse.json(
+      { error: "Too many requests. Please slow down." },
+      {
+        status: 429,
+        headers: {
+          "Retry-After": String(Math.ceil((rateLimit.reset - Date.now()) / 1000)),
+        },
+      },
+    );
+  }
+
+  let supabase;
+  try {
+    supabase = await createServerSupabaseClient();
+  } catch (error) {
+    if (error instanceof Error && error.message === "DEMO_MODE") {
+      return NextResponse.json(
+        { error: "Database access is not configured", code: "DEMO_MODE" },
+        { status: 503 },
+      );
+    }
+    console.error("[HealthLog Upload] Supabase client error:", error);
+    return NextResponse.json({ error: "Unable to connect to the database" }, { status: 500 });
+  }
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return NextResponse.json({ error: "Expected multipart form data" }, { status: 400 });
+  }
+
+  const file = formData.get("file");
+  if (!file || !(file instanceof File)) {
+    return NextResponse.json({ error: "Missing file field" }, { status: 400 });
+  }
+
+  const validation = await validateJournalUploadFile(file);
+  if (!validation.ok) {
+    const message =
+      validation.reason === "file-too-large"
+        ? `File too large (max ${MAX_UPLOAD_MB}MB)`
+        : validation.reason === "unsupported-file-type"
+          ? "Unsupported file type"
+          : "Uploaded file contents do not match a supported image file";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  const { buffer, detectedType, extension } = validation;
+  const objectPath = `${user.id}/${Date.now()}-${safeFileStem(file.name)}.${extension}`;
+
+  const { error: uploadError } = await supabase.storage
+    .from("journal-photos")
+    .upload(objectPath, buffer, { contentType: detectedType, upsert: false });
+
+  if (uploadError) {
+    console.error("[HealthLog Upload] Storage error:", uploadError);
+    return NextResponse.json({ error: "Upload failed" }, { status: 500 });
+  }
+
+  return NextResponse.json({ path: objectPath });
+}

--- a/src/app/api/health-log/upload/route.ts
+++ b/src/app/api/health-log/upload/route.ts
@@ -99,5 +99,11 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Upload failed" }, { status: 500 });
   }
 
-  return NextResponse.json({ path: objectPath });
+  // Short-lived signed URL so the client can show a thumbnail immediately. The
+  // PATH is what's persisted; the signedUrl is display-only and best-effort.
+  const { data: signed } = await supabase.storage
+    .from("journal-photos")
+    .createSignedUrl(objectPath, 60 * 60);
+
+  return NextResponse.json({ path: objectPath, signedUrl: signed?.signedUrl ?? null });
 }

--- a/tests/health-log-upload.route.test.ts
+++ b/tests/health-log-upload.route.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Route-level tests for POST /api/health-log/upload — the real photo upload.
+ * Auth + validation + owner-scoped storage path, with Supabase, rate-limit, and
+ * the shared image validator mocked.
+ */
+
+import { jest } from "@jest/globals";
+
+const mockCheckRateLimit = jest.fn<() => Promise<{ success: boolean; reset: number }>>();
+const mockCreateServerSupabaseClient = jest.fn<() => Promise<unknown>>();
+const mockValidate =
+  jest.fn<() => Promise<{ ok: boolean; reason?: string; buffer?: Buffer; detectedType?: string; extension?: string }>>();
+
+jest.mock("@/lib/rate-limit", () => ({
+  generalApiLimiter: {},
+  checkRateLimit: () => mockCheckRateLimit(),
+  getRateLimitId: () => "test:rate-id",
+}));
+jest.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: () => mockCreateServerSupabaseClient(),
+}));
+jest.mock("@/app/api/journal/upload/validation", () => ({
+  MAX_JOURNAL_UPLOAD_BYTES: 5 * 1024 * 1024,
+  validateJournalUploadFile: () => mockValidate(),
+}));
+
+function buildSupabase(userId: string | null, uploadError: unknown = null) {
+  const uploadCalls: { bucket: string; path: string }[] = [];
+  let lastBucket = "";
+  const supabase = {
+    auth: {
+      getUser: async () => ({
+        data: { user: userId ? { id: userId } : null },
+        error: null,
+      }),
+    },
+    storage: {
+      from: (bucket: string) => {
+        lastBucket = bucket;
+        return {
+          upload: async (path: string) => {
+            uploadCalls.push({ bucket: lastBucket, path });
+            return { error: uploadError };
+          },
+        };
+      },
+    },
+  };
+  return { supabase, uploadCalls };
+}
+
+function uploadRequest(withFile: boolean): Request {
+  const fd = new FormData();
+  if (withFile) {
+    fd.append("file", new File([new Uint8Array([1, 2, 3])], "stool.jpg", { type: "image/jpeg" }));
+  }
+  return new Request("http://localhost/api/health-log/upload", { method: "POST", body: fd });
+}
+
+async function callPost(withFile = true) {
+  const { POST } = await import("@/app/api/health-log/upload/route");
+  return POST(uploadRequest(withFile));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCheckRateLimit.mockResolvedValue({ success: true, reset: Date.now() + 60_000 });
+  mockValidate.mockResolvedValue({
+    ok: true,
+    buffer: Buffer.from([1, 2, 3]),
+    detectedType: "image/jpeg",
+    extension: "jpg",
+  });
+});
+
+describe("POST /api/health-log/upload", () => {
+  it("401 when unauthenticated", async () => {
+    mockCreateServerSupabaseClient.mockResolvedValue(buildSupabase(null).supabase);
+    const res = await callPost();
+    expect(res.status).toBe(401);
+  });
+
+  it("400 when no file is provided", async () => {
+    mockCreateServerSupabaseClient.mockResolvedValue(buildSupabase("user-1").supabase);
+    const res = await callPost(false);
+    expect(res.status).toBe(400);
+  });
+
+  it("400 on validation failure (e.g. too large)", async () => {
+    mockCreateServerSupabaseClient.mockResolvedValue(buildSupabase("user-1").supabase);
+    mockValidate.mockResolvedValue({ ok: false, reason: "file-too-large" });
+    const res = await callPost();
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error.toLowerCase()).toContain("too large");
+  });
+
+  it("uploads to the journal-photos bucket under the user's id and returns the path", async () => {
+    const { supabase, uploadCalls } = buildSupabase("user-1");
+    mockCreateServerSupabaseClient.mockResolvedValue(supabase);
+
+    const res = await callPost();
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(uploadCalls).toHaveLength(1);
+    expect(uploadCalls[0].bucket).toBe("journal-photos");
+    // owner-scoped: path starts with the user's id, ends with the validated extension
+    expect(uploadCalls[0].path.startsWith("user-1/")).toBe(true);
+    expect(uploadCalls[0].path.endsWith(".jpg")).toBe(true);
+    expect(json.path).toBe(uploadCalls[0].path);
+  });
+
+  it("503 in demo mode (no Supabase)", async () => {
+    mockCreateServerSupabaseClient.mockRejectedValue(new Error("DEMO_MODE"));
+    const res = await callPost();
+    expect(res.status).toBe(503);
+    const json = await res.json();
+    expect(json.code).toBe("DEMO_MODE");
+  });
+
+  it("500 when storage upload fails", async () => {
+    mockCreateServerSupabaseClient.mockResolvedValue(
+      buildSupabase("user-1", { message: "storage down" }).supabase,
+    );
+    const res = await callPost();
+    expect(res.status).toBe(500);
+  });
+});

--- a/tests/health-log-upload.route.test.ts
+++ b/tests/health-log-upload.route.test.ts
@@ -42,6 +42,10 @@ function buildSupabase(userId: string | null, uploadError: unknown = null) {
             uploadCalls.push({ bucket: lastBucket, path });
             return { error: uploadError };
           },
+          createSignedUrl: async (path: string) => ({
+            data: { signedUrl: `https://signed.example/${path}` },
+            error: null,
+          }),
         };
       },
     },
@@ -109,6 +113,9 @@ describe("POST /api/health-log/upload", () => {
     expect(uploadCalls[0].path.startsWith("user-1/")).toBe(true);
     expect(uploadCalls[0].path.endsWith(".jpg")).toBe(true);
     expect(json.path).toBe(uploadCalls[0].path);
+    // a display-only signed URL is returned for the thumbnail
+    expect(typeof json.signedUrl).toBe("string");
+    expect(json.signedUrl).toContain(uploadCalls[0].path);
   });
 
   it("503 in demo mode (no Supabase)", async () => {


### PR DESCRIPTION
Photos were uploaded + counted but not shown. Upload route now returns a short-lived signed URL (display-only; path still persisted); the form renders thumbnails of just-attached photos; Clear resets both. tsc/eslint clean, 6 upload tests, build passes.