### PR TITLE
fix(security): upgrade torch 2.12.1 + torchvision 0.27.1 — clear all sidecar torch advisories

### DIFF
--- a/services/async-review-service/Dockerfile
+++ b/services/async-review-service/Dockerfile
@@ -16,8 +16,8 @@ WORKDIR /app
 
 # CPU-only PyTorch to keep the image size manageable for dev builds.
 RUN pip install --no-cache-dir \
-    "torch==2.5.1+cpu" \
-    "torchvision==0.20.1+cpu" \
+    "torch==2.12.1+cpu" \
+    "torchvision==0.27.1+cpu" \
     --index-url https://download.pytorch.org/whl/cpu
 
 COPY requirements.txt .

--- a/services/async-review-service/Dockerfile.gpu
+++ b/services/async-review-service/Dockerfile.gpu
@@ -25,8 +25,8 @@ RUN apt-get update \
 WORKDIR /app
 
 RUN pip install --no-cache-dir \
-    "torch==2.5.1" \
-    "torchvision==0.20.1" \
+    "torch==2.12.1" \
+    "torchvision==0.27.1" \
     --index-url https://download.pytorch.org/whl/cu124
 
 COPY requirements.txt .

--- a/services/async-review-service/requirements.txt
+++ b/services/async-review-service/requirements.txt
@@ -1,8 +1,8 @@
 fastapi==0.116.1
 uvicorn[standard]==0.35.0
 transformers==4.50.0
-torch==2.8.0
-torchvision==0.20.1
+torch==2.12.1
+torchvision==0.27.1
 accelerate==1.2.1
 huggingface_hub[hf_xet]>=0.32.0
 qwen-vl-utils==0.0.8

--- a/services/multimodal-consult-service/Dockerfile
+++ b/services/multimodal-consult-service/Dockerfile
@@ -16,8 +16,8 @@ WORKDIR /app
 # CPU-only PyTorch (~800 MB vs ~2.5 GB for the default CUDA wheel).
 # Install before requirements.txt so pip reuses this torch for transformers/accelerate.
 RUN pip install --no-cache-dir \
-    "torch==2.5.1+cpu" \
-    "torchvision==0.20.1+cpu" \
+    "torch==2.12.1+cpu" \
+    "torchvision==0.27.1+cpu" \
     --index-url https://download.pytorch.org/whl/cpu
 
 COPY requirements.txt .

--- a/services/multimodal-consult-service/Dockerfile.gpu
+++ b/services/multimodal-consult-service/Dockerfile.gpu
@@ -24,8 +24,8 @@ WORKDIR /app
 
 # CUDA-enabled PyTorch for cu124
 RUN pip install --no-cache-dir \
-    "torch==2.5.1" \
-    "torchvision==0.20.1" \
+    "torch==2.12.1" \
+    "torchvision==0.27.1" \
     --index-url https://download.pytorch.org/whl/cu124
 
 COPY requirements.txt .

--- a/services/multimodal-consult-service/requirements.txt
+++ b/services/multimodal-consult-service/requirements.txt
@@ -1,8 +1,8 @@
 fastapi==0.116.1
 uvicorn[standard]==0.35.0
 transformers==4.50.0
-torch==2.8.0
-torchvision==0.20.1
+torch==2.12.1
+torchvision==0.27.1
 accelerate==1.2.1
 qwen-vl-utils==0.0.8
 Pillow==12.2.0

--- a/services/vision-preprocess-service/requirements.txt
+++ b/services/vision-preprocess-service/requirements.txt
@@ -1,8 +1,8 @@
 fastapi==0.116.1
 uvicorn[standard]==0.35.0
 transformers==4.57.0
-torch==2.8.0
-torchvision==0.20.1
+torch==2.12.1
+torchvision==0.27.1
 accelerate==1.2.1
 numpy==1.26.4
 Pillow==12.2.0


### PR DESCRIPTION
## Summary

- Upgrades `torch` from 2.8.0 → **2.12.1** and `torchvision` from 0.20.1 → **0.27.1** across all 3 Python sidecar services
- Also fixes the `Dockerfile` pre-install pins (were stuck at 2.5.1+cpu, out of sync with requirements.txt)
- Fixes the latent torchvision mismatch (0.20.1 paired with 2.8.0; correct pair for 2.12.x is 0.27.1)

## Advisories cleared

| Advisory | Severity | Vulnerable range | Status |
|---|---|---|---|
| GHSA-vgrw-7cvw-pwgx | medium | < 2.9.1 | ✅ cleared by 2.12.1 |
| GHSA-qfhq-4f3w-5fph | low | < 2.10.0 | ✅ cleared by 2.12.1 |
| GHSA-rrmf-rvhw-rf47 | low | <= 2.12.0 | ✅ cleared by 2.12.1 |
| GHSA-f4hp-rmr7-r7v8 | medium | <= 2.6.0 | ✅ cleared by 2.12.1 |
| GHSA-x3gm-94wq-g975 | low | <= 2.6.0 | ✅ cleared by 2.12.1 |
| GHSA-c678-jfcj-6jmf | low | <= 2.6.0 | ✅ cleared by 2.12.1 |
| GHSA-887c-mr87-cxwp | medium | <= 2.7.1 | ✅ cleared by 2.12.1 |

## Files changed (7)

- `services/vision-preprocess-service/requirements.txt`
- `services/multimodal-consult-service/requirements.txt`
- `services/multimodal-consult-service/Dockerfile` (CPU)
- `services/multimodal-consult-service/Dockerfile.gpu`
- `services/async-review-service/requirements.txt`
- `services/async-review-service/Dockerfile` (CPU)
- `services/async-review-service/Dockerfile.gpu`

No Node app code touched. Vercel build unaffected (`services/` excluded from `vercel.json`).

## BUILD-TEST evidence

Tested on Python 3.11 (matching `FROM python:3.11-slim` in all service Dockerfiles), CPU wheels:

```
pip install torch==2.12.1 torchvision==0.27.1 \
  --index-url https://download.pytorch.org/whl/cpu
```
```
torch: 2.12.1+cpu | torchvision: 0.27.1+cpu
transformers: 4.57.0 ✅
accelerate: 1.2.1 ✅
timm: 1.0.19 ✅
safetensors: 0.5.3 ✅
einops: 0.8.1 ✅
qwen_vl_utils: ok ✅
torch.inference_mode + rand: ok ✅
torchvision.transforms: ok ✅
```

`startup_check.py` [OK] on all 3 services with `SIDECAR_API_KEY` set.

Full dep stack (transformers, accelerate, timm, safetensors, einops, qwen-vl-utils, redis, httpx) resolves with zero conflicts.

## Test plan

- [ ] Merge to master — Dependabot should auto-close the 7 advisories above
- [ ] Optional: rebuild sidecar Docker images with `docker build -f Dockerfile .` in each service dir to verify the larger `pip install` (GPU wheel pull not required for CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)