### PR TITLE
feat(symptom-checker): match mockup #2 — context strip + remembers panel

### DIFF
--- a/src/app/(dashboard)/symptom-checker/page.tsx
+++ b/src/app/(dashboard)/symptom-checker/page.tsx
@@ -38,6 +38,7 @@ import { useAppStore } from "@/store/app-store";
 import { FullReport, type SymptomReport } from "@/components/symptom-report";
 import { SpeechInputButton } from "@/components/symptom-checker/speech-input-button";
 import { VetRecordIntakeButton } from "@/components/symptom-checker/vet-record-intake-button";
+import { SymptomContextStrip, SymptomRemembersPanel } from "@/components/symptom-checker/context-rail";
 import { QUICK_START_SYMPTOMS } from "@/lib/symptom-chat/quick-start-symptoms";
 import {
   useWebPubSubLiveUpdates,
@@ -994,7 +995,7 @@ export default function SymptomCheckerPage() {
 
   return (
     <TesterOnboardingGate>
-      <div className="mx-auto max-w-4xl space-y-4 sm:space-y-6">
+      <div className="mx-auto max-w-6xl space-y-4 sm:space-y-6">
         {/* Header */}
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="min-w-0">
@@ -1026,11 +1027,24 @@ export default function SymptomCheckerPage() {
           </div>
         </div>
 
-        <div className="rounded-xl border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-700">
-          If your dog is struggling to breathe, has collapsed, is bleeding
-          heavily, having repeated seizures, unable to urinate, or you think
-          this is an emergency, contact a veterinarian immediately.
+        {/* Emergency banner (mockup #2) */}
+        <div className="flex flex-wrap items-center gap-3 rounded-xl border border-[#f3cfc9] bg-[#fbeae8] px-4 py-3">
+          <AlertTriangle className="h-5 w-5 flex-shrink-0 text-[#c0473b]" aria-hidden />
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-semibold text-[#b8473c]">Emergency signs?</p>
+            <p className="text-[13px] leading-snug text-[#9c5b53]">
+              If your dog has difficulty breathing, collapses, has repeated seizures, severe bleeding, or is
+              unable to stand or urinate, go to an emergency vet now.
+            </p>
+          </div>
         </div>
+
+        {/* Dog Brain context strip (mockup #2) — real counts */}
+        <SymptomContextStrip petId={activePet?.id ?? null} petName={displayPetName} />
+
+        {/* Chat (left) + What PawVital remembers (right) */}
+        <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_300px]">
+          <div className="min-w-0 space-y-4 sm:space-y-6">
 
         {/* Pre-session: Welcome + Quick Start */}
         {!sessionStarted && (
@@ -1457,6 +1471,9 @@ export default function SymptomCheckerPage() {
             </div>
           </div>
         )}
+          </div>
+          <SymptomRemembersPanel petId={activePet?.id ?? null} />
+        </div>
       </div>
     </TesterOnboardingGate>
   );

--- a/src/components/symptom-checker/context-rail.tsx
+++ b/src/components/symptom-checker/context-rail.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+/**
+ * Symptom Checker context UI (mockup #2) — additive layout around the existing
+ * triage chat. Purely presentational over REAL owner data; never touches the
+ * deterministic triage logic.
+ *
+ *  - SymptomContextStrip  → "Dog Brain context" counts (logs/photos/signals/reminders)
+ *  - SymptomRemembersPanel → "What PawVital remembers" (active Dog Brain signals)
+ */
+
+import { useEffect, useState } from "react";
+import {
+  ClipboardList,
+  Camera,
+  Activity,
+  Bell,
+  Info,
+  ShieldCheck,
+} from "lucide-react";
+import type { HealthLog } from "@/lib/health-log/types";
+import type { DetectedSignal, SignalSeverity, SignalType } from "@/lib/dog-brain/types";
+
+const SIGNAL_TITLE: Record<SignalType, string> = {
+  appetite_drop: "Appetite change",
+  stool_change: "Stool change",
+  vomiting_trend: "Vomiting",
+  weight_downtrend: "Weight downtrend",
+  possible_med_side_effect: "Medication note",
+};
+
+const SEV_META: Record<SignalSeverity, { line: string; bg: string }> = {
+  info: { line: "#4f7fb8", bg: "#f0f5fb" },
+  watch: { line: "#e8a23c", bg: "#fdf8ef" },
+  alert: { line: "#e2675b", bg: "#fdf1ef" },
+};
+
+export function SymptomContextStrip({ petId, petName }: { petId: string | null; petName: string }) {
+  const [counts, setCounts] = useState({ logs: 0, photos: 0, signals: 0, reminders: 0 });
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!petId) {
+      setLoaded(true);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const [lgRes, remRes, sigRes] = await Promise.all([
+          fetch(`/api/health-log?pet_id=${petId}&limit=14`),
+          fetch(`/api/reminders?pet_id=${petId}&limit=50`),
+          fetch(`/api/dog-brain/signals?pet_id=${petId}`),
+        ]);
+        const lg = (await lgRes.json().catch(() => null)) as { data?: HealthLog[] } | null;
+        const rem = (await remRes.json().catch(() => null)) as { data?: unknown[] } | null;
+        const sig = (await sigRes.json().catch(() => null)) as { signals?: DetectedSignal[] } | null;
+        if (cancelled) return;
+        const logs = Array.isArray(lg?.data) ? lg!.data : [];
+        setCounts({
+          logs: logs.length,
+          photos: logs.reduce((n, l) => n + (Array.isArray(l.photo_urls) ? l.photo_urls.length : 0), 0),
+          signals: Array.isArray(sig?.signals) ? sig!.signals.length : 0,
+          reminders: Array.isArray(rem?.data) ? rem!.data.length : 0,
+        });
+      } catch {
+        /* leave at zero */
+      } finally {
+        if (!cancelled) setLoaded(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [petId]);
+
+  const tiles = [
+    { Icon: ClipboardList, value: counts.logs, label: "Daily logs", sub: "Last 14 days" },
+    { Icon: Camera, value: counts.photos, label: "Photos", sub: "Last 14 days" },
+    { Icon: Activity, value: counts.signals, label: "Health signals", sub: "Active patterns" },
+    { Icon: Bell, value: counts.reminders, label: "Reminders", sub: "Active" },
+  ];
+
+  return (
+    <div className="rounded-xl border border-[#d8ebe1] bg-[#f3f9f6] px-4 py-3.5">
+      <div className="mb-3 flex flex-wrap items-center gap-x-2 gap-y-1">
+        <Info className="h-4 w-4 text-[#15795a]" aria-hidden />
+        <span className="text-[13px] font-semibold text-[#15795a]">Dog Brain context for {petName}</span>
+        <span className="text-[11px] text-[#6f8579]">— what PawVital already knows (supportive context only)</span>
+      </div>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {tiles.map((t) => (
+          <div key={t.label} className="flex items-center gap-2.5">
+            <t.Icon className="h-[18px] w-[18px] flex-shrink-0 text-[#1f9d6b]" aria-hidden />
+            <div className="min-w-0">
+              <div className="text-base font-semibold leading-none text-[#1c2522]">{loaded ? t.value : "·"}</div>
+              <div className="mt-0.5 text-[11px] text-[#7d8e86]">{t.label}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function SymptomRemembersPanel({ petId }: { petId: string | null }) {
+  const [signals, setSignals] = useState<DetectedSignal[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!petId) {
+      setLoaded(true);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`/api/dog-brain/signals?pet_id=${petId}`);
+        const j = (await res.json().catch(() => null)) as { signals?: DetectedSignal[] } | null;
+        if (!cancelled) setSignals(Array.isArray(j?.signals) ? j!.signals : []);
+      } catch {
+        /* ignore */
+      } finally {
+        if (!cancelled) setLoaded(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [petId]);
+
+  return (
+    <aside className="space-y-3">
+      <div className="rounded-2xl border border-[#eef1ef] bg-white p-4">
+        <p className="mb-3 text-[10px] font-semibold uppercase tracking-widest text-[#8a978f]">
+          What PawVital remembers
+        </p>
+        {signals.length > 0 ? (
+          <ul className="space-y-2.5">
+            {signals.map((s) => {
+              const m = SEV_META[s.severity];
+              return (
+                <li
+                  key={s.dedupe_key}
+                  className="rounded-r-lg border-l-[3px] py-1.5 pl-2.5"
+                  style={{ borderColor: m.line, background: m.bg }}
+                >
+                  <div className="text-[12px] font-medium text-[#1c2522]">{SIGNAL_TITLE[s.signal_type]}</div>
+                  <div className="text-[11px] leading-snug text-[#8a978f]">{s.owner_message}</div>
+                </li>
+              );
+            })}
+          </ul>
+        ) : (
+          <p className="text-[13px] text-[#8a978f]">
+            {loaded
+              ? "No patterns noted yet — your daily logs build this memory over time."
+              : "Loading…"}
+          </p>
+        )}
+      </div>
+
+      <div className="rounded-2xl border border-[#d6e4f2] bg-[#f0f5fb] p-4">
+        <div className="flex gap-2">
+          <ShieldCheck className="h-4 w-4 flex-shrink-0 text-[#4f7fb8]" aria-hidden />
+          <p className="text-[11px] leading-relaxed text-[#5a6f86]">
+            <span className="font-medium">This is not a diagnosis.</span> PawVital gives general guidance from what
+            you share. Always consult your vet for diagnosis and treatment.
+          </p>
+        </div>
+      </div>
+
+      <a
+        href="/analytics"
+        target="_top"
+        className="block rounded-lg border border-[#bfe0cf] bg-white py-2 text-center text-xs font-medium text-[#15795a] hover:bg-[#f3f9f6] transition-colors"
+      >
+        View full history &amp; signals
+      </a>
+    </aside>
+  );
+}


### PR DESCRIPTION
Additive layout around the existing triage chat (triage logic untouched): red emergency banner, real 'Dog Brain context' strip (logs/photos/signals/reminders counts), 'What PawVital remembers' right panel from /api/dog-brain/signals, 2-col grid. Verified via Vercel preview build (READY).

🤖 Generated with [Claude Code](https://claude.com/claude-code)