### PR TITLE
feat(reminders): wire reminders page to real API (CRUD)

### DIFF
--- a/src/app/(dashboard)/reminders/page.tsx
+++ b/src/app/(dashboard)/reminders/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   Bell,
   Plus,
@@ -11,7 +11,6 @@ import {
   Clock,
   Check,
   Trash2,
-  Edit2,
 } from "lucide-react";
 import { PrivateTesterQuarantinedSurface } from "@/components/private-tester/quarantined-surface";
 import Card from "@/components/ui/card";
@@ -20,243 +19,281 @@ import Input from "@/components/ui/input";
 import Select from "@/components/ui/select";
 import Modal from "@/components/ui/modal";
 import { getPrivateTesterQuarantinedSurface } from "@/lib/private-tester-scope";
+import { useAppStore } from "@/store/app-store";
 
-interface ReminderItem {
+type ReminderType = "medication" | "vet_appointment" | "flea_tick" | "vaccination" | "custom";
+type Frequency = "daily" | "weekly" | "monthly" | "yearly" | "once";
+
+interface ReminderRow {
   id: string;
   title: string;
-  type: "medication" | "vet_appointment" | "flea_tick" | "vaccination" | "custom";
-  frequency: string;
-  time: string;
-  nextDue: string;
-  isActive: boolean;
-  notes?: string;
-  completedToday?: boolean;
+  type: ReminderType;
+  frequency: Frequency;
+  time: string | null;
+  next_due: string | null;
+  is_active: boolean;
+  notes: string | null;
 }
 
-const typeConfig = {
-  medication: { icon: Pill, color: "text-purple-600", bg: "bg-purple-50" },
-  vet_appointment: { icon: Calendar, color: "text-blue-600", bg: "bg-blue-50" },
-  flea_tick: { icon: Bug, color: "text-amber-600", bg: "bg-amber-50" },
-  vaccination: { icon: Syringe, color: "text-green-600", bg: "bg-green-50" },
+const typeConfig: Record<ReminderType, { icon: typeof Pill; color: string; bg: string }> = {
+  medication: { icon: Pill, color: "text-[#7c4dc4]", bg: "bg-purple-50" },
+  vet_appointment: { icon: Calendar, color: "text-[#4f7fb8]", bg: "bg-blue-50" },
+  flea_tick: { icon: Bug, color: "text-[#c1852a]", bg: "bg-amber-50" },
+  vaccination: { icon: Syringe, color: "text-[#15795a]", bg: "bg-[#e7f4ee]" },
   custom: { icon: Bell, color: "text-gray-600", bg: "bg-gray-50" },
 };
 
-const initialReminders: ReminderItem[] = [
-  {
-    id: "1",
-    title: "Morning Joint Supplement",
-    type: "medication",
-    frequency: "Daily",
-    time: "8:00 AM",
-    nextDue: "Today, 8:00 AM",
-    isActive: true,
-    completedToday: true,
-  },
-  {
-    id: "2",
-    title: "Evening Joint Supplement",
-    type: "medication",
-    frequency: "Daily",
-    time: "6:00 PM",
-    nextDue: "Today, 6:00 PM",
-    isActive: true,
-    completedToday: false,
-  },
-  {
-    id: "3",
-    title: "Omega-3 Fish Oil",
-    type: "medication",
-    frequency: "Daily",
-    time: "8:00 AM",
-    nextDue: "Today, 8:00 AM",
-    isActive: true,
-    completedToday: true,
-  },
-  {
-    id: "4",
-    title: "Flea & Tick Treatment",
-    type: "flea_tick",
-    frequency: "Monthly",
-    time: "9:00 AM",
-    nextDue: "Tomorrow",
-    isActive: true,
-    completedToday: false,
-  },
-  {
-    id: "5",
-    title: "Annual Vet Checkup",
-    type: "vet_appointment",
-    frequency: "Yearly",
-    time: "10:00 AM",
-    nextDue: "In 5 days",
-    isActive: true,
-    notes: "Dr. Smith at Riverside Vet Clinic",
-  },
-  {
-    id: "6",
-    title: "Rabies Vaccination",
-    type: "vaccination",
-    frequency: "Yearly",
-    time: "10:00 AM",
-    nextDue: "In 2 weeks",
-    isActive: true,
-  },
-  {
-    id: "7",
-    title: "Heartworm Prevention",
-    type: "medication",
-    frequency: "Monthly",
-    time: "8:00 AM",
-    nextDue: "In 12 days",
-    isActive: true,
-  },
-];
+const FREQUENCY_LABEL: Record<Frequency, string> = {
+  daily: "Daily",
+  weekly: "Weekly",
+  monthly: "Monthly",
+  yearly: "Yearly",
+  once: "One time",
+};
+
+/** Roll a clock time forward by one frequency interval. */
+function advanceDue(currentIso: string | null, frequency: Frequency): string | null {
+  if (frequency === "once") return null;
+  const base = currentIso ? new Date(currentIso) : new Date();
+  if (Number.isNaN(base.getTime())) return null;
+  const d = new Date(base);
+  switch (frequency) {
+    case "daily": d.setDate(d.getDate() + 1); break;
+    case "weekly": d.setDate(d.getDate() + 7); break;
+    case "monthly": d.setMonth(d.getMonth() + 1); break;
+    case "yearly": d.setFullYear(d.getFullYear() + 1); break;
+  }
+  return d.toISOString();
+}
+
+/** Next occurrence ISO for a clock time, advanced if it already passed today. */
+function computeNextDue(time: string, frequency: Frequency): string | null {
+  const [h, m] = (time || "08:00").split(":").map((n) => Number(n) || 0);
+  const d = new Date();
+  d.setHours(h, m, 0, 0);
+  if (d.getTime() < Date.now()) return advanceDue(d.toISOString(), frequency);
+  return d.toISOString();
+}
+
+function dueLabel(nextDue: string | null): string {
+  if (!nextDue) return "Scheduled";
+  const due = new Date(nextDue);
+  if (Number.isNaN(due.getTime())) return "Scheduled";
+  const now = new Date();
+  const timeStr = due.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+  if (due.toDateString() === now.toDateString()) return `Today, ${timeStr}`;
+  const days = Math.round((due.getTime() - now.getTime()) / 86_400_000);
+  if (days === 1) return "Tomorrow";
+  if (days > 1 && days <= 14) return `In ${days} days`;
+  return due.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
 
 function RemindersPageContent() {
-  const [reminders, setReminders] = useState(initialReminders);
+  const { activePet, userDataLoaded } = useAppStore();
+  const petId = activePet?.id ?? null;
+
+  const [reminders, setReminders] = useState<ReminderRow[]>([]);
+  const [loading, setLoading] = useState(true);
   const [showAddModal, setShowAddModal] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
   const [newReminder, setNewReminder] = useState({
     title: "",
-    type: "medication",
-    frequency: "daily",
+    type: "medication" as ReminderType,
+    frequency: "daily" as Frequency,
     time: "08:00",
     notes: "",
   });
 
-  const toggleComplete = (id: string) => {
-    setReminders((prev) =>
-      prev.map((r) => (r.id === id ? { ...r, completedToday: !r.completedToday } : r))
-    );
-  };
+  const load = useCallback(async () => {
+    if (!petId) {
+      setReminders([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/reminders?pet_id=${petId}&limit=100`);
+      const json = (await res.json().catch(() => null)) as { data?: ReminderRow[] } | null;
+      setReminders(Array.isArray(json?.data) ? json!.data : []);
+    } catch {
+      setReminders([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [petId]);
 
-  const deleteReminder = (id: string) => {
-    setReminders((prev) => prev.filter((r) => r.id !== id));
-  };
+  useEffect(() => {
+    if (userDataLoaded) load();
+  }, [userDataLoaded, load]);
 
-  const addReminder = (e: React.FormEvent) => {
+  async function addReminder(e: React.FormEvent) {
     e.preventDefault();
-    const reminder: ReminderItem = {
-      id: crypto.randomUUID(),
-      title: newReminder.title,
-      type: newReminder.type as ReminderItem["type"],
-      frequency: newReminder.frequency,
-      time: newReminder.time,
-      nextDue: "Tomorrow",
-      isActive: true,
-      notes: newReminder.notes || undefined,
-    };
-    setReminders((prev) => [...prev, reminder]);
-    setShowAddModal(false);
-    setNewReminder({ title: "", type: "medication", frequency: "daily", time: "08:00", notes: "" });
-  };
+    if (!petId) return;
+    setSaving(true);
+    try {
+      await fetch("/api/reminders", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          pet_id: petId,
+          title: newReminder.title,
+          type: newReminder.type,
+          frequency: newReminder.frequency,
+          time: newReminder.time || null,
+          next_due: computeNextDue(newReminder.time, newReminder.frequency),
+          notes: newReminder.notes || null,
+        }),
+      });
+      setShowAddModal(false);
+      setNewReminder({ title: "", type: "medication", frequency: "daily", time: "08:00", notes: "" });
+      await load();
+    } finally {
+      setSaving(false);
+    }
+  }
 
-  const todayReminders = reminders.filter((r) => r.nextDue.includes("Today"));
-  const upcomingReminders = reminders.filter((r) => !r.nextDue.includes("Today"));
-  const completedToday = todayReminders.filter((r) => r.completedToday).length;
+  async function completeReminder(r: ReminderRow) {
+    setBusyId(r.id);
+    try {
+      const body =
+        r.frequency === "once"
+          ? { is_active: false }
+          : { next_due: advanceDue(r.next_due, r.frequency) };
+      await fetch(`/api/reminders/${r.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      await load();
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function deleteReminder(id: string) {
+    setBusyId(id);
+    try {
+      await fetch(`/api/reminders/${id}`, { method: "DELETE" });
+      setReminders((prev) => prev.filter((r) => r.id !== id));
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  const todayReminders = reminders.filter((r) => dueLabel(r.next_due).startsWith("Today"));
+  const upcomingReminders = reminders.filter((r) => !dueLabel(r.next_due).startsWith("Today"));
 
   return (
     <div className="max-w-4xl mx-auto space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Reminders</h1>
-          <p className="text-gray-500 mt-1">Never miss a medication or appointment</p>
+          <h1 className="text-2xl font-semibold text-[#1c2522]">Reminders</h1>
+          <p className="text-[#8a978f] mt-1">
+            {activePet ? `Never miss a med or appointment for ${activePet.name}` : "Never miss a med or appointment"}
+          </p>
         </div>
-        <Button onClick={() => setShowAddModal(true)}>
+        <Button onClick={() => setShowAddModal(true)} disabled={!petId}>
           <Plus className="w-4 h-4 mr-2" /> Add Reminder
         </Button>
       </div>
 
-      {/* Today's Progress */}
-      <Card className="p-6">
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-bold text-gray-900">Today&apos;s Tasks</h2>
-          <span className="text-sm text-gray-500">
-            {completedToday}/{todayReminders.length} completed
-          </span>
-        </div>
-        <div className="w-full bg-gray-200 rounded-full h-2 mb-4">
-          <div
-            className="bg-green-500 h-2 rounded-full transition-all duration-500"
-            style={{ width: `${todayReminders.length > 0 ? (completedToday / todayReminders.length) * 100 : 0}%` }}
-          />
-        </div>
-        <div className="space-y-3">
-          {todayReminders.map((r) => {
-            const config = typeConfig[r.type];
-            return (
-              <div
-                key={r.id}
-                className={`flex items-center gap-4 p-4 rounded-xl border transition-all ${
-                  r.completedToday ? "bg-green-50 border-green-200" : "bg-white border-gray-200"
-                }`}
-              >
-                <button
-                  onClick={() => toggleComplete(r.id)}
-                  className={`w-6 h-6 rounded-full border-2 flex items-center justify-center flex-shrink-0 transition-colors ${
-                    r.completedToday
-                      ? "bg-green-500 border-green-500"
-                      : "border-gray-300 hover:border-blue-500"
-                  }`}
-                >
-                  {r.completedToday && <Check className="w-4 h-4 text-white" />}
-                </button>
-                <div className={`w-10 h-10 rounded-xl ${config.bg} flex items-center justify-center`}>
-                  <config.icon className={`w-5 h-5 ${config.color}`} />
-                </div>
-                <div className="flex-1">
-                  <p className={`font-medium ${r.completedToday ? "text-gray-400 line-through" : "text-gray-900"}`}>
-                    {r.title}
-                  </p>
-                  <div className="flex items-center gap-2 text-xs text-gray-500 mt-1">
-                    <Clock className="w-3 h-3" />
-                    {r.time} · {r.frequency}
-                  </div>
-                </div>
+      {!petId ? (
+        <Card className="p-8 text-center">
+          <Bell className="mx-auto h-8 w-8 text-[#b9c6bf]" />
+          <p className="mt-3 text-sm text-[#8a978f]">Add a dog profile to start tracking reminders.</p>
+        </Card>
+      ) : loading ? (
+        <div className="h-40 animate-pulse rounded-2xl border border-[#eef1ef] bg-[#f6f8f7]" aria-hidden />
+      ) : reminders.length === 0 ? (
+        <Card className="p-8 text-center">
+          <Bell className="mx-auto h-8 w-8 text-[#b9c6bf]" />
+          <p className="mt-3 text-sm text-[#8a978f]">
+            No reminders yet. Add medication, vaccine, or vet-appointment reminders and they&apos;ll show on your dashboard.
+          </p>
+          <Button onClick={() => setShowAddModal(true)} className="mt-4">
+            <Plus className="w-4 h-4 mr-2" /> Add your first reminder
+          </Button>
+        </Card>
+      ) : (
+        <>
+          {todayReminders.length > 0 && (
+            <Card className="p-6">
+              <h2 className="text-lg font-semibold text-[#1c2522] mb-4">Today&apos;s Tasks</h2>
+              <div className="space-y-3">
+                {todayReminders.map((r) => {
+                  const config = typeConfig[r.type];
+                  return (
+                    <div key={r.id} className="flex items-center gap-4 p-4 rounded-xl border border-[#eef1ef] bg-white">
+                      <button
+                        onClick={() => completeReminder(r)}
+                        disabled={busyId === r.id}
+                        aria-label="Mark done"
+                        className="w-6 h-6 rounded-full border-2 border-gray-300 hover:border-[#1f9d6b] flex items-center justify-center flex-shrink-0 transition-colors disabled:opacity-50"
+                      >
+                        <Check className="w-4 h-4 text-transparent" />
+                      </button>
+                      <div className={`w-10 h-10 rounded-xl ${config.bg} flex items-center justify-center`}>
+                        <config.icon className={`w-5 h-5 ${config.color}`} />
+                      </div>
+                      <div className="flex-1">
+                        <p className="font-medium text-[#1c2522]">{r.title}</p>
+                        <div className="flex items-center gap-2 text-xs text-[#8a978f] mt-1">
+                          <Clock className="w-3 h-3" />
+                          {dueLabel(r.next_due)} · {FREQUENCY_LABEL[r.frequency]}
+                        </div>
+                      </div>
+                      <button
+                        onClick={() => deleteReminder(r.id)}
+                        disabled={busyId === r.id}
+                        aria-label="Delete reminder"
+                        className="p-2 hover:bg-red-50 rounded-lg transition-colors disabled:opacity-50"
+                      >
+                        <Trash2 className="w-4 h-4 text-red-400" />
+                      </button>
+                    </div>
+                  );
+                })}
               </div>
-            );
-          })}
-        </div>
-      </Card>
+            </Card>
+          )}
 
-      {/* Upcoming */}
-      <Card className="p-6">
-        <h2 className="text-lg font-bold text-gray-900 mb-4">Upcoming</h2>
-        <div className="space-y-3">
-          {upcomingReminders.map((r) => {
-            const config = typeConfig[r.type];
-            return (
-              <div key={r.id} className="flex items-center gap-4 p-4 bg-gray-50 rounded-xl">
-                <div className={`w-10 h-10 rounded-xl ${config.bg} flex items-center justify-center`}>
-                  <config.icon className={`w-5 h-5 ${config.color}`} />
-                </div>
-                <div className="flex-1">
-                  <p className="font-medium text-gray-900">{r.title}</p>
-                  <div className="flex items-center gap-2 text-xs text-gray-500 mt-1">
-                    <Clock className="w-3 h-3" />
-                    {r.nextDue} · {r.frequency}
-                  </div>
-                  {r.notes && (
-                    <p className="text-xs text-gray-400 mt-1">{r.notes}</p>
-                  )}
-                </div>
-                <div className="flex items-center gap-1">
-                  <button className="p-2 hover:bg-gray-200 rounded-lg transition-colors">
-                    <Edit2 className="w-4 h-4 text-gray-400" />
-                  </button>
-                  <button
-                    onClick={() => deleteReminder(r.id)}
-                    className="p-2 hover:bg-red-50 rounded-lg transition-colors"
-                  >
-                    <Trash2 className="w-4 h-4 text-red-400" />
-                  </button>
-                </div>
+          {upcomingReminders.length > 0 && (
+            <Card className="p-6">
+              <h2 className="text-lg font-semibold text-[#1c2522] mb-4">Upcoming</h2>
+              <div className="space-y-3">
+                {upcomingReminders.map((r) => {
+                  const config = typeConfig[r.type];
+                  return (
+                    <div key={r.id} className="flex items-center gap-4 p-4 bg-[#fbfcfb] rounded-xl border border-[#eef1ef]">
+                      <div className={`w-10 h-10 rounded-xl ${config.bg} flex items-center justify-center`}>
+                        <config.icon className={`w-5 h-5 ${config.color}`} />
+                      </div>
+                      <div className="flex-1">
+                        <p className="font-medium text-[#1c2522]">{r.title}</p>
+                        <div className="flex items-center gap-2 text-xs text-[#8a978f] mt-1">
+                          <Clock className="w-3 h-3" />
+                          {dueLabel(r.next_due)} · {FREQUENCY_LABEL[r.frequency]}
+                        </div>
+                        {r.notes && <p className="text-xs text-[#a8b0ab] mt-1">{r.notes}</p>}
+                      </div>
+                      <button
+                        onClick={() => deleteReminder(r.id)}
+                        disabled={busyId === r.id}
+                        aria-label="Delete reminder"
+                        className="p-2 hover:bg-red-50 rounded-lg transition-colors disabled:opacity-50"
+                      >
+                        <Trash2 className="w-4 h-4 text-red-400" />
+                      </button>
+                    </div>
+                  );
+                })}
               </div>
-            );
-          })}
-        </div>
-      </Card>
+            </Card>
+          )}
+        </>
+      )}
 
-      {/* Add Reminder Modal */}
       <Modal isOpen={showAddModal} onClose={() => setShowAddModal(false)} title="Add Reminder">
         <form onSubmit={addReminder} className="space-y-4">
           <Input
@@ -269,7 +306,7 @@ function RemindersPageContent() {
           <Select
             label="Type"
             value={newReminder.type}
-            onChange={(e) => setNewReminder({ ...newReminder, type: e.target.value })}
+            onChange={(e) => setNewReminder({ ...newReminder, type: e.target.value as ReminderType })}
             options={[
               { value: "medication", label: "Medication" },
               { value: "vet_appointment", label: "Vet Appointment" },
@@ -281,7 +318,7 @@ function RemindersPageContent() {
           <Select
             label="Frequency"
             value={newReminder.frequency}
-            onChange={(e) => setNewReminder({ ...newReminder, frequency: e.target.value })}
+            onChange={(e) => setNewReminder({ ...newReminder, frequency: e.target.value as Frequency })}
             options={[
               { value: "daily", label: "Daily" },
               { value: "weekly", label: "Weekly" },
@@ -306,7 +343,9 @@ function RemindersPageContent() {
             <Button type="button" variant="ghost" onClick={() => setShowAddModal(false)}>
               Cancel
             </Button>
-            <Button type="submit">Add Reminder</Button>
+            <Button type="submit" loading={saving}>
+              Add Reminder
+            </Button>
           </div>
         </form>
       </Modal>

--- a/src/app/api/reminders/[id]/route.ts
+++ b/src/app/api/reminders/[id]/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { generalApiLimiter, checkRateLimit, getRateLimitId } from "@/lib/rate-limit";
+
+/**
+ * Single-reminder operations.
+ *
+ * PATCH  /api/reminders/[id]  → update (title, is_active, next_due, notes, time).
+ *                               Used for "complete" (advance next_due) and edits.
+ * DELETE /api/reminders/[id]  → remove a reminder.
+ *
+ * Auth + RLS: only the owner's rows can be touched (filtered by user_id).
+ */
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const UpdateSchema = z
+  .object({
+    title: z.string().trim().min(1).max(200).optional(),
+    is_active: z.boolean().optional(),
+    next_due: z.string().datetime({ offset: true }).nullable().optional(),
+    notes: z.string().trim().max(2000).nullable().optional(),
+    time: z.string().regex(/^\d{2}:\d{2}(:\d{2})?$/).nullable().optional(),
+  })
+  .strict();
+
+export async function PATCH(request: NextRequest, context: { params: Promise<{ id: string }> }) {
+  const limit = await checkRateLimit(generalApiLimiter, getRateLimitId(request));
+  if (!limit.success) return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+
+  const { id } = await context.params;
+  if (!UUID_RE.test(id)) return NextResponse.json({ error: "Invalid id" }, { status: 400 });
+
+  const body = await request.json().catch(() => null);
+  const parsed = UpdateSchema.safeParse(body);
+  if (!parsed.success || Object.keys(parsed.data).length === 0) {
+    return NextResponse.json({ error: "Invalid update" }, { status: 400 });
+  }
+
+  try {
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const { data, error } = await supabase
+      .from("reminders")
+      .update(parsed.data)
+      .eq("id", id)
+      .eq("user_id", user.id)
+      .select()
+      .maybeSingle();
+    if (error) throw error;
+    if (!data) return NextResponse.json({ error: "Not found" }, { status: 404 });
+    return NextResponse.json({ data });
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === "DEMO_MODE") {
+      return NextResponse.json({ error: "Database not configured", code: "DEMO_MODE" }, { status: 503 });
+    }
+    console.error("[Reminders] PATCH failed:", err);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest, context: { params: Promise<{ id: string }> }) {
+  const limit = await checkRateLimit(generalApiLimiter, getRateLimitId(request));
+  if (!limit.success) return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+
+  const { id } = await context.params;
+  if (!UUID_RE.test(id)) return NextResponse.json({ error: "Invalid id" }, { status: 400 });
+
+  try {
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const { error } = await supabase.from("reminders").delete().eq("id", id).eq("user_id", user.id);
+    if (error) throw error;
+    return NextResponse.json({ ok: true });
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === "DEMO_MODE") {
+      return NextResponse.json({ error: "Database not configured", code: "DEMO_MODE" }, { status: 503 });
+    }
+    console.error("[Reminders] DELETE failed:", err);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
Replaces hardcoded initialReminders with live data — GET on mount, POST add, PATCH complete (advance next_due), DELETE. Adds /api/reminders/[id] (PATCH+DELETE, auth+RLS). No mock reminders left in the app. Verified via Vercel preview build (READY).

🤖 Generated with [Claude Code](https://claude.com/claude-code)