### PR TITLE
feat(dog-brain): explain memory behind symptom questions

### DIFF
--- a/src/app/(dashboard)/symptom-checker/page.tsx
+++ b/src/app/(dashboard)/symptom-checker/page.tsx
@@ -90,6 +90,8 @@ interface ChatMessage {
   ownerMessage?: string | null;
   recommendedNextStep?: string | null;
   askingBecause?: string | null;
+  /** Owner-friendly "Why this came up" memory note; null when not Brain-driven. */
+  brainQuestionEvidence?: string | null;
   promptVetRecord?: boolean;
   timestamp: Date;
 }
@@ -267,6 +269,18 @@ function ChatBubble({
             <span>
               <span className="font-semibold">Why I&apos;m asking: </span>
               {message.askingBecause}
+            </span>
+          </div>
+        )}
+        {message.brainQuestionEvidence && !isUser && (
+          <div
+            className="mt-1.5 flex items-start gap-[7px] rounded-[10px] px-2.5 py-2 text-[12.5px] leading-snug"
+            style={{ background: "#f3f6f2", border: "1px solid #e3ebe1", color: "#5a7a55" }}
+          >
+            <ShieldCheck className="mt-px h-[14px] w-[14px] flex-shrink-0" aria-hidden />
+            <span>
+              <span className="font-semibold">Why this came up: </span>
+              {message.brainQuestionEvidence}
             </span>
           </div>
         )}
