### PR TITLE
fix(deploy): drop Python ML sidecars from Vercel build (GPU-host services)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,11 @@
   "buildCommand": "next build",
   "outputDirectory": ".next",
   "framework": "nextjs",
-  "installCommand": "npm install"
+  "installCommand": "npm install",
+  "experimentalServices": {
+    "frontend": {
+      "routePrefix": "/",
+      "framework": "nextjs"
+    }
+  }
 }


### PR DESCRIPTION
Fresh Vercel deploys failed because experimentalServices tried to bundle the Python ML services (torch/torchvision/transformers ~5.3GB) into Lambdas (500MB limit). These run on the GPU host (Dockerfiles + docker-compose), and the app reaches them via env URLs (ASYNC_REVIEW_SERVICE_URL etc.), not Vercel routes — verified in src/lib. Keep only the Next.js frontend service; matches the working nodejs-only prod deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)