### PR TITLE
fix(build): use next build for Vercel; keep Windows wrapper as build:local

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "node scripts/build.js",
+    "build": "next build",
+    "build:local": "node scripts/build.js",
     "start": "next start",
     "guard:prod-deploy": "node scripts/guard-prod-deploy.mjs",
     "deploy:prod": "node scripts/guard-prod-deploy.mjs && npx vercel --prod",


### PR DESCRIPTION
Vercel CLI prod deploys were failing because the `build` script pointed at the Windows-only `scripts/build.js` wrapper (which `.vercelignore` excludes). The last good prod deploy ran `next build` (Turbopack). This points `build` at `next build` (matching vercel.json) and keeps the Windows wrapper as `build:local`. Prod-build risk is ~zero — it's the same command that already deploys successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)