### PR TITLE
feat(reminders): real /api/reminders + wire dashboard (drop hardcoded mock)

### DIFF
--- a/src/app/api/reminders/route.ts
+++ b/src/app/api/reminders/route.ts
@@ -1,0 +1,133 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { generalApiLimiter, checkRateLimit, getRateLimitId } from "@/lib/rate-limit";
+
+/**
+ * Reminders API.
+ *
+ * GET  /api/reminders?pet_id=...&limit=...  → active reminders for the user
+ *                                             (RLS-scoped), soonest-due first.
+ * POST /api/reminders                       → create a reminder.
+ *
+ * Mirrors the health-log / notifications routes: auth + RLS enforced, demo mode
+ * (no Supabase) and missing-table both degrade to empty/503 gracefully so the
+ * dashboard and reminders page never 500.
+ */
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const CreateSchema = z.object({
+  pet_id: z.string().uuid(),
+  title: z.string().trim().min(1).max(200),
+  type: z.enum(["medication", "vet_appointment", "flea_tick", "vaccination", "custom"]).default("custom"),
+  frequency: z.enum(["daily", "weekly", "monthly", "yearly", "once"]).default("daily"),
+  time: z.string().regex(/^\d{2}:\d{2}(:\d{2})?$/).nullable().optional(),
+  next_due: z.string().datetime({ offset: true }).nullable().optional(),
+  notes: z.string().trim().max(2000).nullable().optional(),
+});
+
+function isMissingTable(error: { code?: string; message?: string } | null): boolean {
+  if (!error) return false;
+  if (error.code === "42P01" || error.code === "PGRST205") return true;
+  return /relation .* does not exist|could not find the table/i.test(error.message ?? "");
+}
+
+export async function GET(request: Request) {
+  const limit = await checkRateLimit(generalApiLimiter, getRateLimitId(request));
+  if (!limit.success) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  const url = new URL(request.url);
+  const petId = url.searchParams.get("pet_id")?.trim() || null;
+  const rows = Math.min(Math.max(Number(url.searchParams.get("limit")) || 20, 1), 100);
+
+  try {
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return NextResponse.json({ data: [] });
+
+    let query = supabase
+      .from("reminders")
+      .select("*")
+      .eq("user_id", user.id)
+      .eq("is_active", true)
+      .order("next_due", { ascending: true, nullsFirst: false })
+      .limit(rows);
+    if (petId && UUID_RE.test(petId)) query = query.eq("pet_id", petId);
+
+    const { data, error } = await query;
+    if (error) {
+      if (isMissingTable(error)) return NextResponse.json({ data: [], code: "TABLE_MISSING" });
+      throw error;
+    }
+    return NextResponse.json({ data: data ?? [] });
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === "DEMO_MODE") {
+      return NextResponse.json({ data: [], code: "DEMO_MODE" });
+    }
+    console.error("[Reminders] GET failed:", err);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  const limit = await checkRateLimit(generalApiLimiter, getRateLimitId(request));
+  if (!limit.success) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = CreateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid reminder", details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  try {
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    // Verify pet ownership before writing.
+    const { data: pet } = await supabase
+      .from("pets")
+      .select("id")
+      .eq("id", parsed.data.pet_id)
+      .eq("user_id", user.id)
+      .maybeSingle();
+    if (!pet) return NextResponse.json({ error: "Pet not found" }, { status: 404 });
+
+    const { data, error } = await supabase
+      .from("reminders")
+      .insert({
+        user_id: user.id,
+        pet_id: parsed.data.pet_id,
+        title: parsed.data.title,
+        type: parsed.data.type,
+        frequency: parsed.data.frequency,
+        time: parsed.data.time ?? null,
+        next_due: parsed.data.next_due ?? null,
+        notes: parsed.data.notes ?? null,
+      })
+      .select()
+      .single();
+    if (error) {
+      if (isMissingTable(error)) {
+        return NextResponse.json({ error: "Reminders aren't set up yet.", code: "TABLE_MISSING" }, { status: 503 });
+      }
+      throw error;
+    }
+    return NextResponse.json({ data }, { status: 201 });
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === "DEMO_MODE") {
+      return NextResponse.json({ error: "Database not configured", code: "DEMO_MODE" }, { status: 503 });
+    }
+    console.error("[Reminders] POST failed:", err);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+}

