### PR TITLE
feat(health-log): photo thumbnails on upload

### DIFF
--- a/src/app/(dashboard)/health-log/page.tsx
+++ b/src/app/(dashboard)/health-log/page.tsx
@@ -68,6 +68,8 @@ export default function HealthLogPage() {
   const [saving, setSaving] = useState(false);
   const [savedAt, setSavedAt] = useState<string | null>(null);
   const [photoUploading, setPhotoUploading] = useState(false);
+  // Display-only signed URLs (parallel to form.photo_urls paths) for thumbnails.
+  const [photoPreviews, setPhotoPreviews] = useState<string[]>([]);
 
   const [form, setForm] = useState<HealthLogInput>({
     pet_id: activePet?.id ?? pets[0]?.id ?? "",
@@ -186,6 +188,7 @@ export default function HealthLogPage() {
     setPhotoUploading(true);
     setError(null);
     const uploaded: string[] = [];
+    const previews: string[] = [];
     try {
       for (let i = 0; i < files.length && uploaded.length < 6; i++) {
         const fd = new FormData();
@@ -200,13 +203,17 @@ export default function HealthLogPage() {
           setError(json.error || "Photo upload failed.");
           break;
         }
-        if (typeof json.path === "string") uploaded.push(json.path);
+        if (typeof json.path === "string") {
+          uploaded.push(json.path);
+          previews.push(typeof json.signedUrl === "string" ? json.signedUrl : "");
+        }
       }
       if (uploaded.length > 0) {
         setForm((f) => ({
           ...f,
           photo_urls: [...(f.photo_urls ?? []), ...uploaded].slice(0, 6),
         }));
+        setPhotoPreviews((prev) => [...prev, ...previews].slice(0, 6));
       }
     } catch {
       setError("Photo upload failed.");
@@ -588,13 +595,31 @@ export default function HealthLogPage() {
                   <button
                     type="button"
                     className="ml-2 text-xs font-medium text-[#b23636] hover:underline"
-                    onClick={() => setField("photo_urls", null)}
+                    onClick={() => {
+                      setField("photo_urls", null);
+                      setPhotoPreviews([]);
+                    }}
                   >
                     Clear
                   </button>
                 </span>
               ) : null}
             </div>
+            {photoPreviews.some(Boolean) ? (
+              <div className="mt-2 flex flex-wrap gap-2">
+                {photoPreviews.map((url, i) =>
+                  url ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      key={i}
+                      src={url}
+                      alt="Attached health-log photo"
+                      className="h-16 w-16 rounded-lg border border-[#e8e2d8] object-cover"
+                    />
+                  ) : null,
+                )}
+              </div>
+            ) : null}
             <p className="mt-1 text-xs text-[#8a857a]">
               JPG, PNG, or WebP up to 5MB each (max 6). Stored privately for your vet records.
             </p>

--- a/src/app/api/health-log/upload/route.ts
+++ b/src/app/api/health-log/upload/route.ts
@@ -99,5 +99,11 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Upload failed" }, { status: 500 });
   }
 
-  return NextResponse.json({ path: objectPath });
+  // Short-lived signed URL so the client can show a thumbnail immediately. The
+  // PATH is what's persisted; the signedUrl is display-only and best-effort.
+  const { data: signed } = await supabase.storage
+    .from("journal-photos")
+    .createSignedUrl(objectPath, 60 * 60);
+
+  return NextResponse.json({ path: objectPath, signedUrl: signed?.signedUrl ?? null });
 }

--- a/tests/health-log-upload.route.test.ts
+++ b/tests/health-log-upload.route.test.ts
@@ -42,6 +42,10 @@ function buildSupabase(userId: string | null, uploadError: unknown = null) {
             uploadCalls.push({ bucket: lastBucket, path });
             return { error: uploadError };
           },
+          createSignedUrl: async (path: string) => ({
+            data: { signedUrl: `https://signed.example/${path}` },
+            error: null,
+          }),
         };
       },
     },
@@ -109,6 +113,9 @@ describe("POST /api/health-log/upload", () => {
     expect(uploadCalls[0].path.startsWith("user-1/")).toBe(true);
     expect(uploadCalls[0].path.endsWith(".jpg")).toBe(true);
     expect(json.path).toBe(uploadCalls[0].path);
+    // a display-only signed URL is returned for the thumbnail
+    expect(typeof json.signedUrl).toBe("string");
+    expect(json.signedUrl).toContain(uploadCalls[0].path);
   });
 
   it("503 in demo mode (no Supabase)", async () => {


### PR DESCRIPTION
Photos were uploaded + counted but not shown. Upload route returns a short-lived signed URL (display-only; path persisted); form renders thumbnails of just-attached photos; Clear resets both. Isolated cherry-pick (3 files). tsc/eslint clean, 6 upload tests, build passes.