### PR TITLE
fix(report): restore owner limitations + fix 8 stale UI tests

### DIFF
--- a/src/components/symptom-report/full-report.tsx
+++ b/src/components/symptom-report/full-report.tsx
@@ -292,8 +292,28 @@ export function FullReport({
         actions={report.actions}
         actionTitle={presentation.actionTitle}
         warningSigns={report.warning_signs}
-        warningTitle="Go sooner if you notice"
+        warningTitle={presentation.warningTitle}
       />
+
+      {presentation.limitations.length > 0 ? (
+        <Card className="border border-gray-200 p-4 sm:p-5">
+          <div className="space-y-3">
+            <h3 className="text-base font-semibold text-gray-900 sm:text-lg">
+              What PawVital still can&apos;t determine
+            </h3>
+            <ul className="space-y-2">
+              {presentation.limitations.map((limitation) => (
+                <li
+                  key={limitation}
+                  className="text-sm leading-6 text-gray-700"
+                >
+                  {limitation}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </Card>
+      ) : null}
 
       <div ref={handoffRef}>
         <VetHandoffCard

--- a/tests/full-report-owner-summary.test.ts
+++ b/tests/full-report-owner-summary.test.ts
@@ -60,14 +60,16 @@ describe("full report owner summary", () => {
     render(React.createElement(FullReport, { report: makeReport() }));
 
     expect(
-      screen.getByText("What this result means for your dog right now"),
+      screen.getByRole("heading", {
+        name: "Seek emergency veterinary care immediately",
+      }),
     ).toBeTruthy();
-    expect(screen.getAllByText("Emergency care now")).toHaveLength(2);
+    expect(screen.getByText("Emergency · seek care immediately")).toBeTruthy();
     expect(screen.getByText("Do this now")).toBeTruthy();
     expect(
       screen.getByText("Get urgent help even faster if you notice"),
     ).toBeTruthy();
-    expect(screen.getByText("Why PawVital recommended this")).toBeTruthy();
+    expect(screen.getByText("What's happening")).toBeTruthy();
     expect(
       screen.getByText("What PawVital still can't determine"),
     ).toBeTruthy();
@@ -77,10 +79,7 @@ describe("full report owner summary", () => {
       ),
     ).toBeTruthy();
     expect(
-      screen.getByRole("button", { name: "Copy Shareable Summary" }),
-    ).toBeTruthy();
-    expect(
-      screen.getByRole("button", { name: "See Feedback Status" }),
+      screen.getByRole("button", { name: "Copy clinic handoff for your vet" }),
     ).toBeTruthy();
     expect(screen.getByText("Feedback for this report")).toBeTruthy();
     expect(
@@ -104,8 +103,14 @@ describe("full report owner summary", () => {
       }),
     );
 
-    expect(screen.getByRole("button", { name: "Open Feedback" })).toBeTruthy();
-    expect(screen.getByText("Was this helpful?")).toBeTruthy();
+    expect(
+      screen.getByRole("heading", { name: "Did this match what happened?" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("heading", { name: "Private tester feedback" }),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Share outcome" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Send feedback" })).toBeTruthy();
   });
 
   it("does not render system notes telemetry even if a persisted report still carries observability", () => {
@@ -149,7 +154,11 @@ describe("full report owner summary", () => {
       }),
     );
 
-    expect(screen.getAllByText("Home monitoring for now")).toHaveLength(2);
+    expect(
+      screen.getByRole("heading", {
+        name: "Monitor at home with the guidance below",
+      }),
+    ).toBeTruthy();
     expect(screen.getByText("What to do now")).toBeTruthy();
     expect(
       screen.getByText("Offer small amounts of water frequently."),
@@ -176,7 +185,7 @@ describe("full report owner summary", () => {
     render(React.createElement(FullReport, { report: makeReport() }));
 
     fireEvent.click(
-      screen.getByRole("button", { name: "Copy Shareable Summary" }),
+      screen.getByRole("button", { name: "Copy clinic handoff for your vet" }),
     );
 
     const clipboard = window.navigator.clipboard as {

--- a/tests/private-tester-scope-ui.test.ts
+++ b/tests/private-tester-scope-ui.test.ts
@@ -17,6 +17,7 @@ import { useAppStore } from "@/store/app-store";
 import type { Pet, UserProfile } from "@/types";
 
 const mockUsePathname = jest.fn();
+const mockRedirect = jest.fn();
 const mockSignOut = jest.fn();
 
 jest.mock("next/link", () => {
@@ -36,6 +37,7 @@ jest.mock("next/link", () => {
 });
 
 jest.mock("next/navigation", () => ({
+  redirect: (...args: unknown[]) => mockRedirect(...args),
   usePathname: () => mockUsePathname(),
 }));
 
@@ -154,7 +156,7 @@ describe("private tester scope UI", () => {
     expect(screen.queryByText("Paw Circle")).toBeNull();
   });
 
-  it("VET-1368 tester scope UI: keeps the full sidebar navigation when private tester mode is off", () => {
+  it("VET-1368 tester scope UI: keeps approved sidebar navigation when private tester mode is off", () => {
     setPrivateTesterMode(false);
 
     render(React.createElement(Sidebar));
@@ -164,7 +166,7 @@ describe("private tester scope UI", () => {
     expect(screen.getByText("Supplements")).toBeTruthy();
     expect(screen.getByText("Reminders")).toBeTruthy();
     expect(screen.getByText("Journal")).toBeTruthy();
-    expect(screen.getByText("Paw Circle")).toBeTruthy();
+    expect(screen.queryByText("Paw Circle")).toBeNull();
   });
 
   it("VET-1368 tester scope UI: swaps the dashboard to private-test-safe focus content", () => {
@@ -192,21 +194,12 @@ describe("private tester scope UI", () => {
     expect(screen.queryByText("Joint supplement administered")).toBeNull();
   });
 
-  it("VET-1368 tester scope UI: quarantines Paw Circle with safe private-test copy", () => {
+  it("VET-1368 tester scope UI: redirects Paw Circle direct access to the dashboard", () => {
     setPrivateTesterMode(true);
 
-    render(React.createElement(CommunityPage));
+    CommunityPage();
 
-    expect(
-      screen.getByText("Paw Circle is disabled for private testers")
-    ).toBeTruthy();
-    expect(
-      screen.getByText("Community features are not part of this private test.")
-    ).toBeTruthy();
-    expect(screen.queryByText("Connect with fellow dog parents")).toBeNull();
-    expect(
-      screen.queryByText("Cooper's mobility improved so much in 3 months!")
-    ).toBeNull();
+    expect(mockRedirect).toHaveBeenCalledWith("/dashboard");
   });
 
   it("VET-1368 tester scope UI: quarantines supplements with safe private-test copy", () => {
@@ -272,7 +265,6 @@ describe("private tester scope UI", () => {
         null,
         React.createElement(Sidebar),
         React.createElement(DashboardPage),
-        React.createElement(CommunityPage),
         React.createElement(SupplementsPage)
       )
     );
@@ -281,13 +273,14 @@ describe("private tester scope UI", () => {
     expect(screen.queryByText("Paw Circle")).toBeNull();
     expect(screen.getByText("Private tester home")).toBeTruthy();
     expect(
-      screen.getByText("Paw Circle is disabled for private testers")
-    ).toBeTruthy();
-    expect(
       screen.getByText("Supplement plan is disabled for private testers")
     ).toBeTruthy();
     expect(screen.queryByText("View Supplements")).toBeNull();
     expect(screen.queryByText("Connect with fellow dog parents")).toBeNull();
+
+    CommunityPage();
+
+    expect(mockRedirect).toHaveBeenCalledWith("/dashboard");
   });
 
   it("VET-1390 tester scope UI: respects the server runtime flag when NEXT_PUBLIC mode is not present in the client bundle", () => {
@@ -308,14 +301,10 @@ describe("private tester scope UI", () => {
 
     dashboardView.unmount();
 
-    const communityView = render(React.createElement(CommunityPage));
+    CommunityPage();
 
-    expect(
-      screen.getByText("Paw Circle is disabled for private testers")
-    ).toBeTruthy();
+    expect(mockRedirect).toHaveBeenCalledWith("/dashboard");
     expect(screen.queryByText("Connect with fellow dog parents")).toBeNull();
-
-    communityView.unmount();
 
     render(React.createElement(SupplementsPage));
 


### PR DESCRIPTION
Fixes the remaining 8 pre-existing test failures (#6b/#6c).

- full-report.tsx: restores the owner-visible 'What PawVital still can't determine' limitations card (dropped in the declutter redesign) + uses the recommendation-specific warning heading (presentation.warningTitle). Safety-positive, additive.
- full-report-owner-summary.test.ts: assertions updated to the current FullReport UI, limitations safety check preserved.
- private-tester-scope-ui.test.ts: Paw Circle tests updated to the documented /community -> /dashboard redirect.

Verified: typecheck clean, full Jest suite GREEN (3928 passed, 0 failures), 666 report/symptom tests no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)