--- a/src/components/dog-brain/health-brief.tsx
+++ b/src/components/dog-brain/health-brief.tsx
@@ -323,17 +323,34 @@ function PatternTimeline({ logs }: { logs: HealthLog[] }) {
 
 // ─── RIGHT SIDEBAR ────────────────────────────────────────────────────────────
 
-const STATIC_REMINDERS = [
-  { label: "Heartworm check-up", timing: "Today", timingBg: "#e7f4ee", timingFg: "#15795a" },
-  { label: "Flea & tick prevention", timing: "3 days", timingBg: "#fbf0db", timingFg: "#c1852a" },
-  { label: "Annual vaccination", timing: "15 days", timingBg: "#f3f4f6", timingFg: "#6b7280" },
-];
+interface ReminderRow {
+  id: string;
+  title: string;
+  next_due: string | null;
+}
+
+/** Owner-friendly timing badge from next_due relative to now. */
+function reminderTiming(nextDue: string | null): { label: string; bg: string; fg: string } {
+  if (!nextDue) return { label: "Scheduled", bg: "#f3f4f6", fg: "#6b7280" };
+  const due = new Date(nextDue);
+  if (Number.isNaN(due.getTime())) return { label: "Scheduled", bg: "#f3f4f6", fg: "#6b7280" };
+  const days = Math.round((due.getTime() - Date.now()) / 86_400_000);
+  if (days <= 0) return { label: "Today", bg: "#e7f4ee", fg: "#15795a" };
+  if (days <= 7) return { label: `${days} day${days === 1 ? "" : "s"}`, bg: "#fbf0db", fg: "#c1852a" };
+  return {
+    label: due.toLocaleDateString(undefined, { month: "short", day: "numeric" }),
+    bg: "#f3f4f6",
+    fg: "#6b7280",
+  };
+}
 
 function RightSidebar({
   actions,
+  reminders,
   petName,
 }: {
   actions: string[];
+  reminders: ReminderRow[];
   petName: string;
 }) {
   return (
@@ -369,25 +386,32 @@ function RightSidebar({
         <p className="text-[10px] font-semibold uppercase tracking-widest text-[#8a978f] mb-3">
           Upcoming Reminders
         </p>
-        <ul className="space-y-2.5">
-          {STATIC_REMINDERS.map((r) => (
-            <li key={r.label} className="flex items-center justify-between gap-2">
-              <span className="text-[13px] text-[#3f4a45]">{r.label}</span>
-              <span
-                className="shrink-0 rounded-full px-2.5 py-1 text-[11px] font-semibold"
-                style={{ background: r.timingBg, color: r.timingFg }}
-              >
-                {r.timing}
-              </span>
-            </li>
-          ))}
-        </ul>
+        {reminders.length > 0 ? (
+          <ul className="space-y-2.5">
+            {reminders.map((r) => {
+              const t = reminderTiming(r.next_due);
+              return (
+                <li key={r.id} className="flex items-center justify-between gap-2">
+                  <span className="text-[13px] text-[#3f4a45]">{r.title}</span>
+                  <span
+                    className="shrink-0 rounded-full px-2.5 py-1 text-[11px] font-semibold"
+                    style={{ background: t.bg, color: t.fg }}
+                  >
+                    {t.label}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        ) : (
+          <p className="text-[13px] text-[#8a978f]">No upcoming reminders yet.</p>
+        )}
         <a
           href="/reminders"
           target="_top"
           className="mt-3 block text-center text-xs font-medium text-[#1f9d6b] hover:underline"
         >
-          View all reminders
+          {reminders.length > 0 ? "View all reminders" : "Add a reminder"}
         </a>
       </div>
 
@@ -508,6 +532,7 @@ export default function HealthBrief({
   const [signals, setSignals] = useState<DetectedSignal[]>([]);
   const [state, setState] = useState<BriefState>("stable");
   const [logs, setLogs] = useState<HealthLog[]>([]);
+  const [reminders, setReminders] = useState<ReminderRow[]>([]);
 
   useEffect(() => {
     if (!petId) {
@@ -518,21 +543,25 @@ export default function HealthBrief({
     setLoading(true);
     (async () => {
       try {
-        const [sigRes, logRes] = await Promise.all([
+        const [sigRes, logRes, remRes] = await Promise.all([
           fetch(`/api/dog-brain/signals?pet_id=${petId}`),
           fetch(`/api/health-log?pet_id=${petId}&limit=14`),
+          fetch(`/api/reminders?pet_id=${petId}&limit=4`),
         ]);
         const sig = (await sigRes.json().catch(() => null)) as DogBrainSignalsResponse | null;
         const lg = (await logRes.json().catch(() => null)) as { data?: HealthLog[] } | null;
+        const rem = (await remRes.json().catch(() => null)) as { data?: ReminderRow[] } | null;
         if (cancelled) return;
         setSignals(sig?.signals ?? []);
         setState(sig?.state ?? "stable");
         setLogs(Array.isArray(lg?.data) ? lg!.data : []);
+        setReminders(Array.isArray(rem?.data) ? rem!.data : []);
       } catch {
         if (!cancelled) {
           setSignals([]);
           setState("stable");
           setLogs([]);
+        setReminders([]);
         }
       } finally {
         if (!cancelled) setLoading(false);
@@ -575,7 +604,7 @@ export default function HealthBrief({
       </div>
 
       {/* Right sidebar */}
-      <RightSidebar actions={actions} petName={petName} />
+      <RightSidebar actions={actions} reminders={reminders} petName={petName} />
     </div>
   );
 }


### PR DESCRIPTION
Audit follow-up: the dashboard's Upcoming Reminders was hardcoded (STATIC_REMINDERS) because no /api/reminders route ever existed (the reminders table does). Adds GET/POST /api/reminders (auth+RLS+graceful) and wires the dashboard to it — real reminders or honest empty state. Verified via Vercel preview build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)