### PR TITLE
test: fix two stale pre-existing assertions

### DIFF
--- a/tests/media-router.test.ts
+++ b/tests/media-router.test.ts
@@ -106,11 +106,12 @@ describe("suggestMedia — image domain routing", () => {
     expect(result && "domain" in result && result.domain).toBe("skin_wound");
   });
 
-  test("suggests skin_wound image from keyword alone (no symptom key)", () => {
+  test("suggests mass_swelling image from keyword alone (no symptom key)", () => {
     const session = makeSession([]);
+    // "lump" is a mass_swelling keyword (not skin_wound) — deterministic routing.
     const result = suggestMedia("I noticed a lump on her back", session);
     expect(result?.mediaType).toBe("image");
-    expect(result && "domain" in result && result.domain).toBe("skin_wound");
+    expect(result && "domain" in result && result.domain).toBe("mass_swelling");
   });
 
   test("suggests eye image for eye_discharge symptom", () => {

--- a/tests/pet-onboarding-host.test.ts
+++ b/tests/pet-onboarding-host.test.ts
@@ -26,7 +26,7 @@ describe("PetOnboardingHost", () => {
   it("opens the pet profile modal when the session has not dismissed onboarding", async () => {
     render(React.createElement(PetOnboardingHost));
 
-    expect(await screen.findByText("Add your dog")).toBeTruthy();
+    expect(await screen.findByText("Get started")).toBeTruthy();
   });
 
   it("stays closed when onboarding was dismissed in session storage", async () => {


### PR DESCRIPTION
Fixes 2 of the pre-existing failing tests (stale assertions, unrelated to recent work):
- `media-router`: 'lump' deterministically routes to mass_swelling, not skin_wound.
- `pet-onboarding-host`: assert the redesigned welcome flow's 'Get started' button.

Test-only, no runtime change. The other pre-existing failures (`full-report-owner-summary`, `private-tester-scope-ui` = 8 tests) are product-redesign drift (FullReport dropped OwnerSummary; community page now hard-redirects) and need a product call on canonical behavior before rewriting — left as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)