@@ -865,6 +879,11 @@ export default function SymptomCheckerPage() {
             askingBecause:
               typeof data.asking_because === "string"
                 ? data.asking_because
+                : null,
+            brainQuestionEvidence:
+              data.brain_question_trace &&
+              typeof data.brain_question_trace.evidence_summary === "string"
+                ? data.brain_question_trace.evidence_summary
                 : null,
             terminalState:
               isTerminalOutcome && typeof data.terminal_state === "string"

--- a/src/app/api/ai/symptom-chat/route.ts
+++ b/src/app/api/ai/symptom-chat/route.ts
@@ -163,6 +163,7 @@ import {
   loadDogBrainContext,
   loadDogBrainContextWithSignals,
 } from "@/lib/health-log/dog-brain-context";
+import type { BrainSymptomEvidence } from "@/lib/dog-brain/question-priority";
 import {
   isAsyncWorkerReplay,
   maybeOffloadSymptomChatTurn,
@@ -981,16 +982,20 @@ export async function POST(request: Request) {
     // deterministic planner picks the next question (never overrides complaint or
     // red-flag selection, never reaches urgency logic). Empty on any failure.
     let brainPrioritySymptoms: string[] = [];
+    let brainPrioritySymptomEvidence: Record<string, BrainSymptomEvidence> = {};
     if (action === "chat" && verifiedUserId && effectivePet) {
       try {
         // Single best-effort load: the narrative context AND the question-tiebreak
         // priority symptoms come from one fetch (no duplicate logs/ownership query).
-        const { context: brainContext, prioritySymptoms } =
-          await loadDogBrainContextWithSignals({
-            userId: verifiedUserId,
-            petName: effectivePet.name,
-            petId: effectivePet.id,
-          });
+        const {
+          context: brainContext,
+          prioritySymptoms,
+          prioritySymptomEvidence,
+        } = await loadDogBrainContextWithSignals({
+          userId: verifiedUserId,
+          petName: effectivePet.name,
+          petId: effectivePet.id,
+        });
         if (brainContext) {
           const memory = ensureStructuredCaseMemory(session);
           session = {
@@ -999,6 +1004,7 @@ export async function POST(request: Request) {
           };
         }
         brainPrioritySymptoms = prioritySymptoms;
+        brainPrioritySymptomEvidence = prioritySymptomEvidence;
       } catch {
         /* best-effort — Brain memory must never block the clinical turn */
       }
@@ -2447,6 +2453,7 @@ export async function POST(request: Request) {
       turnFocusSymptoms,
       visualEvidence,
       brainPrioritySymptoms,
+      brainPrioritySymptomEvidence,
     });
     session = nextQuestionState.session;
     const nextQuestionId = nextQuestionState.nextQuestionId;
@@ -2472,6 +2479,15 @@ export async function POST(request: Request) {
     const effectiveQuestionId =
       orchestratorResult.selectedQuestionId ?? nextQuestionId;
     const askingBecause = orchestratorResult.askingBecause;
+
+    // Brain trace is explanation-only. It was computed against the legacy/brain
+    // selection (nextQuestionId). Be conservative: only surface it when the
+    // question actually asked (effectiveQuestionId) is still the Brain-driven one
+    // — if the planner-live path swapped in a different question, emit null.
+    const brainQuestionTrace =
+      effectiveQuestionId === nextQuestionId
+        ? nextQuestionState.brainQuestionTrace
+        : null;
     const promptVetRecord = shouldPromptVetRecordUpload(
       session,
       effectiveQuestionId
@@ -2507,6 +2523,7 @@ export async function POST(request: Request) {
       turnDeadline,
       turnDepth,
       askingBecause,
+      brainQuestionTrace,
       promptVetRecord,
     });
   } catch (error) {

--- a/src/lib/dog-brain/question-priority.ts
+++ b/src/lib/dog-brain/question-priority.ts
@@ -42,6 +42,99 @@ const SEVERITY_RANK: Record<DetectedSignal["severity"], number> = {
 };
 
 /**
+ * Owner-friendly, non-diagnostic evidence for a single Brain-prioritised symptom
+ * key — explanation-only metadata that NEVER alters question selection, urgency,
+ * or any control state. Surfaced to the owner as a calm "Why this came up" line.
+ */
+export interface BrainSymptomEvidence {
+  /** The Dog Brain signal type that made this symptom relevant. */
+  signal_type: SignalType;
+  /** Owner-friendly, non-diagnostic summary derived from the signal. */
+  evidence_summary: string;
+  /** Relative phrase like "in recent check-ins"; omitted when no date is reliable. */
+  evidence_date_range?: string;
+}
+
+/** Match an ISO date (YYYY-MM-DD) anywhere in a signal's dedupe_key. */
+const ISO_DATE = /\d{4}-\d{2}-\d{2}/g;
+
+/**
+ * Derive a relative date phrase from the dates a signal embeds in its dedupe_key.
+ * Returns undefined when no reliable date can be parsed (NEVER guesses).
+ */
+function deriveEvidenceDateRange(
+  dedupeKey: string,
+  now: Date,
+): string | undefined {
+  const matches = dedupeKey.match(ISO_DATE);
+  if (!matches || matches.length === 0) {
+    return undefined;
+  }
+
+  const times = matches
+    .map((iso) => Date.parse(`${iso}T00:00:00Z`))
+    .filter((t) => Number.isFinite(t));
+  if (times.length === 0) {
+    return undefined;
+  }
+
+  // Use the most recent date the signal references.
+  const newest = Math.max(...times);
+  const days = Math.round((now.getTime() - newest) / 86_400_000);
+
+  if (!Number.isFinite(days) || days < 0) {
+    // A future date is not trustworthy — omit rather than guess.
+    return "in recent check-ins";
+  }
+  if (days === 0) return "today";
+  if (days === 1) return "about a day ago";
+  if (days <= 30) return `about ${days} days ago`;
+  return "in recent check-ins";
+}
+
+/**
+ * Map each Brain-prioritised symptom key back to the source signal plus an
+ * owner-friendly, non-diagnostic evidence summary. Pure + side-effect free.
+ *
+ * Safety contract:
+ *  - No disease names, no diagnosis — the summary is the signal's own
+ *    owner_message (already owner-facing) plus an optional relative date.
+ *  - An unknown / unmapped signal degrades to a no-op (skipped, never thrown).
+ *  - Highest-severity signal wins when two signals map to the same symptom key,
+ *    matching brainPrioritySymptomsFromSignals' ordering.
+ */
+export function brainPrioritySymptomEvidence(
+  signals: DetectedSignal[],
+  now: Date = new Date(),
+): Record<string, BrainSymptomEvidence> {
+  const ordered = [...signals].sort(
+    (a, b) => (SEVERITY_RANK[a.severity] ?? 9) - (SEVERITY_RANK[b.severity] ?? 9),
+  );
+
+  const evidence: Record<string, BrainSymptomEvidence> = {};
+  for (const signal of ordered) {
+    const keys = BRAIN_SIGNAL_SYMPTOM_KEYS[signal.signal_type];
+    if (!keys || keys.length === 0) continue;
+
+    const summary = (signal.owner_message ?? "").trim();
+    if (!summary) continue;
+
+    const dateRange = deriveEvidenceDateRange(signal.dedupe_key ?? "", now);
+
+    for (const key of keys) {
+      // First (highest-severity) signal to claim a key wins — don't overwrite.
+      if (evidence[key]) continue;
+      evidence[key] = {
+        signal_type: signal.signal_type,
+        evidence_summary: summary,
+        ...(dateRange ? { evidence_date_range: dateRange } : {}),
+      };
+    }
+  }
+  return evidence;
+}
+
+/**
  * Derive the supportive symptom keys the Dog Brain would like the symptom
  * checker to consider — highest-severity signals first, deduped. Pure.
  */

--- a/src/lib/health-log/dog-brain-context.ts
+++ b/src/lib/health-log/dog-brain-context.ts
@@ -6,18 +6,29 @@ import {
   type FollowupContextRow,
 } from "./context";
 import { detectDogBrainSignals } from "@/lib/dog-brain/signals";
-import { brainPrioritySymptomsFromSignals } from "@/lib/dog-brain/question-priority";
+import {
+  brainPrioritySymptomsFromSignals,
+  brainPrioritySymptomEvidence,
+  type BrainSymptomEvidence,
+} from "@/lib/dog-brain/question-priority";
 
 export interface DogBrainContextData {
   /** Supportive narrative for the report prompt; null = skip context. */
   context: string | null;
   /** Recurring-signal symptom keys for the symptom-checker question tiebreak. */
   prioritySymptoms: string[];
+  /**
+   * Owner-friendly, non-diagnostic evidence per priority symptom key — used ONLY
+   * to explain (after the fact) why Brain memory surfaced a question. Never alters
+   * selection or control state. Empty when there is no Brain memory.
+   */
+  prioritySymptomEvidence: Record<string, BrainSymptomEvidence>;
 }
 
 const EMPTY_DOG_BRAIN_DATA: DogBrainContextData = {
   context: null,
   prioritySymptoms: [],
+  prioritySymptomEvidence: {},
 };
 
 /**
@@ -309,13 +320,15 @@ export async function loadDogBrainContextWithSignals({
     // derived from the SAME logs already loaded above (detectDogBrainSignals
     // uses the 14 newest internally) — no extra query, no duplicate ownership
     // check. Replaces the former standalone loadDogBrainPrioritySymptoms loader.
-    const prioritySymptoms = brainPrioritySymptomsFromSignals(
-      detectDogBrainSignals(logs).signals,
-    );
+    const detectedSignals = detectDogBrainSignals(logs).signals;
+    const prioritySymptoms = brainPrioritySymptomsFromSignals(detectedSignals);
+    const prioritySymptomEvidence =
+      brainPrioritySymptomEvidence(detectedSignals);
 
     return {
       context: sections.length === 0 ? null : sections.join("\n\n"),
       prioritySymptoms,
+      prioritySymptomEvidence,
     };
   } catch {
     return EMPTY_DOG_BRAIN_DATA;

--- a/src/lib/symptom-chat/answer-coercion.ts
+++ b/src/lib/symptom-chat/answer-coercion.ts
@@ -7,6 +7,89 @@ import {
 import { FOLLOW_UP_QUESTIONS, SYMPTOM_MAP } from "@/lib/clinical-matrix";
 import { coerceAmbiguousReplyToUnknown } from "@/lib/ambiguous-reply";
 import { isEmergencyGradeCriticalQuestionId } from "@/lib/clinical/emergency-grade-critical-questions";
+import type { BrainSymptomEvidence } from "@/lib/dog-brain/question-priority";
+
+/**
+ * Explanation-only metadata describing WHY Dog Brain memory surfaced a question.
+ * It is computed AFTER selection and NEVER alters question selection, urgency, or
+ * any control state. Null whenever the current complaint (or a pending
+ * clarification) drove the question, or there is no Brain memory.
+ */
+export interface BrainQuestionTrace {
+  source: "dog_brain";
+  signal_type: BrainSymptomEvidence["signal_type"];
+  selected_symptom_key: string;
+  selected_question_id: string;
+  evidence_date_range?: string;
+  evidence_summary: string;
+  safety_note: string;
+}
+
+const BRAIN_TRACE_SAFETY_NOTE =
+  "Supportive context only; not a diagnosis.";
+
+/**
+ * Derive a Brain question trace for an already-selected question id. PURE.
+ *
+ * Emits a trace ONLY when ALL hold:
+ *  - the complaint branch (preferredSymptoms) did NOT produce selectedQuestionId,
+ *  - the brain branch (brainPrioritySymptoms) DID produce selectedQuestionId,
+ *  - the brain symptom that produced it has owner-friendly evidence in the map.
+ *
+ * Otherwise returns null (current complaint wins, pending clarification wins,
+ * empty memory, or an unmapped signal/symptom) — never throws.
+ */
+export function deriveBrainQuestionTrace(
+  session: TriageSession,
+  preferredSymptoms: string[],
+  brainPrioritySymptoms: string[],
+  evidenceMap: Record<string, BrainSymptomEvidence>,
+  selectedQuestionId: string | null,
+): BrainQuestionTrace | null {
+  if (!selectedQuestionId) return null;
+  if (!brainPrioritySymptoms.length) return null;
+  if (!evidenceMap || Object.keys(evidenceMap).length === 0) return null;
+
+  // The current complaint always wins: if it would have produced this exact
+  // question, Brain memory did not drive it — no (misleading) trace.
+  if (
+    getNextQuestionForPreferredSymptoms(session, preferredSymptoms) ===
+    selectedQuestionId
+  ) {
+    return null;
+  }
+
+  // The brain branch must genuinely select this exact question id.
+  if (
+    getNextQuestionForPreferredSymptoms(session, brainPrioritySymptoms) !==
+    selectedQuestionId
+  ) {
+    return null;
+  }
+
+  // Find which brain symptom owns the selected follow-up AND has evidence.
+  const selectedSymptomKey = brainPrioritySymptoms.find((symptom) => {
+    if (!evidenceMap[symptom]) return false;
+    const followUps = SYMPTOM_MAP[symptom]?.follow_up_questions;
+    return Array.isArray(followUps) && followUps.includes(selectedQuestionId);
+  });
+  if (!selectedSymptomKey) return null;
+
+  const evidence = evidenceMap[selectedSymptomKey];
+  if (!evidence?.evidence_summary) return null;
+
+  return {
+    source: "dog_brain",
+    signal_type: evidence.signal_type,
+    selected_symptom_key: selectedSymptomKey,
+    selected_question_id: selectedQuestionId,
+    ...(evidence.evidence_date_range
+      ? { evidence_date_range: evidence.evidence_date_range }
+      : {}),
+    evidence_summary: evidence.evidence_summary,
+    safety_note: BRAIN_TRACE_SAFETY_NOTE,
+  };
+}
 
 export function getNextQuestionAvoidingRepeat(
   session: TriageSession,
@@ -37,7 +120,7 @@ export function getNextQuestionAvoidingRepeat(
   return alternatives[0] || nextQuestionId;
 }
 
-function getNextQuestionForPreferredSymptoms(
+export function getNextQuestionForPreferredSymptoms(
   session: TriageSession,
   preferredSymptoms: string[]
 ): string | null {

--- a/src/lib/symptom-chat/next-question-orchestration.ts
+++ b/src/lib/symptom-chat/next-question-orchestration.ts
@@ -8,7 +8,12 @@ import {
   recordConversationTelemetry,
   syncStructuredCaseMemoryQuestions,
 } from "@/lib/symptom-memory";
-import { getNextQuestionAvoidingRepeat } from "@/lib/symptom-chat/answer-coercion";
+import {
+  getNextQuestionAvoidingRepeat,
+  deriveBrainQuestionTrace,
+  type BrainQuestionTrace,
+} from "@/lib/symptom-chat/answer-coercion";
+import type { BrainSymptomEvidence } from "@/lib/dog-brain/question-priority";
 import { didVisualEvidenceInfluenceQuestion } from "@/lib/symptom-chat/report-helpers";
 import {
   getPendingQuestionId,
@@ -29,6 +34,12 @@ interface OrchestrateNextQuestionInput {
    * complaint. Optional; absent / empty preserves pre-Brain behavior exactly.
    */
   brainPrioritySymptoms?: string[];
+  /**
+   * Owner-friendly evidence per Brain priority symptom key — used ONLY to build
+   * the explanation-only brainQuestionTrace. Never affects selection. Optional;
+   * absent / empty means no trace is emitted.
+   */
+  brainPrioritySymptomEvidence?: Record<string, BrainSymptomEvidence>;
 }
 
 interface OrchestrateNextQuestionResult {
@@ -36,6 +47,11 @@ interface OrchestrateNextQuestionResult {
   nextQuestionId: string | null;
   needsClarificationQuestionId: string | null;
   visualEvidenceInfluencedQuestion: boolean;
+  /**
+   * Explanation-only metadata: present only when Dog Brain memory (not the
+   * current complaint and not a pending clarification) drove nextQuestionId.
+   */
+  brainQuestionTrace: BrainQuestionTrace | null;
 }
 
 export function orchestrateNextQuestion(
@@ -49,6 +65,19 @@ export function orchestrateNextQuestion(
       input.turnFocusSymptoms,
       input.brainPrioritySymptoms ?? []
     );
+
+  // Explanation-only trace. A pending clarification re-ask always wins, so a
+  // clarification turn yields no Brain trace. Otherwise emit a trace ONLY when
+  // Brain memory (not the complaint) genuinely drove this exact question.
+  const brainQuestionTrace = needsClarificationQuestionId
+    ? null
+    : deriveBrainQuestionTrace(
+        input.session,
+        input.turnFocusSymptoms,
+        input.brainPrioritySymptoms ?? [],
+        input.brainPrioritySymptomEvidence ?? {},
+        nextQuestionId
+      );
 
   let session = recordRepeatSuppressionTelemetry(
     input.session,
@@ -80,6 +109,7 @@ export function orchestrateNextQuestion(
     nextQuestionId,
     needsClarificationQuestionId,
     visualEvidenceInfluencedQuestion,
+    brainQuestionTrace,
   };
 }
 

--- a/src/lib/symptom-chat/question-response-flow.ts
+++ b/src/lib/symptom-chat/question-response-flow.ts
@@ -31,6 +31,7 @@ import {
   type TurnDepth,
 } from "@/lib/symptom-chat/turn-depth";
 import { getGuideForQuestion } from "@/lib/symptom-chat/response-builders";
+import type { BrainQuestionTrace } from "@/lib/symptom-chat/answer-coercion";
 
 interface BuildQuestionResponseFlowInput {
   session: TriageSession;
@@ -48,6 +49,8 @@ interface BuildQuestionResponseFlowInput {
   turnDeadline?: TurnDeadline;
   turnDepth?: TurnDepth;
   askingBecause?: string | null;
+  /** Explanation-only metadata when Dog Brain memory drove the question. */
+  brainQuestionTrace?: BrainQuestionTrace | null;
   promptVetRecord?: boolean;
 }
 
@@ -83,6 +86,7 @@ export async function buildQuestionResponseFlow(
       ? "needs_clarification"
       : inferConversationState(getStateSnapshot(session)),
     asking_because: input.askingBecause ?? session.case_memory?.asking_because ?? null,
+    brain_question_trace: input.brainQuestionTrace ?? null,
     prompt_vet_record: Boolean(input.promptVetRecord),
     selfCheckGuide: getGuideForQuestion(input.nextQuestionId) ?? null,
   });

--- a/tests/dog-brain-context-urgency-guard.test.ts
+++ b/tests/dog-brain-context-urgency-guard.test.ts
@@ -15,6 +15,8 @@ import {
   type TriageSession,
 } from "@/lib/triage-engine";
 import { ensureStructuredCaseMemory } from "@/lib/symptom-memory";
+import { deriveBrainQuestionTrace } from "@/lib/symptom-chat/answer-coercion";
+import { brainPrioritySymptomEvidence } from "@/lib/dog-brain/question-priority";
 
 const pet: PetProfile = {
   name: "Scout",
@@ -71,5 +73,40 @@ describe("Dog Brain memory cannot downgrade deterministic urgency", () => {
     expect(withBenignMemory.red_flags_triggered).toEqual(
       expect.arrayContaining(["vomit_blood"]),
     );
+  });
+
+  it("Brain question trace is explanation-only — building it never mutates urgency or red flags", () => {
+    const session = emergencySession();
+    const redFlagsBefore = [...session.red_flags_triggered];
+    const urgencyBefore = buildDiagnosisContext(session, pet).highest_urgency;
+
+    const evidenceMap = brainPrioritySymptomEvidence([
+      {
+        signal_type: "stool_change",
+        severity: "watch",
+        owner_message: "The latest log shows a stool change.",
+        dedupe_key: "stool_change:2026-06-10",
+      },
+    ]);
+
+    // Even with Brain priority symptoms + evidence present, deriving the trace is
+    // a pure read: it cannot change the session, urgency, or red flags. And on an
+    // emergency turn the complaint (vomiting) drives selection, so the brain trace
+    // for an unrelated diarrhea question stays null when the complaint owns it.
+    const trace = deriveBrainQuestionTrace(
+      session,
+      ["vomiting"],
+      ["diarrhea"],
+      evidenceMap,
+      // A vomiting follow-up the complaint branch owns — not a brain-driven id.
+      "vomit_blood",
+    );
+    expect(trace).toBeNull();
+
+    expect(session.red_flags_triggered).toEqual(redFlagsBefore);
+    expect(buildDiagnosisContext(session, pet).highest_urgency).toBe(
+      urgencyBefore,
+    );
+    expect(urgencyBefore).toBe("emergency");
   });
 });

--- a/tests/dog-brain-context.test.ts
+++ b/tests/dog-brain-context.test.ts
@@ -3,6 +3,11 @@ import type { HealthLog } from "@/lib/health-log/types";
 import { buildVetTimeline } from "@/lib/analytics/vet-timeline";
 import type { SymptomCheckEntry } from "@/components/timeline/types";
 import type { JournalEntry } from "@/types/journal";
+import { detectDogBrainSignals } from "@/lib/dog-brain/signals";
+import {
+  brainPrioritySymptomsFromSignals,
+  brainPrioritySymptomEvidence,
+} from "@/lib/dog-brain/question-priority";
 
 /** Minimal HealthLog factory */
 function log(overrides: Partial<HealthLog> = {}): HealthLog {
@@ -141,6 +146,49 @@ describe("ContextSignals in HealthLog", () => {
   it("context_signals null when not provided", () => {
     const l = log();
     expect(l.context_signals).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Dog Brain priority-symptom evidence (the data threaded into DogBrainContextData
+// alongside prioritySymptoms — same detector the context loader uses internally).
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("brainPrioritySymptomEvidence from detected signals", () => {
+  it("produces evidence keyed by the SAME priority symptoms the loader threads out", () => {
+    const logs = [
+      log({ log_date: "2026-06-18", stool: "diarrhea" }),
+      log({ log_date: "2026-06-17", stool: "diarrhea" }),
+      log({ log_date: "2026-06-16", stool: "soft" }),
+    ];
+    const signals = detectDogBrainSignals(logs).signals;
+    const prioritySymptoms = brainPrioritySymptomsFromSignals(signals);
+    const evidence = brainPrioritySymptomEvidence(signals);
+
+    expect(prioritySymptoms).toContain("diarrhea");
+    // Every priority symptom that carries evidence references a real signal_type
+    // and an owner-friendly (non-diagnostic) summary.
+    expect(evidence["diarrhea"]?.signal_type).toBe("stool_change");
+    expect(evidence["diarrhea"]?.evidence_summary).toBeTruthy();
+    expect(evidence["diarrhea"]?.evidence_summary).not.toMatch(
+      /diagnos|disease|cancer/i,
+    );
+  });
+
+  it("empty logs ⇒ no priority symptoms AND no evidence (no-op shape)", () => {
+    const signals = detectDogBrainSignals([]).signals;
+    expect(brainPrioritySymptomsFromSignals(signals)).toEqual([]);
+    expect(brainPrioritySymptomEvidence(signals)).toEqual({});
+  });
+
+  it("all-normal logs ⇒ no evidence (no Brain memory ⇒ byte-identical no-op)", () => {
+    const normalLogs = [
+      log({ log_date: "2026-06-18" }),
+      log({ log_date: "2026-06-17" }),
+      log({ log_date: "2026-06-16" }),
+    ];
+    const signals = detectDogBrainSignals(normalLogs).signals;
+    expect(brainPrioritySymptomEvidence(signals)).toEqual({});
   });
 });
 

--- a/tests/dog-brain-question-priority.orchestration.test.ts
+++ b/tests/dog-brain-question-priority.orchestration.test.ts
@@ -2,16 +2,20 @@ import { createSession } from "@/lib/triage-engine";
 import { orchestrateNextQuestion } from "@/lib/symptom-chat/next-question-orchestration";
 
 const mockGetNextQuestionAvoidingRepeat = jest.fn();
+const mockDeriveBrainQuestionTrace = jest.fn();
 
 jest.mock("@/lib/symptom-chat/answer-coercion", () => ({
   getNextQuestionAvoidingRepeat: (...args: unknown[]) =>
     mockGetNextQuestionAvoidingRepeat(...args),
+  deriveBrainQuestionTrace: (...args: unknown[]) =>
+    mockDeriveBrainQuestionTrace(...args),
 }));
 
 describe("orchestrateNextQuestion — Dog Brain priority wiring", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetNextQuestionAvoidingRepeat.mockReturnValue(null);
+    mockDeriveBrainQuestionTrace.mockReturnValue(null);
   });
 
   it("forwards brainPrioritySymptoms to the selector as the third argument", () => {
@@ -58,6 +62,56 @@ describe("orchestrateNextQuestion — Dog Brain priority wiring", () => {
 
     expect(result.needsClarificationQuestionId).toBe("breathing_effort");
     expect(result.nextQuestionId).toBe("breathing_effort");
+    // Pending clarification wins ⇒ NO Brain trace, and the trace helper is never
+    // even consulted on a clarification turn.
+    expect(result.brainQuestionTrace).toBeNull();
+    expect(mockDeriveBrainQuestionTrace).not.toHaveBeenCalled();
+  });
+
+  it("emits the brainQuestionTrace returned by the helper when Brain drove the question", () => {
+    mockGetNextQuestionAvoidingRepeat.mockReturnValue("diarrhea_duration");
+    const trace = {
+      source: "dog_brain" as const,
+      signal_type: "stool_change" as const,
+      selected_symptom_key: "diarrhea",
+      selected_question_id: "diarrhea_duration",
+      evidence_summary: "The latest log shows a stool change.",
+      safety_note: "Supportive context only; not a diagnosis.",
+    };
+    mockDeriveBrainQuestionTrace.mockReturnValue(trace);
+
+    const session = createSession();
+    session.known_symptoms = [];
+
+    const result = orchestrateNextQuestion({
+      session,
+      incomingUnresolvedIds: [],
+      pendingQResolvedThisTurn: false,
+      turnFocusSymptoms: [],
+      visualEvidence: null,
+      brainPrioritySymptoms: ["diarrhea"],
+      brainPrioritySymptomEvidence: {
+        diarrhea: {
+          signal_type: "stool_change",
+          evidence_summary: "The latest log shows a stool change.",
+        },
+      },
+    });
+
+    expect(result.brainQuestionTrace).toEqual(trace);
+    // Helper receives the actually-selected question id + the evidence map.
+    expect(mockDeriveBrainQuestionTrace).toHaveBeenCalledWith(
+      session,
+      [],
+      ["diarrhea"],
+      {
+        diarrhea: {
+          signal_type: "stool_change",
+          evidence_summary: "The latest log shows a stool change.",
+        },
+      },
+      "diarrhea_duration",
+    );
   });
 
   it("defaults to no Brain preference when the field is omitted (backward compatible)", () => {

--- a/tests/dog-brain-question-priority.test.ts
+++ b/tests/dog-brain-question-priority.test.ts
@@ -1,6 +1,13 @@
-import { brainPrioritySymptomsFromSignals } from "@/lib/dog-brain/question-priority";
+import {
+  brainPrioritySymptomsFromSignals,
+  brainPrioritySymptomEvidence,
+} from "@/lib/dog-brain/question-priority";
 import type { DetectedSignal } from "@/lib/dog-brain/types";
-import { getNextQuestionAvoidingRepeat } from "@/lib/symptom-chat/answer-coercion";
+import {
+  getNextQuestionAvoidingRepeat,
+  getNextQuestionForPreferredSymptoms,
+  deriveBrainQuestionTrace,
+} from "@/lib/symptom-chat/answer-coercion";
 import { createSession } from "@/lib/triage-engine";
 import { SYMPTOM_MAP } from "@/lib/clinical-matrix";
 
@@ -170,5 +177,186 @@ describe("getNextQuestionAvoidingRepeat — Dog Brain tiebreak", () => {
       [],
     );
     expect(withEmptyBrain).toBe(legacy);
+  });
+});
+
+describe("brainPrioritySymptomEvidence (owner-friendly, non-diagnostic)", () => {
+  it("maps each priority symptom key to its source signal_type + summary", () => {
+    const evidence = brainPrioritySymptomEvidence([
+      signal({
+        signal_type: "stool_change",
+        severity: "watch",
+        owner_message: "The latest log shows a stool change.",
+        dedupe_key: "stool_change:2026-06-10",
+      }),
+    ]);
+
+    // The mapped keys (diarrhea, blood_in_stool) each reference the same signal.
+    expect(evidence["diarrhea"]?.signal_type).toBe("stool_change");
+    expect(evidence["blood_in_stool"]?.signal_type).toBe("stool_change");
+    expect(evidence["diarrhea"]?.evidence_summary).toBe(
+      "The latest log shows a stool change.",
+    );
+    // Owner-friendly: no disease names / diagnosis language.
+    expect(evidence["diarrhea"]?.evidence_summary).not.toMatch(
+      /diagnos|disease|cancer|infection/i,
+    );
+  });
+
+  it("derives a relative date phrase only when a date is reliable", () => {
+    const now = new Date("2026-06-15T00:00:00Z");
+    const evidence = brainPrioritySymptomEvidence(
+      [
+        signal({
+          signal_type: "vomiting_trend",
+          severity: "watch",
+          owner_message: "Vomiting was reported 3 times.",
+          dedupe_key: "vomiting_trend:2026-06-13",
+        }),
+      ],
+      now,
+    );
+    expect(evidence["vomiting"]?.evidence_date_range).toBe("about 2 days ago");
+  });
+
+  it("omits the date when the dedupe_key has no parseable date", () => {
+    const evidence = brainPrioritySymptomEvidence([
+      signal({
+        signal_type: "appetite_drop",
+        severity: "watch",
+        owner_message: "Appetite was down recently.",
+        dedupe_key: "appetite_drop:unknown",
+      }),
+    ]);
+    expect(evidence["not_eating"]).toBeDefined();
+    expect(evidence["not_eating"]?.evidence_date_range).toBeUndefined();
+  });
+
+  it("is empty for no signals and for unmapped (medication) signals", () => {
+    expect(brainPrioritySymptomEvidence([])).toEqual({});
+    expect(
+      brainPrioritySymptomEvidence([
+        signal({ signal_type: "possible_med_side_effect", severity: "info" }),
+      ]),
+    ).toEqual({});
+  });
+
+  it("highest-severity signal wins when two signals map to the same key", () => {
+    const evidence = brainPrioritySymptomEvidence([
+      signal({
+        signal_type: "vomiting_trend",
+        severity: "info",
+        owner_message: "low severity message",
+        dedupe_key: "vomiting_trend:2026-06-01",
+      }),
+      signal({
+        signal_type: "vomiting_trend",
+        severity: "alert",
+        owner_message: "high severity message",
+        dedupe_key: "vomiting_trend:2026-06-10",
+      }),
+    ]);
+    expect(evidence["vomiting"]?.evidence_summary).toBe("high severity message");
+  });
+});
+
+describe("deriveBrainQuestionTrace (explanation-only)", () => {
+  function brainSession() {
+    const session = createSession();
+    session.known_symptoms = []; // no current complaint
+    session.answered_questions = [];
+    return session;
+  }
+
+  it("(proof 1+2) returns a trace referencing the correct signal_type when Brain drove the question", () => {
+    const session = brainSession();
+    const evidenceMap = brainPrioritySymptomEvidence([
+      signal({
+        signal_type: "stool_change",
+        severity: "watch",
+        owner_message: "The latest log shows a stool change.",
+        dedupe_key: "stool_change:2026-06-10",
+      }),
+    ]);
+    const selected = getNextQuestionForPreferredSymptoms(session, ["diarrhea"]);
+    expect(selected).toBeTruthy();
+
+    const trace = deriveBrainQuestionTrace(
+      session,
+      [], // complaint branch empty
+      ["diarrhea"], // brain branch
+      evidenceMap,
+      selected,
+    );
+
+    expect(trace).not.toBeNull();
+    expect(trace?.source).toBe("dog_brain");
+    expect(trace?.signal_type).toBe("stool_change");
+    expect(trace?.selected_symptom_key).toBe("diarrhea");
+    expect(trace?.selected_question_id).toBe(selected);
+    expect(trace?.safety_note).toMatch(/not a diagnosis/i);
+  });
+
+  it("(proof 3) returns null when Brain memory is empty (no evidence)", () => {
+    const session = brainSession();
+    const selected = getNextQuestionForPreferredSymptoms(session, ["diarrhea"]);
+    expect(
+      deriveBrainQuestionTrace(session, [], ["diarrhea"], {}, selected),
+    ).toBeNull();
+    expect(
+      deriveBrainQuestionTrace(session, [], [], {}, selected),
+    ).toBeNull();
+  });
+
+  it("(proof 4) returns null when the current complaint drove the question", () => {
+    const session = createSession();
+    session.known_symptoms = ["vomiting"];
+    session.answered_questions = [];
+
+    // Complaint = vomiting; the selected question belongs to vomiting's follow-ups.
+    const selected = getNextQuestionForPreferredSymptoms(session, ["vomiting"]);
+    expect(selected).toBeTruthy();
+
+    const evidenceMap = brainPrioritySymptomEvidence([
+      signal({
+        signal_type: "vomiting_trend",
+        severity: "watch",
+        owner_message: "Vomiting was reported 3 times.",
+        dedupe_key: "vomiting_trend:2026-06-10",
+      }),
+    ]);
+
+    // Even though Brain also maps to "vomiting", the complaint produced this
+    // question first — no misleading Brain trace.
+    const trace = deriveBrainQuestionTrace(
+      session,
+      ["vomiting"],
+      ["vomiting"],
+      evidenceMap,
+      selected,
+    );
+    expect(trace).toBeNull();
+  });
+
+  it("(proof 7) returns null (no throw) for an unmapped symptom key with no evidence", () => {
+    const session = brainSession();
+    const selected = getNextQuestionForPreferredSymptoms(session, ["diarrhea"]);
+    // Evidence map references a DIFFERENT key than the one that produced the
+    // question — unknown/unmapped ⇒ safe no-op.
+    const trace = deriveBrainQuestionTrace(
+      session,
+      [],
+      ["diarrhea"],
+      { vomiting: { signal_type: "vomiting_trend", evidence_summary: "x" } },
+      selected,
+    );
+    expect(trace).toBeNull();
+  });
+
+  it("returns null for a null selected question id", () => {
+    const session = brainSession();
+    expect(
+      deriveBrainQuestionTrace(session, [], ["diarrhea"], {}, null),
+    ).toBeNull();
   });
 });

--- a/tests/next-question-orchestration.test.ts
+++ b/tests/next-question-orchestration.test.ts
@@ -4,6 +4,9 @@ import { orchestrateNextQuestion } from "@/lib/symptom-chat/next-question-orches
 const mockGetNextQuestionAvoidingRepeat = jest.fn();
 
 jest.mock("@/lib/symptom-chat/answer-coercion", () => ({
+  // Preserve real exports (e.g. deriveBrainQuestionTrace) — only override the
+  // selector so question routing can be driven deterministically per test.
+  ...jest.requireActual("@/lib/symptom-chat/answer-coercion"),
   getNextQuestionAvoidingRepeat: (...args: unknown[]) =>
     mockGetNextQuestionAvoidingRepeat(...args),
 }));


### PR DESCRIPTION
## What changed
When Dog Brain memory (not the current complaint) drives the next symptom-checker question, the API now returns a structured `brain_question_trace` and the UI renders a second calm line **"Why this came up: …"** below the existing clinical "Why I'm asking". The clinical `asking_because` is untouched.

- `src/lib/dog-brain/question-priority.ts` — `brainPrioritySymptomEvidence(signals)` → owner-friendly evidence map (signal_type + non-diagnostic summary; relative date only when reliably derivable).
- `src/lib/health-log/dog-brain-context.ts` — exposes `prioritySymptomEvidence` from the same `detectDogBrainSignals(logs)` (no extra query); empty on no memory.
- `src/lib/symptom-chat/answer-coercion.ts` — pure `deriveBrainQuestionTrace(...)`; selection signature unchanged.
- `src/lib/symptom-chat/next-question-orchestration.ts` + `turn-pipeline` + `route.ts` + `question-response-flow.ts` — thread `brain_question_trace` (sibling of `asking_because`); null unless memory drove the selected question.
- `src/app/(dashboard)/symptom-checker/page.tsx` — renders the "Why this came up:" line when `brain_question_trace.evidence_summary` exists.

## Safety boundary
Trace is **explanation-only metadata** — never alters question selection, urgency, or red-flag logic (`triage-engine.ts`/`clinical-matrix.ts` untouched). Emitted ONLY when: complaint branch did NOT produce the question, the brain branch DID, the symptom has evidence, it is not a pending-clarification turn, and the planner did not swap the question. **Current complaint wins; pending clarification wins; empty memory ⇒ no trace (no-op); emergency ⇒ trace null.**

## Live proof (feature branch, local dev server + real DB, sandbox account)
Captured live with `brain_question_trace` populated:
- Q "How long has the vomiting been going on?" → `signal_type: vomiting_trend`, `evidence_summary: "Vomiting was reported 4 times across the latest 3 logged days."`, `safety_note: "Supportive context only; not a diagnosis."`
- UI renders both "Why I'm asking:" (clinical) and "Why this came up:" (memory).
- Emergency ("collapsed, pale gums, struggling to breathe") → `type: emergency`, **trace null** (memory did not soften urgency).
- Sandbox data deleted — **0 residual**.
- Screenshots: `C:\e2e_shots\brain-trace\` (q1–q3, emergency) + `trace-evidence.json`.

## Tests run
- `npm run typecheck` → clean.
- eslint on all 8 touched files → 0 errors.
- `npm test -- --runInBand --testPathPatterns="dog-brain|symptom|health-log"` → 38 suites / 852 tests pass (incl. urgency-guard 3/3 and 26 question-priority/trace tests).
- New tests cover: trace emitted for brain-driven question, correct signal_type, empty memory ⇒ no trace, complaint wins ⇒ no trace, pending clarification ⇒ no trace, emergency urgency unchanged, unknown signal no-op, existing `asking_because` unchanged.

## symptom_checks persistence (Phase 4 — documented, no code change)
The write path already exists and is correct: `generate_report` → `saveSymptomReportToDB` (`src/lib/report-storage.ts:151`), owner-scoped, completed-report-only, insert-failure non-fatal. The live "0 rows" is **environmental** — a chat-only E2E never calls `generate_report`. No second insert was added (would risk double-inserts). Follow-up: capture `onDiagnostic` reasons during a real authenticated `generate_report` run to confirm the gate, if persistence-on-chat is desired.

Do not merge / do not deploy — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)