### PR TITLE
fix(dog-brain): quarantine Paw Circle from nav + de-eager owner signals

### DIFF
--- a/src/components/dashboard/sidebar.tsx
+++ b/src/components/dashboard/sidebar.tsx
@@ -10,7 +10,6 @@ import {
   Pill,
   Bell,
   BookOpen,
-  Users,
   Settings,
   Heart,
   LogOut,
@@ -34,7 +33,8 @@ const navItems = [
   { href: "/supplements", icon: Pill, label: "Supplements" },
   { href: "/reminders", icon: Bell, label: "Reminders" },
   { href: "/journal", icon: BookOpen, label: "Journal" },
-  { href: "/community", icon: Users, label: "Paw Circle" },
+  // Paw Circle (community) is quarantined from default nav until a separate
+  // moderated-community ticket exists. The route still exists but is unlinked.
   { href: "/settings", icon: Settings, label: "Settings" },
 ];
 

--- a/src/lib/dog-brain/signals.ts
+++ b/src/lib/dog-brain/signals.ts
@@ -98,6 +98,12 @@ function vomitingSignal(logs: HealthLog[]): DetectedSignal | null {
   const total = recent.reduce((sum, log) => sum + Math.max(0, log.vomiting_count ?? 0), 0);
   if (total === 0) return null;
 
+  // A single isolated vomit isn't a pattern — don't alarm an owner over it.
+  // Require repetition: ≥2 episodes, vomiting on ≥2 days, or one heavy day (≥3).
+  const daysWithVomiting = recent.filter((log) => (log.vomiting_count ?? 0) > 0).length;
+  const heavySingleDay = recent.some((log) => (log.vomiting_count ?? 0) >= 3);
+  if (total < 2 && daysWithVomiting < 2 && !heavySingleDay) return null;
+
   const severity: SignalSeverity = latest.vomiting_count >= 3 || total >= 4 ? "alert" : "watch";
   return {
     signal_type: "vomiting_trend",
@@ -118,7 +124,8 @@ function weightSignal(logs: HealthLog[]): DetectedSignal | null {
   const weighed = [...logs]
     .reverse()
     .filter((log) => typeof log.weight_kg === "number" && log.weight_kg > 0);
-  if (weighed.length < 2) return null;
+  // Need at least 3 weigh-ins to call a trend (two points is just noise).
+  if (weighed.length < 3) return null;
 
   const first = weighed[0];
   const last = weighed[weighed.length - 1];
@@ -126,6 +133,11 @@ function weightSignal(logs: HealthLog[]): DetectedSignal | null {
   const lastWeight = last.weight_kg as number;
   const dropRatio = (firstWeight - lastWeight) / firstWeight;
   if (dropRatio < WEIGHT_WATCH_DROP) return null;
+
+  // Only a SUSTAINED downtrend: the latest reading must be the lowest, so a
+  // dip-then-recovery (e.g. 30 → 20 → 29) doesn't read as a downward trend.
+  const minWeight = Math.min(...weighed.map((w) => w.weight_kg as number));
+  if (lastWeight > minWeight) return null;
 
   const severity: SignalSeverity = dropRatio >= WEIGHT_ALERT_DROP ? "alert" : "watch";
   return {

--- a/tests/dog-brain-signals.test.ts
+++ b/tests/dog-brain-signals.test.ts
@@ -68,9 +68,10 @@ describe("detectDogBrainSignals", () => {
 
   it("detects weight downtrends and medication history without clinical dosing advice", () => {
     const result = detectDogBrainSignals([
+      log({ log_date: "2026-06-05", weight_kg: 18.8 }),
       log({
         log_date: "2026-06-03",
-        weight_kg: 18.8,
+        weight_kg: 19.2,
         meds_given: true,
         context_signals: {
           medication: {
@@ -92,5 +93,31 @@ describe("detectDogBrainSignals", () => {
     expect(result.signals.find((signal) => signal.signal_type === "possible_med_side_effect")?.next_action).toContain(
       "ask your vet before changing any dose",
     );
+  });
+
+  it("does not alarm an owner over a single isolated vomit", () => {
+    const result = detectDogBrainSignals([
+      log({ log_date: "2026-06-05", vomiting_count: 1 }),
+      log({ log_date: "2026-06-04", vomiting_count: 0 }),
+      log({ log_date: "2026-06-03", vomiting_count: 0 }),
+    ]);
+    expect(result.signals.find((s) => s.signal_type === "vomiting_trend")).toBeUndefined();
+  });
+
+  it("needs at least 3 weigh-ins before calling a weight downtrend", () => {
+    const result = detectDogBrainSignals([
+      log({ log_date: "2026-06-05", weight_kg: 18.8 }),
+      log({ log_date: "2026-06-01", weight_kg: 20 }),
+    ]);
+    expect(result.signals.find((s) => s.signal_type === "weight_downtrend")).toBeUndefined();
+  });
+
+  it("does not call a dip-then-recovery a weight downtrend", () => {
+    const result = detectDogBrainSignals([
+      log({ log_date: "2026-06-05", weight_kg: 18.5 }),
+      log({ log_date: "2026-06-03", weight_kg: 15 }),
+      log({ log_date: "2026-06-01", weight_kg: 20 }),
+    ]);
+    expect(result.signals.find((s) => s.signal_type === "weight_downtrend")).toBeUndefined();
   });
 });


### PR DESCRIPTION
## What
Two owner-safety polish fixes on current master:

1. **Paw Circle removed from nav** — quarantined until a separate moderated-community ticket (route kept, unlinked).
2. **De-eager the signal detector** so it doesn't alarm owners over noise on a live vet app:
   - `vomiting_trend` no longer fires on a *single* isolated vomit (needs ≥2 episodes / ≥2 days / one heavy day).
   - `weight_downtrend` needs ≥3 weigh-ins **and** the latest reading to be the lowest (a dip-then-recovery isn't a trend).

## Verification
- tsc clean
- 60/60 dog-brain tests green (updated the weight test to a real 3-reading downtrend + added guard tests for single-vomit, 2-weigh-in, and dip-recovery)

## Safety
No change to deterministic clinical triage. Dog Brain signals remain owner-attention only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)