### PR TITLE
Investor-demo hardening: Dog Brain memory loop (ranking, analytics, clinical knowledge, live-E2E)

### DIFF
--- a/.github/workflows/dog-brain-live-e2e.yml
+++ b/.github/workflows/dog-brain-live-e2e.yml
@@ -1,0 +1,76 @@
+# Dog Brain live E2E — MANUAL ONLY.
+#
+# Proves the full memory loop against a real (sandbox/staging) deployment:
+# seed → memory-driven question → emergency trace suppression → cleanup → 0 residual.
+#
+# Deliberately NOT triggered on push/pull_request — it creates and deletes real
+# rows via the service-role key, so it must be run intentionally by an operator
+# against a SANDBOX project, never automatically on every PR.
+name: dog-brain-live-e2e
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Deployment base URL to test (e.g. https://staging.pawvital-ai.vercel.app)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dog-brain-live-e2e
+  cancel-in-progress: false
+
+jobs:
+  live-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: dog-brain-e2e # gate behind a protected environment + its secrets
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright (chromium)
+        run: npx playwright install --with-deps chromium
+
+      - name: Preflight — required secrets present
+        env:
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_ROLE_KEY }}
+          SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
+          E2E_SANDBOX_EMAIL: ${{ secrets.E2E_SANDBOX_EMAIL }}
+          E2E_SANDBOX_PASSWORD: ${{ secrets.E2E_SANDBOX_PASSWORD }}
+        run: |
+          missing=0
+          for v in SUPABASE_SERVICE_ROLE_KEY SUPABASE_URL E2E_SANDBOX_EMAIL E2E_SANDBOX_PASSWORD; do
+            if [ -z "${!v}" ]; then echo "::error::missing secret $v"; missing=1; fi
+          done
+          if [ "$missing" = "1" ]; then
+            echo "Configure the dog-brain-e2e environment secrets before running."; exit 1
+          fi
+
+      - name: Run Dog Brain live E2E
+        env:
+          E2E_BASE_URL: ${{ inputs.base_url }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_ROLE_KEY }}
+          SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
+          E2E_SANDBOX_EMAIL: ${{ secrets.E2E_SANDBOX_EMAIL }}
+          E2E_SANDBOX_PASSWORD: ${{ secrets.E2E_SANDBOX_PASSWORD }}
+        run: npx ts-node --esm tests/e2e/dog-brain-live-e2e.ts
+
+      - name: Upload artifacts (screenshots + result)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dog-brain-e2e-artifacts
+          path: artifacts/dog-brain-e2e/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/docs/dog-brain/INVESTOR_DEMO_HARDENING_STATE.md
+++ b/docs/dog-brain/INVESTOR_DEMO_HARDENING_STATE.md
@@ -18,7 +18,7 @@
 | 1 | Selector trace from selected source | **ALREADY LANDED** | PR #710 `fd3cd14`: selector reports branch (complaint/brain/fallback); `deriveBrainQuestionTrace` no longer re-derives; repeat-avoidance trace gap fixed; tests added. |
 | 2 | 60/90-day memory ranking (`src/lib/dog-brain/memory-ranking.ts`) | **DONE (iter 2)** | Pure module + 13 tests; wired in dog-brain-context.ts; severity stays dominant (urgency-safe). |
 | 3 | Privacy-safe analytics (`src/lib/dog-brain/analytics.ts`) | **MODULE DONE (iter 3)** | 8 events + builders + tests over existing App Insights sink; call-site wiring is next. |
-| 4 | Live E2E workflow (`.github/workflows/dog-brain-live-e2e.yml`) | **NOT BUILT** | File absent. |
+| 4 | Live E2E workflow (`.github/workflows/dog-brain-live-e2e.yml`) | **HARNESS DONE (iter 5)** | Manual workflow_dispatch + env-gated `tests/e2e/dog-brain-live-e2e.ts` (seed→memory-question poll→emergency-suppression→cleanup→0-residual). Typechecks+lints; NOT yet executed live (needs operator secrets). |
 | 5 | Supabase migration-ledger verify (`dog_brain_supplement_trials`) | **RUNBOOK (iter 4)** | STOP: MCP bound to wrong project (JobsearchAi, not PawVital). Runbook written with exact verify + repair commands + Node pg one-off. Live verify deferred to operator with correct creds. |
 | 6 | UX polish across tabs | **NOT STARTED** | — |
 | 8 | Clinical knowledge layer (`src/lib/clinical/knowledge-base.ts`, root-cause, supplement-guardrails) | **NOT BUILT** | Files absent. |
@@ -56,3 +56,10 @@
 - **Failed / STOP:** live DB verification — **STOP CONDITION "Supabase project is wrong"**. Did NOT run anything against the wrong project. Followed Phase 5's prescribed fallback (write runbook). psql/CLI absent + stale env passwords (per memory) compound this; needs operator with current PawVital creds.
 - **Next action:** Phase 4 — `.github/workflows/dog-brain-live-e2e.yml` (manual, env-gated) + e2e script skeleton; then Phase 3b route trace wiring with route tests; then Phase 8 clinical knowledge layer.
 - **Stop/defer:** Phase 5 live verify deferred to operator (documented, not faked). No full-loop stop — other phases proceed.
+
+### Iteration 5 — 2026-06-23 (Phase 4 live-E2E harness)
+- **Changed:** added `.github/workflows/dog-brain-live-e2e.yml` (manual `workflow_dispatch`, protected-environment-gated, installs Playwright chromium, uploads artifacts); added `tests/e2e/dog-brain-live-e2e.ts` (env-gated; seeds 90-day storyline + pending follow-up + worse-outcome supplement trial via service-role; logs in through the real UI; polls `POST /api/ai/symptom-chat` until `brain_question_trace` surfaces; asserts the emergency turn suppresses the trace; deletes everything in `finally` and asserts 0 residual; writes screenshots/result to `artifacts/dog-brain-e2e/`); added `e2e:dog-brain` npm script.
+- **Verified:** typecheck clean while authored under `scripts/` (tsc strict-mode-validated the whole flow), then relocated to `tests/e2e/` (repo convention: `/scripts/*` is gitignored; `tests/` is committable but tsconfig-excluded) — code unchanged after validation incl. real endpoint/body shape, real table columns, response key `brain_question_trace.evidence_summary`); eslint clean. Assertions hit the API contract directly (robust) rather than DOM scraping.
+- **Failed:** NOT executed against a live deployment — no E2E secrets / sandbox project in this environment, and running it would create prod rows (cleanup-residual is a STOP condition). First run is an operator action via the workflow with the `dog-brain-e2e` environment secrets.
+- **Next action:** Phase 3b route trace wiring (analytics emitters) with route tests; then Phase 8 curated clinical knowledge layer; then Phase 6 UX polish.
+- **Stop/defer:** live E2E execution deferred to operator (honest skeleton, typecheck-validated). No full-loop stop.

--- a/docs/dog-brain/INVESTOR_DEMO_HARDENING_STATE.md
+++ b/docs/dog-brain/INVESTOR_DEMO_HARDENING_STATE.md
@@ -84,3 +84,27 @@
 - **Failed:** nothing. `emergency_question_trace_suppressed` intentionally NOT wired — it would require touching 3+ emergency early-return sites (the "churns the giant file" risk the brief says to STOP on); the emergency path already returns no trace, so this is a missing telemetry event only, not a behavior gap.
 - **Next action:** Phase 6 UX polish (Playwright screenshots from the NTFS dev server; document if demo-mode loading stall blocks it), then `/thermo-review`, push, PR, final handoff.
 - **Stop/defer:** emergency-suppressed emit deferred (multi-site risk). No stop conditions hit.
+
+### Iteration 9 — 2026-06-23 (thermo-review + PR + handoff — LOOP COMPLETE)
+- **Changed:** ran `/thermo-review` (APPROVE, no blocking findings); pushed `codex/investor-demo-hardening`; opened **PR #713**.
+- **Verified:** thermo-review approved; full targeted suite **2382 pass**; typecheck + eslint clean; PR created. CI = "no checks reported" (Actions quota dead since Jun 3 — documented, not a regression).
+- **Failed / deferred (operator/env-gated, NOT faked):** live E2E execution (needs sandbox secrets); Supabase live migration verify (MCP on wrong project); `emergency_question_trace_suppressed` emit (multi-site route risk); Phase 6 UX polish (this branch has ZERO `.tsx` changes — nothing visual to screenshot; full audit is separate net-new work + blocked by demo-mode loading stall).
+- **Next action:** operator runs the live-E2E workflow + the migration runbook with correct creds; admin-merge PR #713 (CI gate is dead).
+
+---
+
+## FINAL HANDOFF
+
+- **Branch:** `codex/investor-demo-hardening` (off `origin/master` @ #710)
+- **PR:** https://github.com/kandamukeshkumar4-cmyk/pawvital-ai/pull/713
+- **Commits (7):** d9b6f55 ranking · 3c740ce analytics module · 9334f6a migration runbook · c34e7cc live-E2E harness · cb29011 lifecycle wiring · 1a87eb7 clinical knowledge layer · 06edcdb route trace emits
+- **Landed:** memory-ranking + wiring; analytics module + 8-event wiring (CRUD + route); clinical knowledge layer (4 modules); manual live-E2E harness; migration runbook. 6 new modules, 5 test suites (+57 tests), 2 docs, 1 CI workflow.
+- **Did NOT land (deferred, documented):** live-E2E execution; Supabase live-verify (wrong-project STOP); emergency-suppressed emit; knowledge-layer route/UI wiring; Phase 6 UX (no UI in diff).
+- **Failing:** none. Targeted suite 2382 pass; typecheck + eslint clean.
+- **Migration ledger:** UNVERIFIED live (runbook written; MCP wrong project — STOP honored).
+- **Production / live-E2E:** harness ready, NOT executed (needs operator secrets).
+- **Thermo-review verdict:** APPROVE (no blockers; 2 minor DRY follow-ups noted).
+- **Build:** deferred to NTFS/Vercel (local `G:` exFAT).
+- **SIA:** verifier=typecheck+eslint+2382 targeted tests+thermo-review | trajectory=9 iterations, 7 commits, state doc per-iteration | decision=harness (added analytics/knowledge/E2E harness + runbook + state doc) | Goodhart guard=clinical determinism untouched; ranking/knowledge floors provably never alter triage urgency.
+- **AutoLab:** baseline=#710 typecheck-clean+2329 tests | benchmark=typecheck+eslint+targeted suite+thermo gate | iterations=9 (best = 2382 pass, +57, 0 regressions) | budget=self-paced loop | outcome=improved.
+- **Final verdict:** **STAGE-READY for the code that landed** (ranking, analytics, clinical knowledge, harness — all green + thermo-approved). **NOT yet fully stage-PROVEN end-to-end** until an operator runs the live-E2E + migration-verify with correct credentials and admin-merges #713 (CI gate dead).

--- a/docs/dog-brain/INVESTOR_DEMO_HARDENING_STATE.md
+++ b/docs/dog-brain/INVESTOR_DEMO_HARDENING_STATE.md
@@ -19,7 +19,7 @@
 | 2 | 60/90-day memory ranking (`src/lib/dog-brain/memory-ranking.ts`) | **DONE (iter 2)** | Pure module + 13 tests; wired in dog-brain-context.ts; severity stays dominant (urgency-safe). |
 | 3 | Privacy-safe analytics (`src/lib/dog-brain/analytics.ts`) | **MODULE DONE (iter 3)** | 8 events + builders + tests over existing App Insights sink; call-site wiring is next. |
 | 4 | Live E2E workflow (`.github/workflows/dog-brain-live-e2e.yml`) | **NOT BUILT** | File absent. |
-| 5 | Supabase migration-ledger verify (`dog_brain_supplement_trials`) | **UNVERIFIED** | Needs live check / runbook. |
+| 5 | Supabase migration-ledger verify (`dog_brain_supplement_trials`) | **RUNBOOK (iter 4)** | STOP: MCP bound to wrong project (JobsearchAi, not PawVital). Runbook written with exact verify + repair commands + Node pg one-off. Live verify deferred to operator with correct creds. |
 | 6 | UX polish across tabs | **NOT STARTED** | — |
 | 8 | Clinical knowledge layer (`src/lib/clinical/knowledge-base.ts`, root-cause, supplement-guardrails) | **NOT BUILT** | Files absent. |
 
@@ -49,3 +49,10 @@
 - **Failed:** nothing.
 - **Next action:** wire emitters at safe call-sites — `brain_context_loaded` in `dog-brain-context.ts`, follow-up/supplement lifecycle emits, and `question_trace`/`emergency_suppressed` in the symptom-chat route (trace-only, with route tests). Then Phase 5 migration-ledger verify (Supabase MCP available).
 - **Stop/defer:** route trace wiring deliberately separated into its own route-test-gated commit. No stop conditions hit.
+
+### Iteration 4 — 2026-06-23 (Phase 5 migration-ledger runbook — STOP hit, handled)
+- **Changed:** added `docs/runbooks/supabase-migration-ledger-repair.md` (exact read-only verify SQL, Node `pg` one-off for this host, CLI `migration repair` path, evidence checklist).
+- **Verified:** Supabase MCP `list_projects` returns ONLY `oripsqtuvyvhdhcnkgbz` ("JobsearchAi") — NOT PawVital `aammaxdsjhezmbvdkqee`. Confirmed target migration `supabase/migrations/20260622000000_dog_brain_supplement_trials.sql` is idempotent (IF NOT EXISTS table/columns/indexes, DROP/CREATE policy) with RLS + 3 indexes + owner-only policy in its DDL.
+- **Failed / STOP:** live DB verification — **STOP CONDITION "Supabase project is wrong"**. Did NOT run anything against the wrong project. Followed Phase 5's prescribed fallback (write runbook). psql/CLI absent + stale env passwords (per memory) compound this; needs operator with current PawVital creds.
+- **Next action:** Phase 4 — `.github/workflows/dog-brain-live-e2e.yml` (manual, env-gated) + e2e script skeleton; then Phase 3b route trace wiring with route tests; then Phase 8 clinical knowledge layer.
+- **Stop/defer:** Phase 5 live verify deferred to operator (documented, not faked). No full-loop stop — other phases proceed.

--- a/docs/dog-brain/INVESTOR_DEMO_HARDENING_STATE.md
+++ b/docs/dog-brain/INVESTOR_DEMO_HARDENING_STATE.md
@@ -17,7 +17,7 @@
 |-------|-------|--------|----------|
 | 1 | Selector trace from selected source | **ALREADY LANDED** | PR #710 `fd3cd14`: selector reports branch (complaint/brain/fallback); `deriveBrainQuestionTrace` no longer re-derives; repeat-avoidance trace gap fixed; tests added. |
 | 2 | 60/90-day memory ranking (`src/lib/dog-brain/memory-ranking.ts`) | **DONE (iter 2)** | Pure module + 13 tests; wired in dog-brain-context.ts; severity stays dominant (urgency-safe). |
-| 3 | Privacy-safe analytics (`src/lib/dog-brain/analytics.ts`) | **MODULE DONE (iter 3)** | 8 events + builders + tests over existing App Insights sink; call-site wiring is next. |
+| 3 | Privacy-safe analytics (`src/lib/dog-brain/analytics.ts`) | **MODULE + LIFECYCLE WIRING DONE (iter 3,6)** | 8 events + 21 tests; lifecycle emitters wired into followups POST + followups/[id] PATCH + supplements POST/PATCH (5 points) with a 6-test wiring suite. `brain_context_loaded` + route trace/emergency emits in symptom-chat route still pending (higher-risk). |
 | 4 | Live E2E workflow (`.github/workflows/dog-brain-live-e2e.yml`) | **HARNESS DONE (iter 5)** | Manual workflow_dispatch + env-gated `tests/e2e/dog-brain-live-e2e.ts` (seed→memory-question poll→emergency-suppression→cleanup→0-residual). Typechecks+lints; NOT yet executed live (needs operator secrets). |
 | 5 | Supabase migration-ledger verify (`dog_brain_supplement_trials`) | **RUNBOOK (iter 4)** | STOP: MCP bound to wrong project (JobsearchAi, not PawVital). Runbook written with exact verify + repair commands + Node pg one-off. Live verify deferred to operator with correct creds. |
 | 6 | UX polish across tabs | **NOT STARTED** | — |
@@ -63,3 +63,10 @@
 - **Failed:** NOT executed against a live deployment — no E2E secrets / sandbox project in this environment, and running it would create prod rows (cleanup-residual is a STOP condition). First run is an operator action via the workflow with the `dog-brain-e2e` environment secrets.
 - **Next action:** Phase 3b route trace wiring (analytics emitters) with route tests; then Phase 8 curated clinical knowledge layer; then Phase 6 UX polish.
 - **Stop/defer:** live E2E execution deferred to operator (honest skeleton, typecheck-validated). No full-loop stop.
+
+### Iteration 6 — 2026-06-23 (Phase 3b lifecycle emitter wiring)
+- **Changed:** wired privacy-safe analytics emitters (fire-and-forget `void recordDogBrainEvent(...)`) into the CRUD routes where lifecycle events naturally occur — `dog_brain_followup_created` (followups POST, 201 only), `dog_brain_followup_outcome_recorded` (followups/[id] PATCH), `supplement_trial_started` (supplements POST, 201), `supplement_trial_marked_active` + `supplement_trial_outcome_recorded` (supplements PATCH). Added `tests/dog-brain-analytics-wiring.test.ts` (6 tests, real builders + spied sink).
+- **Verified:** typecheck clean; eslint clean on changed files; **105 suites / 2365 tests pass** (no regression). Tests prove each route emits the correct event on genuine success and stays SILENT on dedup. Emitters are no-op without App Insights and never throw; they carry only counts/enums (no prompt/notes/supplement-name).
+- **Failed:** nothing.
+- **Next action:** Phase 8 — curated deterministic `src/lib/clinical/{knowledge-base,clinical-patterns,root-cause-hypotheses,supplement-guardrails}.ts` (evidence-linked, ask-vet framing, NO dosage/brand/price/diagnosis) + tests. Then the higher-risk symptom-chat route trace/context emits with route tests. Then Phase 6 UX polish.
+- **Stop/defer:** `brain_context_loaded` + route trace emits intentionally deferred (giant route, multiple emergency early-returns → needs careful flag threading + route tests). No stop conditions hit.

--- a/docs/dog-brain/INVESTOR_DEMO_HARDENING_STATE.md
+++ b/docs/dog-brain/INVESTOR_DEMO_HARDENING_STATE.md
@@ -77,3 +77,10 @@
 - **Failed:** nothing.
 - **Next action:** wire the knowledge layer + the deferred analytics trace/context emits into the symptom-chat route (with route tests, minding emergency early-returns); then Phase 6 UX polish; then /thermo-review + open the PR.
 - **Stop/defer:** route/UI wiring of the knowledge layer is a follow-up (modules are tested infra, like the analytics module). No stop conditions hit.
+
+### Iteration 8 — 2026-06-23 (Phase 3c symptom-chat route analytics wiring)
+- **Changed:** wired the two clean single-site Dog Brain analytics emits into `src/app/api/ai/symptom-chat/route.ts` — `brain_context_loaded` (set a count flag where Dog Brain context loads) and `brain_question_trace.emitted` (set a flag where `brainQuestionTrace` is computed), both emitted once in the EXISTING deferred `runAfterSafely(after())` telemetry block. Added `trackEvent` to the route test's telemetry mock so the inline-run deferred block doesn't throw.
+- **Verified:** typecheck clean; eslint 0 errors (6 pre-existing warnings, none new); symptom-chat route tests **11 suites / 624 pass**; full targeted **106 suites / 2382 pass** (no regression). TRACE/TELEMETRY ONLY — no clinical decision, no payload shape, no emergency early-return touched; flags only flow into the deferred block.
+- **Failed:** nothing. `emergency_question_trace_suppressed` intentionally NOT wired — it would require touching 3+ emergency early-return sites (the "churns the giant file" risk the brief says to STOP on); the emergency path already returns no trace, so this is a missing telemetry event only, not a behavior gap.
+- **Next action:** Phase 6 UX polish (Playwright screenshots from the NTFS dev server; document if demo-mode loading stall blocks it), then `/thermo-review`, push, PR, final handoff.
+- **Stop/defer:** emergency-suppressed emit deferred (multi-site risk). No stop conditions hit.

--- a/docs/dog-brain/INVESTOR_DEMO_HARDENING_STATE.md
+++ b/docs/dog-brain/INVESTOR_DEMO_HARDENING_STATE.md
@@ -17,7 +17,7 @@
 |-------|-------|--------|----------|
 | 1 | Selector trace from selected source | **ALREADY LANDED** | PR #710 `fd3cd14`: selector reports branch (complaint/brain/fallback); `deriveBrainQuestionTrace` no longer re-derives; repeat-avoidance trace gap fixed; tests added. |
 | 2 | 60/90-day memory ranking (`src/lib/dog-brain/memory-ranking.ts`) | **DONE (iter 2)** | Pure module + 13 tests; wired in dog-brain-context.ts; severity stays dominant (urgency-safe). |
-| 3 | Privacy-safe analytics (`src/lib/dog-brain/analytics.ts`) | **NOT BUILT** | File absent. |
+| 3 | Privacy-safe analytics (`src/lib/dog-brain/analytics.ts`) | **MODULE DONE (iter 3)** | 8 events + builders + tests over existing App Insights sink; call-site wiring is next. |
 | 4 | Live E2E workflow (`.github/workflows/dog-brain-live-e2e.yml`) | **NOT BUILT** | File absent. |
 | 5 | Supabase migration-ledger verify (`dog_brain_supplement_trials`) | **UNVERIFIED** | Needs live check / runbook. |
 | 6 | UX polish across tabs | **NOT STARTED** | — |
@@ -42,3 +42,10 @@
 - **Failed:** nothing.
 - **Next action:** Phase 3 — `src/lib/dog-brain/analytics.ts` privacy-safe event layer (no free-text / raw symptom / photo) + tests.
 - **Stop/defer:** build still deferred to NTFS/Vercel. No stop conditions hit.
+
+### Iteration 3 — 2026-06-23 (Phase 3 analytics module)
+- **Changed:** extended `src/lib/azure/telemetry.ts` allow-lists with 8 `dogbrain.*` `SafeEventName`s + 2 enum `SafePropertyKey`s (`questionSource`, `outcomeBucket`); added `src/lib/dog-brain/analytics.ts` (pure event builders + `toOutcomeBucket` coercion + `recordDogBrainEvent` over the existing App Insights sink); added `tests/dog-brain-analytics.test.ts` (21 tests).
+- **Verified:** typecheck clean; eslint clean on changed files; **34 tests pass** (21 new analytics + 13 existing azure-telemetry, no regression). Privacy proven: builder params are enums/numbers only (free text structurally impossible); test asserts property keys ⊆ {questionSource, outcomeBucket}, measurements are non-negative ints, and the serialized envelope contains none of symptom/ownername/petname/notes/photo. Demo-mode = silent no-op.
+- **Failed:** nothing.
+- **Next action:** wire emitters at safe call-sites — `brain_context_loaded` in `dog-brain-context.ts`, follow-up/supplement lifecycle emits, and `question_trace`/`emergency_suppressed` in the symptom-chat route (trace-only, with route tests). Then Phase 5 migration-ledger verify (Supabase MCP available).
+- **Stop/defer:** route trace wiring deliberately separated into its own route-test-gated commit. No stop conditions hit.

--- a/docs/dog-brain/INVESTOR_DEMO_HARDENING_STATE.md
+++ b/docs/dog-brain/INVESTOR_DEMO_HARDENING_STATE.md
@@ -1,0 +1,44 @@
+# Investor Demo Hardening — Closed Loop State
+
+> Single source of truth for the investor-demo hardening loop. Updated every iteration.
+> Branch: `codex/investor-demo-hardening` · Worktree: `C:\pv-hardening` (NTFS, build/test capable)
+> Main worktree `G:\MY Website\pawvital-ai` is exFAT — typecheck/eslint/test only, **no build**.
+
+## Baseline (Iteration 1 — 2026-06-23)
+
+- **Current commit:** `bba69b0` (origin/master tip) — Merge PR #710.
+- **master contains PR #709 or newer:** YES. master tip is **#710** (`fd3cd14`).
+  - #706 vet-safe supplement schema, #707 lifecycle safety hotfix, #708 onboarding test drift,
+    #709 memory-trace ("explain memory behind symptom questions"), #710 selector-source trace.
+
+### Phase status read from code (verified, not assumed)
+
+| Phase | Scope | Status | Evidence |
+|-------|-------|--------|----------|
+| 1 | Selector trace from selected source | **ALREADY LANDED** | PR #710 `fd3cd14`: selector reports branch (complaint/brain/fallback); `deriveBrainQuestionTrace` no longer re-derives; repeat-avoidance trace gap fixed; tests added. |
+| 2 | 60/90-day memory ranking (`src/lib/dog-brain/memory-ranking.ts`) | **DONE (iter 2)** | Pure module + 13 tests; wired in dog-brain-context.ts; severity stays dominant (urgency-safe). |
+| 3 | Privacy-safe analytics (`src/lib/dog-brain/analytics.ts`) | **NOT BUILT** | File absent. |
+| 4 | Live E2E workflow (`.github/workflows/dog-brain-live-e2e.yml`) | **NOT BUILT** | File absent. |
+| 5 | Supabase migration-ledger verify (`dog_brain_supplement_trials`) | **UNVERIFIED** | Needs live check / runbook. |
+| 6 | UX polish across tabs | **NOT STARTED** | — |
+| 8 | Clinical knowledge layer (`src/lib/clinical/knowledge-base.ts`, root-cause, supplement-guardrails) | **NOT BUILT** | Files absent. |
+
+### Do-not-touch (clinical determinism)
+- `src/lib/triage-engine.ts`, `src/lib/clinical-matrix.ts`, `src/lib/symptom-memory.ts`
+- `src/app/api/ai/symptom-chat/route.ts`: trace-wiring only, never clinical decisions.
+
+## Iteration log
+
+### Iteration 1 — 2026-06-23 (setup + verification)
+- **Changed:** created NTFS worktree `C:\pv-hardening` on branch `codex/investor-demo-hardening` off `origin/master`; started `npm install`; wrote this state doc.
+- **Verified:** master tip = #710; Phase 1 already landed (won't redo); Phases 2/3/4/8 files genuinely absent; `src/` clean in main worktree (only unrelated `plans/*.json` + `tmp/*.json` dirty from concurrent agents).
+- **Failed:** nothing yet (baseline typecheck/test pending install completion).
+- **Next action:** establish typecheck + targeted-test baseline, then implement **Phase 2 memory-ranking** as first commit (pure module, no clinical-logic change, test-backed).
+- **Stop/defer:** build deferred to NTFS/Vercel (G: exFAT). No stop conditions hit.
+
+### Iteration 2 — 2026-06-23 (baseline + Phase 2 memory-ranking)
+- **Changed:** added `src/lib/dog-brain/memory-ranking.ts` (pure ranking module); exported `BRAIN_SIGNAL_SYMPTOM_KEYS` from `question-priority.ts` (single source of truth); wired `rankDetectedSignals` into `dog-brain-context.ts` (reuses already-fetched follow-ups, supplement trials, vet-record text — no extra Supabase query); added `tests/dog-brain-memory-ranking.test.ts` (13 tests).
+- **Verified:** baseline before change = typecheck clean + **102 suites / 2329 tests pass**. After change = typecheck clean, eslint clean on changed files, **103 suites / 2342 tests pass** (+13, zero regressions). Urgency-safety proven by tests: severity tier gap (500) > sum of all other terms (≤128), benign/info can never outrank alert, input never mutated, score is a number not an urgency.
+- **Failed:** nothing.
+- **Next action:** Phase 3 — `src/lib/dog-brain/analytics.ts` privacy-safe event layer (no free-text / raw symptom / photo) + tests.
+- **Stop/defer:** build still deferred to NTFS/Vercel. No stop conditions hit.

--- a/docs/dog-brain/INVESTOR_DEMO_HARDENING_STATE.md
+++ b/docs/dog-brain/INVESTOR_DEMO_HARDENING_STATE.md
@@ -21,7 +21,7 @@
 | 4 | Live E2E workflow (`.github/workflows/dog-brain-live-e2e.yml`) | **HARNESS DONE (iter 5)** | Manual workflow_dispatch + env-gated `tests/e2e/dog-brain-live-e2e.ts` (seed→memory-question poll→emergency-suppression→cleanup→0-residual). Typechecks+lints; NOT yet executed live (needs operator secrets). |
 | 5 | Supabase migration-ledger verify (`dog_brain_supplement_trials`) | **RUNBOOK (iter 4)** | STOP: MCP bound to wrong project (JobsearchAi, not PawVital). Runbook written with exact verify + repair commands + Node pg one-off. Live verify deferred to operator with correct creds. |
 | 6 | UX polish across tabs | **NOT STARTED** | — |
-| 8 | Clinical knowledge layer (`src/lib/clinical/knowledge-base.ts`, root-cause, supplement-guardrails) | **NOT BUILT** | Files absent. |
+| 8 | Clinical knowledge layer (`src/lib/clinical/knowledge-base.ts`, root-cause, supplement-guardrails) | **MODULES DONE (iter 7)** | 4 pure deterministic modules + 17 tests (all 8 domains, evidence-gated hypotheses, hard-fail supplement guardrails). NON-AUTHORITATIVE floor — does not touch triage urgency. Route/UI wiring is follow-up. |
 
 ### Do-not-touch (clinical determinism)
 - `src/lib/triage-engine.ts`, `src/lib/clinical-matrix.ts`, `src/lib/symptom-memory.ts`
@@ -70,3 +70,10 @@
 - **Failed:** nothing.
 - **Next action:** Phase 8 — curated deterministic `src/lib/clinical/{knowledge-base,clinical-patterns,root-cause-hypotheses,supplement-guardrails}.ts` (evidence-linked, ask-vet framing, NO dosage/brand/price/diagnosis) + tests. Then the higher-risk symptom-chat route trace/context emits with route tests. Then Phase 6 UX polish.
 - **Stop/defer:** `brain_context_loaded` + route trace emits intentionally deferred (giant route, multiple emergency early-returns → needs careful flag threading + route tests). No stop conditions hit.
+
+### Iteration 7 — 2026-06-23 (Phase 8 clinical knowledge layer)
+- **Changed:** added 4 pure deterministic modules — `src/lib/clinical/knowledge-base.ts` (8 domains: gi/urinary/skin_ear/respiratory/mobility/senior/medication_supplement/toxin_exposure, each with trigger_signal_keys, owner_observable_questions, NON-AUTHORITATIVE urgency_floor, missing_information, vet_handoff_points, disallowed_outputs, source_refs); `clinical-patterns.ts` (cluster matcher with min-signal thresholds); `root-cause-hypotheses.ts` (non-diagnostic, evidence-gated — no evidence → no hypothesis); `supplement-guardrails.ts` (SupplementSuggestion contract + hard-fail validator for dosage/brand/price/disease-claim/no-evidence + evidence-gated builder). Added `tests/clinical-knowledge-layer.test.ts` (17 tests).
+- **Verified:** typecheck clean; eslint clean; **106 suites / 2382 tests pass** (+17, no regression). Safety proven: a string-scan test asserts NO dosage/price/brand/disease-claim across all curated content; hypotheses never expose disease names and require dog-specific evidence; the builder's own output always passes the guardrails; the owner-facing floor is explicitly separate from triage urgency (`triage-engine`/`clinical-matrix` untouched).
+- **Failed:** nothing.
+- **Next action:** wire the knowledge layer + the deferred analytics trace/context emits into the symptom-chat route (with route tests, minding emergency early-returns); then Phase 6 UX polish; then /thermo-review + open the PR.
+- **Stop/defer:** route/UI wiring of the knowledge layer is a follow-up (modules are tested infra, like the analytics module). No stop conditions hit.

--- a/docs/runbooks/supabase-migration-ledger-repair.md
+++ b/docs/runbooks/supabase-migration-ledger-repair.md
@@ -1,0 +1,142 @@
+# Runbook — Supabase migration-ledger verify & repair (`dog_brain_supplement_trials`)
+
+> Phase 5 of the investor-demo hardening loop. Verifies the Dog Brain supplement
+> persistence backbone and repairs the migration ledger **without hand-editing it**.
+> Do NOT fake completion — fill the Evidence section with real query output.
+
+## Why this is a runbook, not an automated step
+
+The Supabase MCP available in this session is bound to the **wrong account/project**:
+
+- MCP `list_projects` returns exactly one project: `oripsqtuvyvhdhcnkgbz` ("JobsearchAi", us-west-2).
+- The PawVital project is **`aammaxdsjhezmbvdkqee`** (see workspace memory `supabase-new-project`).
+- Therefore the MCP **cannot reach** the PawVital database, and running anything
+  against `oripsqtuvyvhdhcnkgbz` would touch an unrelated project. This is the
+  declared loop **STOP condition "Supabase project is wrong"** — verification is
+  deferred to an operator with the correct project link/credentials.
+
+Additional environment facts (workspace memory):
+- `supabase` CLI / `psql` are **not installed** on this machine.
+- The `.env*` DB passwords are **stale** after the project migration; the current
+  password must be supplied by the project owner at run time.
+- The historically-working method here is a **Node `pg` one-off** (below).
+
+## Target migration
+
+- File: `supabase/migrations/20260622000000_dog_brain_supplement_trials.sql`
+- Version token (14-digit, Supabase convention): **`20260622000000`**
+- The DDL is fully idempotent (`CREATE TABLE IF NOT EXISTS`, `ADD COLUMN IF NOT
+  EXISTS`, `DROP/CREATE POLICY`, `CREATE … INDEX IF NOT EXISTS`), so re-applying
+  it is safe.
+
+## Success criteria
+
+1. Table `public.dog_brain_supplement_trials` exists with the lifecycle columns
+   (`status`, `outcome`, `outcome_at`, `follow_up_due_at`, …).
+2. Indexes exist: `uniq_supplement_trial_open` (partial unique),
+   `idx_dog_brain_supplement_trials_user_pet`, `idx_dog_brain_supplement_trials_due`.
+3. RLS is **enabled** and policy `dog_brain_supplement_trials_owner_all` exists.
+4. `supabase_migrations.schema_migrations` contains version `20260622000000`.
+
+---
+
+## Step 1 — Verify (read-only). Run against project `aammaxdsjhezmbvdkqee`.
+
+Connect with the **current** PawVital DB credentials, then run:
+
+```sql
+-- 1. Table + columns
+SELECT column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE table_schema = 'public' AND table_name = 'dog_brain_supplement_trials'
+ORDER BY ordinal_position;
+
+-- 2. Indexes
+SELECT indexname, indexdef
+FROM pg_indexes
+WHERE schemaname = 'public' AND tablename = 'dog_brain_supplement_trials'
+ORDER BY indexname;
+
+-- 3. RLS enabled + policies
+SELECT relrowsecurity AS rls_enabled
+FROM pg_class
+WHERE oid = 'public.dog_brain_supplement_trials'::regclass;
+
+SELECT polname, cmd
+FROM pg_policies
+WHERE schemaname = 'public' AND tablename = 'dog_brain_supplement_trials';
+
+-- 4. Migration ledger
+SELECT version
+FROM supabase_migrations.schema_migrations
+WHERE version IN ('20260622000000', '20260622000100', '20260618')
+ORDER BY version;
+```
+
+### Node `pg` one-off (no psql/CLI required — the method that works on this host)
+
+```bash
+# From C:\pv-hardening (NTFS worktree). PGURI must be the CURRENT pooled or direct
+# connection string for project aammaxdsjhezmbvdkqee — ask the project owner; the
+# committed .env passwords are stale.
+PGURI='postgresql://postgres:<CURRENT_PW>@db.aammaxdsjhezmbvdkqee.supabase.co:5432/postgres' \
+node -e '
+const { Client } = require("pg");
+(async () => {
+  const c = new Client({ connectionString: process.env.PGURI, ssl: { rejectUnauthorized: false } });
+  await c.connect();
+  const q = async (label, sql) => { const r = await c.query(sql); console.log("\n== " + label + " =="); console.table(r.rows); };
+  await q("columns", "select column_name,data_type,is_nullable from information_schema.columns where table_schema=\047public\047 and table_name=\047dog_brain_supplement_trials\047 order by ordinal_position");
+  await q("indexes", "select indexname from pg_indexes where schemaname=\047public\047 and tablename=\047dog_brain_supplement_trials\047 order by indexname");
+  await q("rls", "select relrowsecurity as rls_enabled from pg_class where oid=\047public.dog_brain_supplement_trials\047::regclass");
+  await q("policies", "select polname,cmd from pg_policies where schemaname=\047public\047 and tablename=\047dog_brain_supplement_trials\047");
+  await q("ledger", "select version from supabase_migrations.schema_migrations where version in (\04720260622000000\047,\04720260622000100\047,\04720260618\047) order by version");
+  await c.end();
+})().catch(e => { console.error(e); process.exit(1); });
+'
+```
+
+## Step 2 — If the table is present but the ledger row is missing
+
+The table was applied out-of-band (the idempotent DDL was run directly), so the
+DB is correct but `schema_migrations` lacks the row. **Do not** `INSERT` into the
+ledger by hand. Use the CLI repair (requires `supabase` CLI + project link):
+
+```bash
+supabase link --project-ref aammaxdsjhezmbvdkqee     # one-time, needs DB password
+supabase migration list                              # shows local vs remote ledger
+supabase migration repair --status applied 20260622000000
+supabase migration repair --status applied 20260622000100   # supplements.notes
+supabase migration list                              # confirm both now "applied" remote
+```
+
+If the CLI is unavailable, install it (`npm i -g supabase` or scoop/brew) on an
+NTFS/WSL host — do not attempt from the `G:` exFAT mount.
+
+## Step 3 — If the table is MISSING entirely
+
+Apply the idempotent migration, then repair the ledger:
+
+```bash
+supabase db push        # applies pending migrations to the linked remote
+# OR, without CLI, run the file via the Node pg one-off, then Step 2 repair.
+```
+
+## STOP / escalation
+
+- If `link`/`repair` asks for a password you don't have → **stop**, ask the owner.
+- If repair reports a permission error → **stop**, needs project-admin.
+- Never run any of the above against `oripsqtuvyvhdhcnkgbz` (JobsearchAi).
+
+## Evidence (fill with real output — do not leave blank to claim "done")
+
+- [ ] Verified on project: `aammaxdsjhezmbvdkqee` at `<UTC timestamp>`
+- [ ] Table + columns: `<paste>`
+- [ ] Indexes (3 expected): `<paste>`
+- [ ] RLS enabled = `true`; policy `dog_brain_supplement_trials_owner_all` present: `<paste>`
+- [ ] `schema_migrations` contains `20260622000000`: `<yes/no>` → repaired? `<yes/no>`
+
+### Prior evidence (workspace memory, not re-verified this iteration)
+Memory `pawvital-pr702-supplement-loop` records the migration was **APPLIED +
+verified** on `aammaxdsjhezmbvdkqee` via a Node `pg` one-off during the #702/#706
+work. This runbook makes that check **repeatable** and adds the ledger-repair path.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "typecheck": "tsc --noEmit",
     "test": "jest --verbose",
     "test:watch": "jest --watch",
+    "e2e:dog-brain": "npx ts-node --esm tests/e2e/dog-brain-live-e2e.ts",
     "smoke:private-tester": "node scripts/private-tester-smoke.mjs production",
     "smoke:private-tester:access": "node scripts/private-tester-smoke.mjs tester-access",
     "smoke:private-tester:emergency-bypass": "node scripts/private-tester-smoke.mjs emergency-bypass",

--- a/src/app/api/ai/symptom-chat/route.ts
+++ b/src/app/api/ai/symptom-chat/route.ts
@@ -165,6 +165,11 @@ import {
 } from "@/lib/health-log/dog-brain-context";
 import type { BrainSymptomEvidence } from "@/lib/dog-brain/question-priority";
 import {
+  recordDogBrainEvent,
+  brainContextLoadedEvent,
+  brainQuestionTraceEmittedEvent,
+} from "@/lib/dog-brain/analytics";
+import {
   isAsyncWorkerReplay,
   maybeOffloadSymptomChatTurn,
 } from "@/lib/symptom-chat/async-turn-offload";
@@ -801,6 +806,10 @@ export async function POST(request: Request) {
   };
   let statusCode = 200;
   let errorCode: string | undefined;
+  // Privacy-safe Dog Brain analytics flags — set on the main path, emitted once
+  // in the deferred telemetry block below. Never affect the response/payload.
+  let brainContextPrioritySymptomCount: number | null = null;
+  let brainTraceWasEmitted = false;
   let liveUpdateTarget: LiveUpdateTarget | null = null;
   let liveUpdateChain: Promise<void> = Promise.resolve();
   const queueTriageLiveUpdate = (
@@ -1005,6 +1014,8 @@ export async function POST(request: Request) {
         }
         brainPrioritySymptoms = prioritySymptoms;
         brainPrioritySymptomEvidence = prioritySymptomEvidence;
+        // Brain memory was consulted this turn (count only — never the content).
+        brainContextPrioritySymptomCount = prioritySymptoms.length;
       } catch {
         /* best-effort — Brain memory must never block the clinical turn */
       }
@@ -2488,6 +2499,8 @@ export async function POST(request: Request) {
       effectiveQuestionId === nextQuestionId
         ? nextQuestionState.brainQuestionTrace
         : null;
+    // The surfaced question is Brain-memory-driven this turn (telemetry flag only).
+    brainTraceWasEmitted = brainQuestionTrace !== null;
     const promptVetRecord = shouldPromptVetRecordUpload(
       session,
       effectiveQuestionId
@@ -2555,6 +2568,20 @@ export async function POST(request: Request) {
       });
       if (errorCode) {
         await trackException(errorCode, { routeName: ROUTE_NAME });
+      }
+      // Privacy-safe Dog Brain usage events (counts/enums only). Deferred so they
+      // never add latency to the response; no-op without App Insights.
+      if (brainContextPrioritySymptomCount !== null) {
+        await recordDogBrainEvent(
+          brainContextLoadedEvent({
+            prioritySymptomCount: brainContextPrioritySymptomCount,
+          }),
+        );
+      }
+      if (brainTraceWasEmitted) {
+        await recordDogBrainEvent(
+          brainQuestionTraceEmittedEvent({ source: "brain_memory", evidenceCount: 1 }),
+        );
       }
     });
     await queueTriageLiveUpdate(

--- a/src/app/api/dog-brain/followups/[id]/route.ts
+++ b/src/app/api/dog-brain/followups/[id]/route.ts
@@ -7,6 +7,11 @@ import {
   generalApiLimiter,
   getRateLimitId,
 } from "@/lib/rate-limit";
+import {
+  recordDogBrainEvent,
+  dogBrainFollowupOutcomeRecordedEvent,
+  toOutcomeBucket,
+} from "@/lib/dog-brain/analytics";
 
 const ParamsSchema = z.object({ id: z.string().uuid() });
 const PatchSchema = z.object({
@@ -61,6 +66,12 @@ export async function PATCH(
       throw error;
     }
     if (!data) return NextResponse.json({ error: "Not found" }, { status: 404 });
+    // Privacy-safe outcome bucket only (better/same/worse/unknown) — no notes.
+    void recordDogBrainEvent(
+      dogBrainFollowupOutcomeRecordedEvent({
+        outcome: toOutcomeBucket(parsed.data.status),
+      }),
+    );
     return NextResponse.json({ data });
   } catch (error) {
     console.error("[DogBrainFollowups] PATCH failed:", error);

--- a/src/app/api/dog-brain/followups/route.ts
+++ b/src/app/api/dog-brain/followups/route.ts
@@ -8,6 +8,10 @@ import {
   generalApiLimiter,
   getRateLimitId,
 } from "@/lib/rate-limit";
+import {
+  recordDogBrainEvent,
+  dogBrainFollowupCreatedEvent,
+} from "@/lib/dog-brain/analytics";
 
 // Durable Dog Brain follow-up queue: when a watch/alert pattern appears, a
 // follow-up is scheduled ("3 days since stool changed — better or worse?") and
@@ -135,6 +139,9 @@ export async function POST(request: Request) {
       }
       throw error;
     }
+    // Privacy-safe usage event only (a count) — never the prompt text. Fire-and-
+    // forget; recordDogBrainEvent is a no-op without App Insights and never throws.
+    void recordDogBrainEvent(dogBrainFollowupCreatedEvent());
     return NextResponse.json({ data }, { status: 201 });
   } catch (error) {
     console.error("[DogBrainFollowups] POST failed:", error);

--- a/src/app/api/dog-brain/supplements/route.ts
+++ b/src/app/api/dog-brain/supplements/route.ts
@@ -3,6 +3,13 @@ import { z } from "zod";
 import { requireAuthenticatedApiUser } from "@/lib/api-auth";
 import { requireOwnedPet } from "@/lib/api/pet-guard";
 import { isMissingTable } from "@/lib/api/table-missing";
+import {
+  recordDogBrainEvent,
+  supplementTrialStartedEvent,
+  supplementTrialMarkedActiveEvent,
+  supplementTrialOutcomeRecordedEvent,
+  toOutcomeBucket,
+} from "@/lib/dog-brain/analytics";
 
 const StartSchema = z.object({
   pet_id: z.string().uuid(),
@@ -132,6 +139,8 @@ export async function POST(request: Request) {
       }
       throw error;
     }
+    // Privacy-safe lifecycle event (a count) — never the supplement name/notes.
+    void recordDogBrainEvent(supplementTrialStartedEvent());
     return NextResponse.json({ data }, { status: 201 });
   } catch (e) {
     console.error("[DogBrainSupplements] POST error", e);
@@ -185,6 +194,7 @@ export async function PATCH(request: Request) {
           { status: 409 },
         );
       }
+      void recordDogBrainEvent(supplementTrialMarkedActiveEvent());
       return NextResponse.json({ data });
     }
 
@@ -221,6 +231,12 @@ export async function PATCH(request: Request) {
     // Zero rows matched: status is ask_vet (vet approval not done), outcome_recorded,
     // stopped, not owned, or missing. Refuse with 409 — never silently 200/500.
     if (!data) return NextResponse.json({ error: "Not found, not owned, or not in an active trial" }, { status: 409 });
+    // Privacy-safe outcome bucket only (better/same/worse/side_effect) — no notes.
+    void recordDogBrainEvent(
+      supplementTrialOutcomeRecordedEvent({
+        outcome: toOutcomeBucket(outcomeData.outcome),
+      }),
+    );
     return NextResponse.json({ data });
   } catch (e) {
     console.error("[DogBrainSupplements] PATCH error", e);

--- a/src/lib/azure/telemetry.ts
+++ b/src/lib/azure/telemetry.ts
@@ -28,7 +28,17 @@ export type SafeEventName =
   | "ai.model.called"
   | "sidecar.health.checked"
   | "azure.service.called"
-  | "feature.flag.checked";
+  | "feature.flag.checked"
+  // Dog Brain loop usage — counts/enums only, never owner notes or raw symptom
+  // text. Emitted via src/lib/dog-brain/analytics.ts.
+  | "dogbrain.context.loaded"
+  | "dogbrain.question_trace.emitted"
+  | "dogbrain.question_trace.emergency_suppressed"
+  | "dogbrain.followup.created"
+  | "dogbrain.followup.outcome_recorded"
+  | "dogbrain.supplement_trial.started"
+  | "dogbrain.supplement_trial.marked_active"
+  | "dogbrain.supplement_trial.outcome_recorded";
 
 // ---------------------------------------------------------------------------
 // Allow-listed property keys — PII boundary enforced at the type level.
@@ -49,7 +59,10 @@ export type SafePropertyKey =
   | "azureService"
   | "sessionId" // opaque ID only — never an owner or user identifier
   | "errorCode"
-  | "demoMode";
+  | "demoMode"
+  // Dog Brain enum dimensions — bounded vocabularies only (see analytics.ts).
+  | "questionSource" // complaint | brain_memory | pending_clarification | emergency | generic
+  | "outcomeBucket"; // better | same | worse | side_effect | unknown
 
 export type SafeProperties = Partial<
   Record<SafePropertyKey, string | number | boolean>

--- a/src/lib/clinical/clinical-patterns.ts
+++ b/src/lib/clinical/clinical-patterns.ts
@@ -1,0 +1,125 @@
+import type { SignalType } from "@/lib/dog-brain/types";
+import {
+  URGENCY_FLOOR_RANK,
+  type KnowledgeUrgencyFloor,
+} from "@/lib/clinical/knowledge-base";
+
+// =============================================================================
+// Curated symptom-cluster patterns (DETERMINISTIC, NON-DIAGNOSTIC)
+//
+// Common owner-observable signal associations — e.g. "soft stool + reduced
+// appetite + vomiting" reads as a digestive pattern. These are PATTERNS, not
+// diseases: the labels are everyday phrases, never medical diagnoses.
+//
+// SAFETY CONTRACT:
+//  - `urgency_floor` is the same NON-AUTHORITATIVE owner-facing floor as the
+//    knowledge base — never the triage decision, never lowers a real urgency.
+//  - A pattern matches only when ENOUGH of its member signals are present
+//    (`min_signals`), so a single benign note never fabricates a pattern.
+//  - Pure data + pure matcher. No disease names, no diagnosis.
+// =============================================================================
+
+export interface ClinicalPattern {
+  id: string;
+  /** Everyday, non-diagnostic label (e.g. "digestive pattern"). */
+  label: string;
+  member_signal_keys: SignalType[];
+  /** How many member signals must be present for the pattern to apply. */
+  min_signals: number;
+  owner_summary: string;
+  urgency_floor: KnowledgeUrgencyFloor;
+  disallowed_outputs: string[];
+}
+
+const NEVER_OUTPUT = [
+  "specific disease diagnosis",
+  "medication or supplement dosage",
+  "product brand recommendation",
+];
+
+export const CLINICAL_PATTERNS: readonly ClinicalPattern[] = [
+  {
+    id: "digestive_pattern",
+    label: "digestive pattern",
+    member_signal_keys: ["stool_change", "vomiting_trend", "appetite_drop"],
+    min_signals: 2,
+    owner_summary:
+      "A few digestive signs are showing up together, which is worth a closer look.",
+    urgency_floor: "watch",
+    disallowed_outputs: [...NEVER_OUTPUT],
+  },
+  {
+    id: "hydration_concern",
+    label: "hydration concern",
+    member_signal_keys: ["water_urination_change", "vomiting_trend", "energy_behavior_change"],
+    min_signals: 2,
+    owner_summary:
+      "Signs that can affect hydration are appearing together — keeping water down matters here.",
+    urgency_floor: "call_vet",
+    disallowed_outputs: [...NEVER_OUTPUT],
+  },
+  {
+    id: "appetite_energy_pattern",
+    label: "appetite-energy pattern",
+    member_signal_keys: ["appetite_drop", "energy_behavior_change", "weight_downtrend"],
+    min_signals: 2,
+    owner_summary:
+      "Appetite, energy, and weight changes are tracking together over time.",
+    urgency_floor: "call_vet",
+    disallowed_outputs: [...NEVER_OUTPUT],
+  },
+  {
+    id: "skin_itch_pattern",
+    label: "skin/itch pattern",
+    member_signal_keys: ["skin_ear_change"],
+    min_signals: 1,
+    owner_summary: "A recurring skin or ear irritation is showing up.",
+    urgency_floor: "watch",
+    disallowed_outputs: [...NEVER_OUTPUT],
+  },
+  {
+    id: "mobility_discomfort_pattern",
+    label: "mobility discomfort pattern",
+    member_signal_keys: ["mobility_pain_change"],
+    min_signals: 1,
+    owner_summary: "Signs of stiffness or discomfort when moving are showing up.",
+    urgency_floor: "call_vet",
+    disallowed_outputs: [...NEVER_OUTPUT],
+  },
+  {
+    id: "respiratory_pattern",
+    label: "breathing pattern",
+    member_signal_keys: ["breathing_cough_change"],
+    min_signals: 1,
+    owner_summary: "A cough or breathing change is showing up and is worth watching closely.",
+    urgency_floor: "urgent",
+    disallowed_outputs: [...NEVER_OUTPUT],
+  },
+  {
+    id: "medication_supplement_reaction_possibility",
+    label: "medication/supplement reaction possibility",
+    member_signal_keys: ["possible_med_side_effect"],
+    min_signals: 1,
+    owner_summary:
+      "A recent medication or supplement change lines up with new signs.",
+    urgency_floor: "call_vet",
+    disallowed_outputs: [...NEVER_OUTPUT],
+  },
+];
+
+/**
+ * Patterns whose member signals are present at or above their `min_signals`
+ * threshold, strongest urgency floor first. Pure; empty input → empty output.
+ */
+export function matchClinicalPatterns(
+  presentSignalKeys: SignalType[],
+): ClinicalPattern[] {
+  const present = new Set(presentSignalKeys);
+  return CLINICAL_PATTERNS.filter((p) => {
+    const hits = p.member_signal_keys.filter((k) => present.has(k)).length;
+    return hits >= p.min_signals;
+  }).sort(
+    (a, b) =>
+      URGENCY_FLOOR_RANK[b.urgency_floor] - URGENCY_FLOOR_RANK[a.urgency_floor],
+  );
+}

--- a/src/lib/clinical/knowledge-base.ts
+++ b/src/lib/clinical/knowledge-base.ts
@@ -1,0 +1,289 @@
+import type { SignalType } from "@/lib/dog-brain/types";
+
+// =============================================================================
+// Curated clinical knowledge pack (DETERMINISTIC, NON-AUTHORITATIVE)
+//
+// A small, hand-curated, vet-safe knowledge layer that connects owner-observable
+// Dog Brain signal families to the next useful owner question, the information a
+// vet will want, and an escalation floor. It replaces "let the model freestyle
+// from internet search" with reviewable, deterministic data.
+//
+// HARD SAFETY CONTRACT (must never be violated):
+//  - This is NOT a diagnosis engine and NOT the deterministic triage urgency.
+//    `urgency_floor` here is an owner-facing, question-planning / vet-handoff
+//    framing hint ONLY. The authoritative urgency is "low|moderate|high|
+//    emergency" in triage-engine / clinical-matrix and is never derived from,
+//    overridden by, or lowered by anything in this file.
+//  - No medication/supplement dosages, no brand names, no prices, no disease
+//    certainty, no treatment plans. Every entry lists `disallowed_outputs` to
+//    make that explicit, and a test scans all curated strings for violations.
+//  - Pure data + pure lookups. No runtime I/O, no model calls.
+// =============================================================================
+
+export type ClinicalDomain =
+  | "gi"
+  | "urinary"
+  | "skin_ear"
+  | "respiratory"
+  | "mobility"
+  | "senior"
+  | "medication_supplement"
+  | "toxin_exposure";
+
+/**
+ * Owner-facing escalation floor — NON-AUTHORITATIVE. Used only to order questions
+ * and frame vet-handoff language. NEVER the triage decision and NEVER allowed to
+ * lower a deterministic urgency. Ordered weakest→strongest for comparison.
+ */
+export type KnowledgeUrgencyFloor =
+  | "self_monitor"
+  | "watch"
+  | "call_vet"
+  | "urgent"
+  | "emergency";
+
+export const URGENCY_FLOOR_RANK: Record<KnowledgeUrgencyFloor, number> = {
+  self_monitor: 0,
+  watch: 1,
+  call_vet: 2,
+  urgent: 3,
+  emergency: 4,
+};
+
+/** Vet-discussion supplement categories — never a product recommendation. */
+export type SupplementCategory =
+  | "gut_support"
+  | "skin_coat"
+  | "joint_mobility"
+  | "hydration_support"
+  | "vet_only_discussion";
+
+export interface ClinicalKnowledgeEntry {
+  id: string;
+  domain: ClinicalDomain;
+  /** Dog Brain signal families this entry is relevant to. */
+  trigger_signal_keys: SignalType[];
+  /** Plain, owner-answerable questions (no clinical jargon, no diagnosis). */
+  owner_observable_questions: string[];
+  urgency_floor: KnowledgeUrgencyFloor;
+  /** What the owner should check / that the Brain is still missing. */
+  missing_information: string[];
+  /** What to tell the vet — turns owner observations into a handoff. */
+  vet_handoff_points: string[];
+  /** Only "ask your vet about" framing — never a product. */
+  supplement_discussion_categories?: SupplementCategory[];
+  /** Explicit list of outputs that must never be produced for this entry. */
+  disallowed_outputs: string[];
+  /** Short, citable source labels (curated guidance, not random blogs). */
+  source_refs: string[];
+}
+
+const NEVER_OUTPUT_BASE = [
+  "specific disease diagnosis",
+  "medication or supplement dosage",
+  "product brand recommendation",
+  "any claim a supplement prevents or cures disease",
+];
+
+export const CLINICAL_KNOWLEDGE: readonly ClinicalKnowledgeEntry[] = [
+  {
+    id: "gi-stool-vomit",
+    domain: "gi",
+    trigger_signal_keys: ["stool_change", "vomiting_trend", "appetite_drop"],
+    owner_observable_questions: [
+      "Have you seen blood, or black or tarry stool, today?",
+      "Is your dog able to keep water down?",
+      "Has there been a recent diet change, new treat, or chance of trash or scavenging?",
+      "How many days has the soft stool or vomiting been going on?",
+    ],
+    urgency_floor: "watch",
+    missing_information: [
+      "presence of blood or black/tarry stool",
+      "ability to keep water down (hydration)",
+      "how long symptoms have lasted",
+      "any known diet change or scavenging",
+    ],
+    vet_handoff_points: [
+      "timeline of stool changes and vomiting",
+      "whether the dog can keep water down",
+      "appetite and energy alongside the GI signs",
+    ],
+    supplement_discussion_categories: ["gut_support"],
+    disallowed_outputs: [...NEVER_OUTPUT_BASE],
+    source_refs: ["Cornell CVM — canine diarrhea owner guidance"],
+  },
+  {
+    id: "urinary-frequency-thirst",
+    domain: "urinary",
+    trigger_signal_keys: ["water_urination_change"],
+    owner_observable_questions: [
+      "Is your dog straining or unable to pass urine?",
+      "Have you noticed accidents, increased thirst, or a change in urine color?",
+      "Is your dog drinking much more or much less than usual?",
+    ],
+    urgency_floor: "call_vet",
+    missing_information: [
+      "straining or inability to urinate (this can be an emergency in male dogs)",
+      "changes in thirst or urine color",
+    ],
+    vet_handoff_points: [
+      "any straining or inability to urinate",
+      "changes in thirst and urine appearance",
+    ],
+    disallowed_outputs: [...NEVER_OUTPUT_BASE],
+    source_refs: ["General small-animal urinary owner guidance"],
+  },
+  {
+    id: "skin-ear-itch",
+    domain: "skin_ear",
+    trigger_signal_keys: ["skin_ear_change"],
+    owner_observable_questions: [
+      "Where is the itching or licking focused, and how long has it lasted?",
+      "Is there redness, odor, discharge, or a hot spot you can see?",
+      "Has anything changed recently — food, environment, or grooming?",
+    ],
+    urgency_floor: "watch",
+    missing_information: [
+      "location and duration of itch or licking",
+      "visible redness, odor, or discharge",
+    ],
+    vet_handoff_points: [
+      "where the skin or ear problem is and how long it has lasted",
+      "a clear photo of the affected area if you have one",
+    ],
+    supplement_discussion_categories: ["skin_coat"],
+    disallowed_outputs: [...NEVER_OUTPUT_BASE],
+    source_refs: ["General small-animal dermatology owner guidance"],
+  },
+  {
+    id: "respiratory-cough-breathing",
+    domain: "respiratory",
+    trigger_signal_keys: ["breathing_cough_change"],
+    owner_observable_questions: [
+      "Is your dog struggling to breathe, or are the gums blue or grey?",
+      "Is the cough new, and is it worse with exercise or at night?",
+      "Have you seen any collapse or fainting?",
+    ],
+    urgency_floor: "urgent",
+    missing_information: [
+      "any breathing difficulty or blue/grey gums (emergency signs)",
+      "cough pattern and exercise tolerance",
+    ],
+    vet_handoff_points: [
+      "breathing effort and gum color",
+      "when the cough started and what makes it worse",
+    ],
+    disallowed_outputs: [...NEVER_OUTPUT_BASE],
+    source_refs: ["General small-animal respiratory owner guidance"],
+  },
+  {
+    id: "mobility-pain",
+    domain: "mobility",
+    trigger_signal_keys: ["mobility_pain_change"],
+    owner_observable_questions: [
+      "Which leg or area seems sore, and is your dog bearing weight on it?",
+      "Is the stiffness worse after rest or after exercise?",
+      "Was there a recent injury, fall, or jump?",
+    ],
+    urgency_floor: "call_vet",
+    missing_information: [
+      "which limb is affected and whether the dog will bear weight",
+      "any known injury",
+    ],
+    vet_handoff_points: [
+      "which limb or area, and weight-bearing",
+      "what makes the stiffness better or worse",
+    ],
+    supplement_discussion_categories: ["joint_mobility"],
+    disallowed_outputs: [...NEVER_OUTPUT_BASE],
+    source_refs: ["General small-animal orthopedic owner guidance"],
+  },
+  {
+    id: "senior-decline",
+    domain: "senior",
+    trigger_signal_keys: ["weight_downtrend", "appetite_drop", "energy_behavior_change"],
+    owner_observable_questions: [
+      "Have you noticed weight loss, appetite change, or lower energy over recent weeks?",
+      "Any changes in drinking, urination, or confusion?",
+      "Is your dog sleeping or pacing more than usual?",
+    ],
+    urgency_floor: "call_vet",
+    missing_information: [
+      "trend in weight, appetite, and energy over weeks",
+      "changes in drinking, urination, or behavior",
+    ],
+    vet_handoff_points: [
+      "the multi-week trend in weight, appetite, and energy",
+      "any drinking, urination, or behavior changes",
+    ],
+    disallowed_outputs: [...NEVER_OUTPUT_BASE],
+    source_refs: ["General senior-dog wellness owner guidance"],
+  },
+  {
+    id: "medication-supplement-reaction",
+    domain: "medication_supplement",
+    trigger_signal_keys: ["possible_med_side_effect"],
+    owner_observable_questions: [
+      "Did anything start, stop, or change with a medication or supplement recently?",
+      "Since the change, did things get better, stay the same, or get worse?",
+      "Have you noticed any new signs you think could be a side effect?",
+    ],
+    urgency_floor: "call_vet",
+    missing_information: [
+      "what changed and when",
+      "whether signs improved or worsened after the change",
+    ],
+    vet_handoff_points: [
+      "the medication or supplement change and its timing",
+      "any new signs since the change",
+    ],
+    supplement_discussion_categories: ["vet_only_discussion"],
+    disallowed_outputs: [...NEVER_OUTPUT_BASE],
+    source_refs: ["WSAVA Global Nutrition Guidelines — owner framing"],
+  },
+  {
+    id: "toxin-exposure",
+    domain: "toxin_exposure",
+    trigger_signal_keys: ["vomiting_trend", "energy_behavior_change"],
+    owner_observable_questions: [
+      "Could your dog have eaten something toxic — trash, plants, human medicine, or a sweetener like xylitol?",
+      "Roughly when do you think the exposure happened?",
+      "Are there new signs like tremors, drooling, or unsteadiness?",
+    ],
+    urgency_floor: "urgent",
+    missing_information: [
+      "what was eaten and when",
+      "any neurologic signs (tremors, unsteadiness)",
+    ],
+    vet_handoff_points: [
+      "what your dog may have eaten and when",
+      "any tremors, drooling, or unsteadiness",
+    ],
+    disallowed_outputs: [...NEVER_OUTPUT_BASE],
+    source_refs: ["General small-animal toxicology owner guidance"],
+  },
+];
+
+/** Knowledge entries whose triggers include the given Dog Brain signal. Pure. */
+export function getKnowledgeForSignal(
+  signalType: SignalType,
+): ClinicalKnowledgeEntry[] {
+  return CLINICAL_KNOWLEDGE.filter((e) =>
+    e.trigger_signal_keys.includes(signalType),
+  );
+}
+
+/** Knowledge entries for a domain. Pure. */
+export function getKnowledgeByDomain(
+  domain: ClinicalDomain,
+): ClinicalKnowledgeEntry[] {
+  return CLINICAL_KNOWLEDGE.filter((e) => e.domain === domain);
+}
+
+/** The stronger of two floors (never lowers). Pure. */
+export function maxUrgencyFloor(
+  a: KnowledgeUrgencyFloor,
+  b: KnowledgeUrgencyFloor,
+): KnowledgeUrgencyFloor {
+  return URGENCY_FLOOR_RANK[a] >= URGENCY_FLOOR_RANK[b] ? a : b;
+}

--- a/src/lib/clinical/root-cause-hypotheses.ts
+++ b/src/lib/clinical/root-cause-hypotheses.ts
@@ -1,0 +1,112 @@
+import type { SignalType } from "@/lib/dog-brain/types";
+import {
+  CLINICAL_KNOWLEDGE,
+  URGENCY_FLOOR_RANK,
+  maxUrgencyFloor,
+  type KnowledgeUrgencyFloor,
+} from "@/lib/clinical/knowledge-base";
+import {
+  matchClinicalPatterns,
+  type ClinicalPattern,
+} from "@/lib/clinical/clinical-patterns";
+
+// =============================================================================
+// Non-diagnostic root-cause hypotheses (DETERMINISTIC)
+//
+// Turns matched signal patterns + the dog's own evidence into doctor-like, but
+// strictly NON-DIAGNOSTIC, hypotheses: a pattern label, the supporting evidence,
+// what is still missing, the single best next question, an owner-facing urgency
+// floor, and an explicit safety boundary.
+//
+// SAFETY CONTRACT:
+//  - Labels are everyday patterns, never disease names.
+//  - A hypothesis is produced ONLY when there is dog-specific evidence for at
+//    least one member signal. No evidence → no hypothesis (never invents).
+//  - `urgency_floor` is NON-AUTHORITATIVE (question framing only). Every
+//    hypothesis carries a safety_boundary that emergency signs override it.
+//  - Pure. No I/O, no model calls.
+// =============================================================================
+
+export const HYPOTHESIS_SAFETY_BOUNDARY =
+  "This is not a diagnosis. Emergency signs override this pattern — if your dog shows emergency signs, contact a vet right away.";
+
+export interface RootCauseHypothesis {
+  hypothesis_label: string;
+  supporting_evidence: string[];
+  missing_information: string[];
+  next_best_question: string;
+  urgency_floor: KnowledgeUrgencyFloor;
+  safety_boundary: string;
+}
+
+export interface HypothesisInput {
+  /** Signal families currently present for this dog. */
+  presentSignalKeys: SignalType[];
+  /** Owner-facing, non-diagnostic evidence per present signal (dog-specific). */
+  evidenceSummaries: Partial<Record<SignalType, string>>;
+}
+
+function knowledgeForKeys(keys: SignalType[]) {
+  const present = new Set(keys);
+  return CLINICAL_KNOWLEDGE.filter((e) =>
+    e.trigger_signal_keys.some((k) => present.has(k)),
+  );
+}
+
+function buildOne(
+  pattern: ClinicalPattern,
+  input: HypothesisInput,
+): RootCauseHypothesis | null {
+  // Supporting evidence = the dog's own summaries for member signals that are
+  // both present AND have a non-empty summary. No dog-specific evidence → skip.
+  const supporting_evidence = pattern.member_signal_keys
+    .map((k) => input.evidenceSummaries[k]?.trim())
+    .filter((s): s is string => Boolean(s));
+  if (supporting_evidence.length === 0) return null;
+
+  const relatedKnowledge = knowledgeForKeys(pattern.member_signal_keys);
+
+  // Missing info + next question come from the strongest-floor knowledge entry
+  // among the member signals, so the question targets the most useful gap.
+  const strongest = relatedKnowledge
+    .slice()
+    .sort(
+      (a, b) =>
+        URGENCY_FLOOR_RANK[b.urgency_floor] - URGENCY_FLOOR_RANK[a.urgency_floor],
+    )[0];
+
+  const missing_information = Array.from(
+    new Set(relatedKnowledge.flatMap((e) => e.missing_information)),
+  ).slice(0, 4);
+
+  const next_best_question =
+    strongest?.owner_observable_questions[0] ??
+    "What have you noticed change most for your dog recently?";
+
+  const urgency_floor = relatedKnowledge.reduce<KnowledgeUrgencyFloor>(
+    (acc, e) => maxUrgencyFloor(acc, e.urgency_floor),
+    pattern.urgency_floor,
+  );
+
+  return {
+    hypothesis_label: pattern.label,
+    supporting_evidence,
+    missing_information,
+    next_best_question,
+    urgency_floor,
+    safety_boundary: HYPOTHESIS_SAFETY_BOUNDARY,
+  };
+}
+
+/**
+ * Build non-diagnostic hypotheses from matched patterns + dog-specific evidence,
+ * strongest urgency floor first. Returns [] when no pattern has supporting
+ * evidence. Pure.
+ */
+export function buildRootCauseHypotheses(
+  input: HypothesisInput,
+): RootCauseHypothesis[] {
+  return matchClinicalPatterns(input.presentSignalKeys)
+    .map((p) => buildOne(p, input))
+    .filter((h): h is RootCauseHypothesis => h !== null);
+}

--- a/src/lib/clinical/supplement-guardrails.ts
+++ b/src/lib/clinical/supplement-guardrails.ts
@@ -1,0 +1,193 @@
+import type { SignalType } from "@/lib/dog-brain/types";
+import type { SupplementCategory } from "@/lib/clinical/knowledge-base";
+
+// =============================================================================
+// Supplement guardrails — "vet discussion trials", never product recommendations
+//
+// A supplement suggestion is only ever "ask your vet whether X is appropriate
+// BECAUSE this dog has Y evidence". This module defines that contract, a builder
+// that refuses to produce a suggestion without dog-specific evidence, and a
+// HARD-FAIL validator that rejects dosage, brand, price, disease claims, and
+// evidence-free suggestions.
+//
+// SAFETY CONTRACT (hard fails — enforced by validateSupplementSuggestion):
+//  - NO dosage (mg/ml/IU/"twice daily"/etc.)
+//  - NO brand name (™/® or known brand denylist)
+//  - NO price ($ / "price" / "cost")
+//  - NO "prevents / cures disease" claim
+//  - NO suggestion without dog-specific evidence (reason signal + memory ids +
+//    evidence summary)
+//  Pure. No I/O.
+// =============================================================================
+
+export interface SupplementSuggestion {
+  name: string;
+  category: SupplementCategory;
+  purpose: string;
+  why_ask_vet: string;
+  evidence_summary: string;
+  reason_signal_key: string;
+  related_memory_ids: string[];
+  safety_note: string;
+  follow_up_question: string;
+  follow_up_due_days: number;
+  priority: "ask_vet" | "monitor";
+}
+
+export type GuardrailCode =
+  | "dosage"
+  | "brand"
+  | "price"
+  | "disease_claim"
+  | "no_evidence";
+
+export interface GuardrailViolation {
+  code: GuardrailCode;
+  detail: string;
+}
+
+// Dosage: a number followed by a dose unit, or an explicit frequency phrase.
+const DOSAGE_UNIT = /\b\d+(\.\d+)?\s*(mg|mcg|µg|g|kg|ml|l|iu|cc|tsp|tbsp|drops?|capsules?|tablets?|scoops?|chews?)\b/i;
+const DOSAGE_FREQUENCY = /\b(once|twice|thrice|[1-9]\s*x|\d+\s*times?)\b[\s\w]*\b(daily|a day|per day|day|week)\b/i;
+const PRICE = /(\$\s*\d|\b\d+\s*(usd|dollars?)\b|\bprice\b|\bcost\s*\$|\bbuy\b|\bdiscount\b)/i;
+const DISEASE_CLAIM = /\b(prevent|prevents|cure|cures|treat|treats|reverse|reverses|fix|fixes)\b[\s\w]*\b(disease|cancer|arthritis|infection|illness|parvo|diabetes)\b/i;
+const TRADEMARK = /[®™]/;
+
+// A small denylist of common supplement brand tokens. Not exhaustive — the
+// builder never emits brands, so this is a backstop against hand-written input.
+const BRAND_DENYLIST = [
+  "nutramax",
+  "cosequin",
+  "dasuquin",
+  "zesty paws",
+  "purina",
+  "vetriscience",
+  "nordic naturals",
+];
+
+function scanText(s: string): GuardrailViolation[] {
+  const out: GuardrailViolation[] = [];
+  if (DOSAGE_UNIT.test(s) || DOSAGE_FREQUENCY.test(s)) {
+    out.push({ code: "dosage", detail: `dosage-like text: "${s}"` });
+  }
+  if (PRICE.test(s)) {
+    out.push({ code: "price", detail: `price-like text: "${s}"` });
+  }
+  if (DISEASE_CLAIM.test(s)) {
+    out.push({ code: "disease_claim", detail: `disease claim: "${s}"` });
+  }
+  const lower = s.toLowerCase();
+  if (TRADEMARK.test(s) || BRAND_DENYLIST.some((b) => lower.includes(b))) {
+    out.push({ code: "brand", detail: `brand-like text: "${s}"` });
+  }
+  return out;
+}
+
+/**
+ * HARD-FAIL validation. Returns ok=false with every violation found. A
+ * suggestion is rejected if any user-visible string contains dosage/brand/price/
+ * disease-claim text, or if it lacks dog-specific evidence. Pure.
+ */
+export function validateSupplementSuggestion(
+  s: SupplementSuggestion,
+): { ok: boolean; violations: GuardrailViolation[] } {
+  const violations: GuardrailViolation[] = [];
+
+  const textFields = [
+    s.name,
+    s.purpose,
+    s.why_ask_vet,
+    s.evidence_summary,
+    s.safety_note,
+    s.follow_up_question,
+  ];
+  for (const field of textFields) {
+    violations.push(...scanText(field));
+  }
+
+  // Evidence gate: a suggestion MUST be tied to this dog's evidence.
+  if (
+    !s.reason_signal_key.trim() ||
+    s.related_memory_ids.length === 0 ||
+    !s.evidence_summary.trim()
+  ) {
+    violations.push({
+      code: "no_evidence",
+      detail: "missing reason_signal_key, related_memory_ids, or evidence_summary",
+    });
+  }
+
+  // Dedupe by code+detail.
+  const seen = new Set<string>();
+  const deduped = violations.filter((v) => {
+    const key = `${v.code}:${v.detail}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
+  return { ok: deduped.length === 0, violations: deduped };
+}
+
+const SIGNAL_TO_CATEGORY: Partial<Record<SignalType, SupplementCategory>> = {
+  stool_change: "gut_support",
+  vomiting_trend: "gut_support",
+  appetite_drop: "gut_support",
+  water_urination_change: "hydration_support",
+  skin_ear_change: "skin_coat",
+  mobility_pain_change: "joint_mobility",
+};
+
+function categoryLabel(category: SupplementCategory): string {
+  switch (category) {
+    case "gut_support":
+      return "gut-support";
+    case "skin_coat":
+      return "skin-and-coat";
+    case "joint_mobility":
+      return "joint-mobility";
+    case "hydration_support":
+      return "hydration-support";
+    case "vet_only_discussion":
+      return "vet-discussion";
+  }
+}
+
+export interface SupplementBuildInput {
+  signalKey: SignalType;
+  /** Owner-facing, non-diagnostic evidence (dog-specific). Required. */
+  evidenceSummary: string;
+  /** Evidence ids backing this suggestion. Required (non-empty). */
+  relatedMemoryIds: string[];
+}
+
+/**
+ * Build a vet-discussion supplement suggestion ONLY when there is dog-specific
+ * evidence. Returns null otherwise (never a generic wellness suggestion). The
+ * result is guaranteed to pass validateSupplementSuggestion. Pure.
+ */
+export function buildSupplementSuggestion(
+  input: SupplementBuildInput,
+): SupplementSuggestion | null {
+  if (!input.evidenceSummary.trim() || input.relatedMemoryIds.length === 0) {
+    return null;
+  }
+  const category = SIGNAL_TO_CATEGORY[input.signalKey] ?? "vet_only_discussion";
+  const label = categoryLabel(category);
+
+  return {
+    name: `${label} supplement (ask your vet)`,
+    category,
+    purpose: `Whether a ${label} supplement might help, decided with your vet.`,
+    why_ask_vet: `Ask your vet whether a ${label} supplement is appropriate, because of the pattern noticed for your dog.`,
+    evidence_summary: input.evidenceSummary.trim(),
+    reason_signal_key: input.signalKey,
+    related_memory_ids: [...input.relatedMemoryIds],
+    safety_note:
+      "Only start a supplement if your vet agrees it is appropriate for your dog.",
+    follow_up_question:
+      "After your vet visit, did things get better, stay the same, or get worse?",
+    follow_up_due_days: 7,
+    priority: "ask_vet",
+  };
+}

--- a/src/lib/dog-brain/analytics.ts
+++ b/src/lib/dog-brain/analytics.ts
@@ -1,0 +1,161 @@
+/**
+ * Dog Brain loop analytics — privacy-safe usage events.
+ *
+ * Answers "is the Brain actually used, and do owners complete the loop?" without
+ * ever logging clinical content. It is a thin, typed wrapper over the existing
+ * App Insights sink (`@/lib/azure/telemetry`), whose `SafeEventName` /
+ * `SafePropertyKey` allow-lists enforce the PII boundary at the type level.
+ *
+ * HARD PRIVACY CONTRACT (must never be violated):
+ *  - NO free-text owner notes, NO raw symptom text, NO photo data, NO pet/owner
+ *    names. Every field is either a bounded enum or a non-negative count.
+ *  - Builder inputs are typed as enums/numbers only, so free text cannot enter
+ *    structurally. Counts go through `measurements` (numeric), enums through the
+ *    two allow-listed property keys (`questionSource`, `outcomeBucket`).
+ *  - Emitting is a silent no-op without an App Insights connection string
+ *    (demo mode / CI) and never throws — telemetry must not affect behavior.
+ */
+
+import {
+  trackEvent,
+  type SafeEventName,
+  type TrackOptions,
+  type TriageTelemetryEvent,
+} from "@/lib/azure/telemetry";
+
+/** Stable event names — counts/enums only. */
+export const DOG_BRAIN_EVENTS = {
+  contextLoaded: "dogbrain.context.loaded",
+  questionTraceEmitted: "dogbrain.question_trace.emitted",
+  emergencyTraceSuppressed: "dogbrain.question_trace.emergency_suppressed",
+  followupCreated: "dogbrain.followup.created",
+  followupOutcomeRecorded: "dogbrain.followup.outcome_recorded",
+  supplementTrialStarted: "dogbrain.supplement_trial.started",
+  supplementTrialMarkedActive: "dogbrain.supplement_trial.marked_active",
+  supplementTrialOutcomeRecorded: "dogbrain.supplement_trial.outcome_recorded",
+} as const satisfies Record<string, SafeEventName>;
+
+/** Which selector branch produced the surfaced question (matches Phase 1). */
+export type QuestionSource =
+  | "complaint"
+  | "brain_memory"
+  | "pending_clarification"
+  | "emergency"
+  | "generic";
+
+/** Bounded outcome vocabulary for follow-ups and supplement trials. */
+export type OutcomeBucket = "better" | "same" | "worse" | "side_effect" | "unknown";
+
+const QUESTION_SOURCES: ReadonlySet<QuestionSource> = new Set([
+  "complaint",
+  "brain_memory",
+  "pending_clarification",
+  "emergency",
+  "generic",
+]);
+
+/** Coerce any raw outcome string into the bounded bucket vocabulary. */
+export function toOutcomeBucket(raw: string | null | undefined): OutcomeBucket {
+  const v = (raw ?? "").trim().toLowerCase();
+  if (v === "better" || v === "improved" || v === "improving") return "better";
+  if (v === "same" || v === "unchanged" || v === "no_change" || v === "stable") {
+    return "same";
+  }
+  if (v === "worse" || v === "worsened" || v === "worsening") return "worse";
+  if (v === "side_effect" || v === "side effect" || v === "adverse") {
+    return "side_effect";
+  }
+  return "unknown";
+}
+
+/** Non-negative integer count (defensive — never a fractional or negative). */
+function safeCount(n: number | undefined): number {
+  if (typeof n !== "number" || !Number.isFinite(n) || n < 0) return 0;
+  return Math.floor(n);
+}
+
+function normalizeSource(source: QuestionSource): QuestionSource {
+  return QUESTION_SOURCES.has(source) ? source : "generic";
+}
+
+// ---------------------------------------------------------------------------
+// Pure event builders — return the telemetry envelope without sending it. Tests
+// assert these carry only enums/counts and never free text.
+// ---------------------------------------------------------------------------
+
+export function brainContextLoadedEvent(counts: {
+  signalCount?: number;
+  prioritySymptomCount?: number;
+  followupCount?: number;
+  supplementTrialCount?: number;
+}): TriageTelemetryEvent {
+  return {
+    name: DOG_BRAIN_EVENTS.contextLoaded,
+    measurements: {
+      signalCount: safeCount(counts.signalCount),
+      prioritySymptomCount: safeCount(counts.prioritySymptomCount),
+      followupCount: safeCount(counts.followupCount),
+      supplementTrialCount: safeCount(counts.supplementTrialCount),
+    },
+  };
+}
+
+export function brainQuestionTraceEmittedEvent(args: {
+  source: QuestionSource;
+  evidenceCount?: number;
+}): TriageTelemetryEvent {
+  return {
+    name: DOG_BRAIN_EVENTS.questionTraceEmitted,
+    properties: { questionSource: normalizeSource(args.source) },
+    measurements: { evidenceCount: safeCount(args.evidenceCount) },
+  };
+}
+
+export function emergencyTraceSuppressedEvent(): TriageTelemetryEvent {
+  return {
+    name: DOG_BRAIN_EVENTS.emergencyTraceSuppressed,
+    properties: { questionSource: "emergency" },
+  };
+}
+
+export function dogBrainFollowupCreatedEvent(): TriageTelemetryEvent {
+  return { name: DOG_BRAIN_EVENTS.followupCreated };
+}
+
+export function dogBrainFollowupOutcomeRecordedEvent(args: {
+  outcome: OutcomeBucket;
+}): TriageTelemetryEvent {
+  return {
+    name: DOG_BRAIN_EVENTS.followupOutcomeRecorded,
+    properties: { outcomeBucket: args.outcome },
+  };
+}
+
+export function supplementTrialStartedEvent(): TriageTelemetryEvent {
+  return { name: DOG_BRAIN_EVENTS.supplementTrialStarted };
+}
+
+export function supplementTrialMarkedActiveEvent(): TriageTelemetryEvent {
+  return { name: DOG_BRAIN_EVENTS.supplementTrialMarkedActive };
+}
+
+export function supplementTrialOutcomeRecordedEvent(args: {
+  outcome: OutcomeBucket;
+}): TriageTelemetryEvent {
+  return {
+    name: DOG_BRAIN_EVENTS.supplementTrialOutcomeRecorded,
+    properties: { outcomeBucket: args.outcome },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Emit — fire-and-forget through the shared sink. Silent no-op in demo mode.
+// ---------------------------------------------------------------------------
+
+/** Send a pre-built Dog Brain analytics event. Never throws. */
+export function recordDogBrainEvent(
+  event: TriageTelemetryEvent,
+  options: TrackOptions = {},
+): Promise<void> {
+  return trackEvent(event, options);
+}

--- a/src/lib/dog-brain/memory-ranking.ts
+++ b/src/lib/dog-brain/memory-ranking.ts
@@ -1,0 +1,241 @@
+import {
+  BRAIN_SIGNAL_SYMPTOM_KEYS,
+} from "@/lib/dog-brain/question-priority";
+import type { DetectedSignal, SignalSeverity, SignalType } from "@/lib/dog-brain/types";
+
+// =============================================================================
+// Dog Brain → 60/90-day memory ranking (SUPPORTIVE TIEBREAK ORDERING ONLY)
+//
+// Orders the owner-logged Dog Brain signals so the symptom checker's tiebreak
+// prefers the *most useful* long-memory facts (recent / repeated / worsening /
+// follow-up-linked) over isolated old notes — instead of a flat severity sort.
+//
+// HARD SAFETY CONTRACT (must never be violated):
+//  - This module ONLY reorders the supportive priority-symptom tiebreak list.
+//    It NEVER emits, raises, or lowers a deterministic urgency. The clinical
+//    matrix / triage engine never read this output.
+//  - Severity stays the dominant ranking term (alert > watch > info), so a
+//    benign-but-recent memory can never outrank a higher-severity signal. This
+//    preserves the existing severity-first ordering at the top tier; the finer
+//    signals only break ties *within* a severity tier.
+//  - Pure + side-effect free. Empty input → empty output. Absent context →
+//    ordering depends only on the signals themselves (deterministic).
+// =============================================================================
+
+/** Context the ranking may consult — all optional, all best-effort. */
+export interface MemoryRankingContext {
+  /** Pending/active follow-up prompts (owner-facing text + status). */
+  followups?: ReadonlyArray<{ prompt?: string | null; status?: string | null }>;
+  /** Supplement trial outcomes (outcome / status). */
+  supplementTrials?: ReadonlyArray<{ outcome?: string | null; status?: string | null }>;
+  /** Concatenated imported vet-record text (owner-uploaded extraction). */
+  vetRecordText?: string | null;
+}
+
+export interface RankedSignalComponents {
+  severity: number;
+  symptomMapMatch: number;
+  recency: number;
+  repetition: number;
+  confidence: number;
+  unresolvedFollowup: number;
+  supplementConcern: number;
+  vetRelevance: number;
+}
+
+export interface RankedSignal {
+  signal: DetectedSignal;
+  /** Higher = more useful to surface. Explanation/telemetry only — never urgency. */
+  score: number;
+  components: RankedSignalComponents;
+}
+
+// Severity dominates: the gap between tiers (500) exceeds the maximum total of
+// every other term combined (<=128), so severity ordering is never overturned.
+const SEVERITY_WEIGHT: Record<SignalSeverity, number> = {
+  alert: 1000,
+  watch: 500,
+  info: 0,
+};
+
+// Owner-observable domain terms per signal — used to match a signal against
+// follow-up prompts and imported vet-record text (substring, case-insensitive).
+const SIGNAL_DOMAIN_TERMS: Record<SignalType, readonly string[]> = {
+  appetite_drop: ["appetite", "eating", "not eating", "food", "hunger"],
+  stool_change: ["stool", "diarrhea", "poop", "bowel", "feces"],
+  vomiting_trend: ["vomit", "throw up", "nausea", "regurgitat"],
+  weight_downtrend: ["weight", "thin", "losing weight"],
+  water_urination_change: ["water", "thirst", "drinking", "urin", "pee", "hydrat"],
+  mobility_pain_change: ["limp", "stiff", "mobility", "pain", "joint", "lame"],
+  breathing_cough_change: ["cough", "breath", "panting", "wheez"],
+  skin_ear_change: ["skin", "ear", "itch", "scratch", "odor", "rash"],
+  energy_behavior_change: ["energy", "lethargy", "behavior", "tired", "lethargic"],
+  possible_med_side_effect: ["medication", "med", "supplement", "side effect", "dose"],
+};
+
+// Signal types a gut/GI-oriented supplement "worse" / "side_effect" outcome is
+// most relevant to. A worsening supplement trial nudges these signals up.
+const SUPPLEMENT_RESPONSIVE: ReadonlySet<SignalType> = new Set<SignalType>([
+  "stool_change",
+  "vomiting_trend",
+  "appetite_drop",
+  "water_urination_change",
+  "possible_med_side_effect",
+]);
+
+const ISO_DATE = /\d{4}-\d{2}-\d{2}/g;
+
+/** Distinct ISO dates referenced by a dedupe_key (proxy for repeated logging). */
+function distinctSignalDates(dedupeKey: string): number[] {
+  const matches = dedupeKey.match(ISO_DATE);
+  if (!matches) return [];
+  const seen = new Set<number>();
+  for (const iso of matches) {
+    const t = Date.parse(`${iso}T00:00:00Z`);
+    if (Number.isFinite(t)) seen.add(t);
+  }
+  return [...seen];
+}
+
+function recencyScore(dates: number[], now: Date): number {
+  if (dates.length === 0) return 0;
+  const newest = Math.max(...dates);
+  const days = Math.round((now.getTime() - newest) / 86_400_000);
+  if (!Number.isFinite(days) || days < 0) return 0; // future/garbled → no credit
+  if (days <= 0) return 25;
+  if (days <= 3) return 18;
+  if (days <= 7) return 12;
+  if (days <= 14) return 6;
+  if (days <= 30) return 3;
+  return 0;
+}
+
+/** Repeated-pattern credit: more distinct logged dates → stronger pattern. */
+function repetitionScore(dates: number[]): number {
+  if (dates.length <= 1) return 0;
+  return Math.min(dates.length, 5) * 5; // up to 25
+}
+
+function confidenceScore(confidence: number | undefined): number {
+  if (typeof confidence !== "number" || !Number.isFinite(confidence)) return 0;
+  const clamped = Math.min(Math.max(confidence, 0), 1);
+  return Math.round(clamped * 10); // up to 10
+}
+
+function matchesDomain(text: string, signalType: SignalType): boolean {
+  const haystack = text.toLowerCase();
+  return (SIGNAL_DOMAIN_TERMS[signalType] ?? []).some((term) =>
+    haystack.includes(term),
+  );
+}
+
+const UNRESOLVED_STATUSES: ReadonlySet<string> = new Set([
+  "pending",
+  "open",
+  "active",
+  "due",
+  "scheduled",
+  "",
+]);
+
+function unresolvedFollowupScore(
+  signalType: SignalType,
+  ctx: MemoryRankingContext,
+): number {
+  for (const f of ctx.followups ?? []) {
+    const status = (f.status ?? "").toLowerCase();
+    if (!UNRESOLVED_STATUSES.has(status)) continue;
+    if (matchesDomain(f.prompt ?? "", signalType)) return 15;
+  }
+  return 0;
+}
+
+const CONCERNING_OUTCOMES: ReadonlySet<string> = new Set([
+  "worse",
+  "worsened",
+  "side_effect",
+  "side effect",
+  "adverse",
+]);
+
+function supplementConcernScore(
+  signalType: SignalType,
+  ctx: MemoryRankingContext,
+): number {
+  if (!SUPPLEMENT_RESPONSIVE.has(signalType)) return 0;
+  for (const t of ctx.supplementTrials ?? []) {
+    const outcome = (t.outcome ?? "").toLowerCase();
+    const status = (t.status ?? "").toLowerCase();
+    if (CONCERNING_OUTCOMES.has(outcome) || CONCERNING_OUTCOMES.has(status)) {
+      return 15;
+    }
+  }
+  return 0;
+}
+
+function vetRelevanceScore(
+  signalType: SignalType,
+  ctx: MemoryRankingContext,
+): number {
+  const text = ctx.vetRecordText ?? "";
+  if (!text.trim()) return 0;
+  return matchesDomain(text, signalType) ? 8 : 0;
+}
+
+function symptomMapMatchScore(signalType: SignalType): number {
+  // Signals whose pattern maps to an actual deterministic follow-up question are
+  // more useful as a tiebreak than ones that map to nothing (e.g. med notes).
+  const keys = BRAIN_SIGNAL_SYMPTOM_KEYS[signalType];
+  return keys && keys.length > 0 ? 30 : 0;
+}
+
+/**
+ * Score a single signal for tiebreak usefulness. Pure. The returned score is
+ * explanation/telemetry only and is NEVER an urgency value.
+ */
+export function scoreDetectedSignal(
+  signal: DetectedSignal,
+  ctx: MemoryRankingContext = {},
+  now: Date = new Date(),
+): RankedSignal {
+  const dates = distinctSignalDates(signal.dedupe_key ?? "");
+  const components: RankedSignalComponents = {
+    severity: SEVERITY_WEIGHT[signal.severity] ?? 0,
+    symptomMapMatch: symptomMapMatchScore(signal.signal_type),
+    recency: recencyScore(dates, now),
+    repetition: repetitionScore(dates),
+    confidence: confidenceScore(signal.confidence),
+    unresolvedFollowup: unresolvedFollowupScore(signal.signal_type, ctx),
+    supplementConcern: supplementConcernScore(signal.signal_type, ctx),
+    vetRelevance: vetRelevanceScore(signal.signal_type, ctx),
+  };
+  const score = Object.values(components).reduce((a, b) => a + b, 0);
+  return { signal, score, components };
+}
+
+/**
+ * Rank detected signals by tiebreak usefulness, returning the scored records in
+ * descending order. Stable for equal scores (input order preserved). Pure.
+ */
+export function rankDetectedSignalsWithScores(
+  signals: DetectedSignal[],
+  ctx: MemoryRankingContext = {},
+  now: Date = new Date(),
+): RankedSignal[] {
+  return signals
+    .map((signal, index) => ({ ranked: scoreDetectedSignal(signal, ctx, now), index }))
+    .sort((a, b) => b.ranked.score - a.ranked.score || a.index - b.index)
+    .map((entry) => entry.ranked);
+}
+
+/**
+ * Rank detected signals and return just the signals, most-useful first. This is
+ * the ordering the symptom-checker tiebreak should consume. Pure; NEVER urgency.
+ */
+export function rankDetectedSignals(
+  signals: DetectedSignal[],
+  ctx: MemoryRankingContext = {},
+  now: Date = new Date(),
+): DetectedSignal[] {
+  return rankDetectedSignalsWithScores(signals, ctx, now).map((r) => r.signal);
+}

--- a/src/lib/dog-brain/question-priority.ts
+++ b/src/lib/dog-brain/question-priority.ts
@@ -18,7 +18,7 @@ import type { DetectedSignal, SignalType } from "@/lib/dog-brain/types";
 //    makes the downstream selector byte-identical to its pre-Brain behavior.
 // =============================================================================
 
-const BRAIN_SIGNAL_SYMPTOM_KEYS: Record<SignalType, readonly string[]> = {
+export const BRAIN_SIGNAL_SYMPTOM_KEYS: Record<SignalType, readonly string[]> = {
   appetite_drop: ["not_eating"],
   // Daily-log stool is normal/soft/diarrhea/none/blood — never constipation — so
   // a stool_change signal always points at loose/bloody stool, not constipation.

--- a/src/lib/health-log/dog-brain-context.ts
+++ b/src/lib/health-log/dog-brain-context.ts
@@ -11,6 +11,7 @@ import {
   brainPrioritySymptomEvidence,
   type BrainSymptomEvidence,
 } from "@/lib/dog-brain/question-priority";
+import { rankDetectedSignals } from "@/lib/dog-brain/memory-ranking";
 
 export interface DogBrainContextData {
   /** Supportive narrative for the report prompt; null = skip context. */
@@ -321,9 +322,25 @@ export async function loadDogBrainContextWithSignals({
     // uses the 14 newest internally) — no extra query, no duplicate ownership
     // check. Replaces the former standalone loadDogBrainPrioritySymptoms loader.
     const detectedSignals = detectDogBrainSignals(logs).signals;
-    const prioritySymptoms = brainPrioritySymptomsFromSignals(detectedSignals);
+    // Rank the supportive tiebreak list so the most useful long-memory facts
+    // (recent / repeated / follow-up- or supplement-linked) surface ahead of
+    // isolated old notes. Severity stays dominant inside both consumers, so this
+    // only breaks ties WITHIN a severity tier — it never touches urgency. Reuses
+    // the follow-ups and supplement trials already fetched above (no extra query).
+    const rankedSignals = rankDetectedSignals(detectedSignals, {
+      followups: (followups ?? []).map((f) => ({
+        prompt: f.prompt,
+        status: f.status,
+      })),
+      supplementTrials: trials.map((t) => ({
+        outcome: t.outcome,
+        status: t.status,
+      })),
+      vetRecordText: vetRecords.map((v) => v.context_text ?? "").join(" "),
+    });
+    const prioritySymptoms = brainPrioritySymptomsFromSignals(rankedSignals);
     const prioritySymptomEvidence =
-      brainPrioritySymptomEvidence(detectedSignals);
+      brainPrioritySymptomEvidence(rankedSignals);
 
     return {
       context: sections.length === 0 ? null : sections.join("\n\n"),

--- a/tests/clinical-knowledge-layer.test.ts
+++ b/tests/clinical-knowledge-layer.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Phase 8 — curated clinical knowledge layer (deterministic, vet-safe).
+ *
+ * Covers the four modules: knowledge-base, clinical-patterns,
+ * root-cause-hypotheses, supplement-guardrails. The recurring theme is the hard
+ * safety contract: no diagnosis, no dosage/brand/price, evidence-linked only,
+ * and the owner-facing urgency floor never poses as the deterministic triage
+ * urgency.
+ */
+import {
+  CLINICAL_KNOWLEDGE,
+  getKnowledgeForSignal,
+  getKnowledgeByDomain,
+  maxUrgencyFloor,
+  type ClinicalKnowledgeEntry,
+} from "@/lib/clinical/knowledge-base";
+import {
+  CLINICAL_PATTERNS,
+  matchClinicalPatterns,
+} from "@/lib/clinical/clinical-patterns";
+import {
+  buildRootCauseHypotheses,
+  HYPOTHESIS_SAFETY_BOUNDARY,
+} from "@/lib/clinical/root-cause-hypotheses";
+import {
+  validateSupplementSuggestion,
+  buildSupplementSuggestion,
+  type SupplementSuggestion,
+} from "@/lib/clinical/supplement-guardrails";
+
+// Forbidden patterns scanned across ALL curated owner-facing strings.
+const DOSAGE = /\b\d+(\.\d+)?\s*(mg|mcg|µg|ml|iu|cc|tsp|tbsp|capsules?|tablets?|scoops?|chews?)\b/i;
+const PRICE = /(\$\s*\d|\b\d+\s*(usd|dollars?)\b)/i;
+const TRADEMARK = /[®™]/;
+const DISEASE_CLAIM = /\b(prevents?|cures?|reverses?)\b[\s\w]*\b(disease|cancer|arthritis|infection)\b/i;
+
+function entryStrings(e: ClinicalKnowledgeEntry): string[] {
+  return [
+    ...e.owner_observable_questions,
+    ...e.missing_information,
+    ...e.vet_handoff_points,
+  ];
+}
+
+describe("knowledge-base — curated + safe", () => {
+  it("every domain has an entry and entries are well-formed", () => {
+    const domains = new Set(CLINICAL_KNOWLEDGE.map((e) => e.domain));
+    for (const d of [
+      "gi",
+      "urinary",
+      "skin_ear",
+      "respiratory",
+      "mobility",
+      "senior",
+      "medication_supplement",
+      "toxin_exposure",
+    ]) {
+      expect(domains.has(d as ClinicalKnowledgeEntry["domain"])).toBe(true);
+    }
+    for (const e of CLINICAL_KNOWLEDGE) {
+      expect(e.owner_observable_questions.length).toBeGreaterThan(0);
+      expect(e.vet_handoff_points.length).toBeGreaterThan(0);
+      expect(e.disallowed_outputs.length).toBeGreaterThan(0);
+      expect(e.source_refs.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("contains no dosage / price / brand / disease-claim text anywhere", () => {
+    for (const e of CLINICAL_KNOWLEDGE) {
+      for (const s of entryStrings(e)) {
+        expect(DOSAGE.test(s)).toBe(false);
+        expect(PRICE.test(s)).toBe(false);
+        expect(TRADEMARK.test(s)).toBe(false);
+        expect(DISEASE_CLAIM.test(s)).toBe(false);
+      }
+    }
+  });
+
+  it("getKnowledgeForSignal joins by trigger signal; getKnowledgeByDomain by domain", () => {
+    expect(getKnowledgeForSignal("stool_change").some((e) => e.domain === "gi")).toBe(true);
+    expect(getKnowledgeByDomain("urinary").length).toBeGreaterThan(0);
+    expect(getKnowledgeForSignal("stool_change").every((e) =>
+      e.trigger_signal_keys.includes("stool_change"),
+    )).toBe(true);
+  });
+
+  it("maxUrgencyFloor never lowers a floor", () => {
+    expect(maxUrgencyFloor("self_monitor", "emergency")).toBe("emergency");
+    expect(maxUrgencyFloor("urgent", "watch")).toBe("urgent");
+    expect(maxUrgencyFloor("call_vet", "call_vet")).toBe("call_vet");
+  });
+});
+
+describe("clinical-patterns — cluster matching", () => {
+  it("matches a digestive pattern only when >= min_signals are present", () => {
+    expect(matchClinicalPatterns(["stool_change"]).map((p) => p.id)).not.toContain(
+      "digestive_pattern",
+    );
+    expect(
+      matchClinicalPatterns(["stool_change", "vomiting_trend"]).map((p) => p.id),
+    ).toContain("digestive_pattern");
+  });
+
+  it("returns strongest urgency floor first", () => {
+    const matched = matchClinicalPatterns([
+      "skin_ear_change", // watch
+      "breathing_cough_change", // urgent
+    ]);
+    expect(matched[0].urgency_floor).toBe("urgent");
+  });
+
+  it("empty input → no patterns; single-signal patterns still match at min 1", () => {
+    expect(matchClinicalPatterns([])).toEqual([]);
+    expect(matchClinicalPatterns(["mobility_pain_change"]).map((p) => p.id)).toContain(
+      "mobility_discomfort_pattern",
+    );
+  });
+
+  it("no pattern label is a disease name", () => {
+    for (const p of CLINICAL_PATTERNS) {
+      expect(p.label).toMatch(/pattern|concern|possibility/);
+    }
+  });
+});
+
+describe("root-cause-hypotheses — non-diagnostic, evidence-gated", () => {
+  it("produces a hypothesis only when there is dog-specific evidence", () => {
+    const none = buildRootCauseHypotheses({
+      presentSignalKeys: ["stool_change", "vomiting_trend"],
+      evidenceSummaries: {}, // no evidence
+    });
+    expect(none).toEqual([]);
+
+    const some = buildRootCauseHypotheses({
+      presentSignalKeys: ["stool_change", "vomiting_trend"],
+      evidenceSummaries: {
+        stool_change: "softer stool logged several times in the last 10 days",
+        vomiting_trend: "vomited twice today",
+      },
+    });
+    expect(some.length).toBeGreaterThan(0);
+    const h = some[0];
+    expect(h.hypothesis_label).toBe("digestive pattern");
+    expect(h.supporting_evidence.length).toBeGreaterThan(0);
+    expect(h.next_best_question.length).toBeGreaterThan(0);
+    expect(h.safety_boundary).toBe(HYPOTHESIS_SAFETY_BOUNDARY);
+  });
+
+  it("never exposes a disease name in the label or safety boundary", () => {
+    const hs = buildRootCauseHypotheses({
+      presentSignalKeys: ["water_urination_change", "vomiting_trend"],
+      evidenceSummaries: { water_urination_change: "drinking much more this week" },
+    });
+    for (const h of hs) {
+      expect(h.hypothesis_label).not.toMatch(/cancer|parvo|diabetes|disease/i);
+    }
+  });
+
+  it("safety boundary states emergency overrides the pattern", () => {
+    expect(HYPOTHESIS_SAFETY_BOUNDARY.toLowerCase()).toContain("not a diagnosis");
+    expect(HYPOTHESIS_SAFETY_BOUNDARY.toLowerCase()).toContain("emergency");
+  });
+});
+
+describe("supplement-guardrails — hard fails", () => {
+  const VALID: SupplementSuggestion = {
+    name: "gut-support supplement (ask your vet)",
+    category: "gut_support",
+    purpose: "Whether a gut-support supplement might help, decided with your vet.",
+    why_ask_vet: "Ask your vet whether a gut-support supplement is appropriate.",
+    evidence_summary: "softer stool on several of the last ten days",
+    reason_signal_key: "stool_change",
+    related_memory_ids: ["evt-1", "evt-2"],
+    safety_note: "Only start a supplement if your vet agrees.",
+    follow_up_question: "After your vet visit, did things get better, same, or worse?",
+    follow_up_due_days: 7,
+    priority: "ask_vet",
+  };
+
+  it("accepts a well-formed, evidence-linked suggestion", () => {
+    expect(validateSupplementSuggestion(VALID).ok).toBe(true);
+  });
+
+  it("rejects dosage text", () => {
+    const r = validateSupplementSuggestion({ ...VALID, purpose: "Give 500 mg twice daily." });
+    expect(r.ok).toBe(false);
+    expect(r.violations.map((v) => v.code)).toContain("dosage");
+  });
+
+  it("rejects brand and price", () => {
+    expect(
+      validateSupplementSuggestion({ ...VALID, name: "Cosequin chews" }).violations.map((v) => v.code),
+    ).toContain("brand");
+    expect(
+      validateSupplementSuggestion({ ...VALID, purpose: "Only $19.99 to buy." }).violations.map((v) => v.code),
+    ).toContain("price");
+  });
+
+  it("rejects disease-prevention claims", () => {
+    const r = validateSupplementSuggestion({
+      ...VALID,
+      why_ask_vet: "This prevents arthritis for sure.",
+    });
+    expect(r.violations.map((v) => v.code)).toContain("disease_claim");
+  });
+
+  it("rejects a suggestion with no dog-specific evidence", () => {
+    const r = validateSupplementSuggestion({
+      ...VALID,
+      reason_signal_key: "",
+      related_memory_ids: [],
+      evidence_summary: "",
+    });
+    expect(r.violations.map((v) => v.code)).toContain("no_evidence");
+  });
+
+  it("builder returns null without evidence and a valid suggestion with it", () => {
+    expect(
+      buildSupplementSuggestion({ signalKey: "stool_change", evidenceSummary: "", relatedMemoryIds: [] }),
+    ).toBeNull();
+
+    const built = buildSupplementSuggestion({
+      signalKey: "stool_change",
+      evidenceSummary: "softer stool several times in ten days",
+      relatedMemoryIds: ["evt-9"],
+    });
+    expect(built).not.toBeNull();
+    expect(built!.category).toBe("gut_support");
+    expect(built!.priority).toBe("ask_vet");
+    // The builder's own output must always pass the guardrails.
+    expect(validateSupplementSuggestion(built!).ok).toBe(true);
+  });
+});

--- a/tests/dog-brain-analytics-wiring.test.ts
+++ b/tests/dog-brain-analytics-wiring.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Phase 3b — analytics emitters are wired at the right CRUD call-sites.
+ *
+ * Keeps the REAL event builders (so payload shape is exercised) and spies only
+ * the sink, asserting each route fires the correct privacy-safe event on genuine
+ * success and stays SILENT on dedup / no-op. Proves the loop is measurable.
+ */
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const mockCheckRateLimit = jest.fn();
+const mockRequireAuth = jest.fn();
+const mockRequireOwnedPet = jest.fn();
+
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: (...a: unknown[]) => mockCheckRateLimit(...a),
+  generalApiLimiter: { id: "general" },
+  getRateLimitId: () => "rate-id",
+}));
+jest.mock("@/lib/api-auth", () => ({
+  requireAuthenticatedApiUser: (...a: unknown[]) => mockRequireAuth(...a),
+}));
+jest.mock("@/lib/api/pet-guard", () => ({
+  requireOwnedPet: (...a: unknown[]) => mockRequireOwnedPet(...a),
+}));
+
+// Keep real builders + enums; spy only the network sink.
+jest.mock("@/lib/dog-brain/analytics", () => {
+  const actual = jest.requireActual<typeof import("@/lib/dog-brain/analytics")>(
+    "@/lib/dog-brain/analytics",
+  );
+  return { ...actual, recordDogBrainEvent: jest.fn() };
+});
+
+import {
+  recordDogBrainEvent,
+  DOG_BRAIN_EVENTS,
+} from "@/lib/dog-brain/analytics";
+
+const emit = recordDogBrainEvent as unknown as jest.Mock;
+const UUID = "11111111-1111-4111-8111-111111111111";
+
+interface EventLike {
+  name: string;
+  properties?: { outcomeBucket?: string };
+}
+function lastEvent(): EventLike {
+  const call = emit.mock.calls.at(-1);
+  return call?.[0] as EventLike;
+}
+
+function chain(steps: { maybeSingle?: unknown[]; result?: unknown }) {
+  let i = 0;
+  const c: Record<string, unknown> = {};
+  for (const m of ["select", "eq", "in", "is", "insert", "update", "order"]) {
+    c[m] = jest.fn(() => c);
+  }
+  c.maybeSingle = jest.fn(async () =>
+    steps.maybeSingle ? steps.maybeSingle[i++] ?? steps.result : steps.result,
+  );
+  return c;
+}
+
+function jsonReq(url: string, method: string, body: unknown) {
+  return new Request(url, {
+    method,
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  // NOTE: deliberately NOT jest.resetModules() — the dynamically-imported routes
+  // must share the SAME mocked recordDogBrainEvent instance captured below as
+  // `emit`. resetModules would hand the route a fresh mock and the assertions
+  // would observe an empty call log. Per-test behavior comes from the auth /
+  // supabase mocks, not module state, so caching the route module is safe.
+  jest.clearAllMocks();
+  mockCheckRateLimit.mockResolvedValue({ success: true });
+});
+
+describe("followups POST → dog_brain_followup_created", () => {
+  const BODY = { pet_id: UUID, signal_key: "stool_change", prompt: "better/same/worse?" };
+
+  it("emits on a genuinely new follow-up (201)", async () => {
+    const pet = chain({ result: { data: { id: UUID }, error: null } });
+    const fu = chain({ maybeSingle: [{ data: null, error: null }, { data: { id: "new" }, error: null }] });
+    mockRequireAuth.mockResolvedValue({
+      supabase: { from: (t: string) => (t === "pets" ? pet : fu) },
+      user: { id: "u1" },
+    });
+    const { POST } = await import("../src/app/api/dog-brain/followups/route");
+    const res = await POST(jsonReq("http://x/api/dog-brain/followups", "POST", BODY));
+    expect(res.status).toBe(201);
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(lastEvent().name).toBe(DOG_BRAIN_EVENTS.followupCreated);
+  });
+
+  it("stays SILENT when the follow-up already exists (deduped)", async () => {
+    const pet = chain({ result: { data: { id: UUID }, error: null } });
+    const fu = chain({ result: { data: { id: "existing", status: "pending" }, error: null } });
+    mockRequireAuth.mockResolvedValue({
+      supabase: { from: (t: string) => (t === "pets" ? pet : fu) },
+      user: { id: "u1" },
+    });
+    const { POST } = await import("../src/app/api/dog-brain/followups/route");
+    const res = await POST(jsonReq("http://x/api/dog-brain/followups", "POST", BODY));
+    expect(res.status).toBe(200);
+    expect(emit).not.toHaveBeenCalled();
+  });
+});
+
+describe("followups/[id] PATCH → dog_brain_followup_outcome_recorded", () => {
+  it("emits the outcome bucket on a recorded outcome", async () => {
+    const fu = chain({ result: { data: { id: UUID, status: "worse" }, error: null } });
+    mockRequireAuth.mockResolvedValue({
+      supabase: { from: () => fu },
+      user: { id: "u1" },
+    });
+    const { PATCH } = await import("../src/app/api/dog-brain/followups/[id]/route");
+    const res = await PATCH(
+      jsonReq(`http://x/api/dog-brain/followups/${UUID}`, "PATCH", { status: "worse" }),
+      { params: Promise.resolve({ id: UUID }) },
+    );
+    expect(res.status).toBe(200);
+    expect(lastEvent().name).toBe(DOG_BRAIN_EVENTS.followupOutcomeRecorded);
+    expect(lastEvent().properties?.outcomeBucket).toBe("worse");
+  });
+});
+
+describe("supplements POST/PATCH → trial lifecycle events", () => {
+  it("POST emits supplement_trial_started (201)", async () => {
+    const trials = chain({ maybeSingle: [{ data: null, error: null }, { data: { id: "t1" }, error: null }] });
+    mockRequireOwnedPet.mockResolvedValue({
+      supabase: { from: () => trials },
+      user: { id: "u1" },
+      petId: UUID,
+    });
+    const { POST } = await import("../src/app/api/dog-brain/supplements/route");
+    const res = await POST(
+      jsonReq("http://x/api/dog-brain/supplements", "POST", {
+        pet_id: UUID,
+        supplement_name: "gut support",
+      }),
+    );
+    expect(res.status).toBe(201);
+    expect(lastEvent().name).toBe(DOG_BRAIN_EVENTS.supplementTrialStarted);
+  });
+
+  it("PATCH mark_active emits supplement_trial_marked_active", async () => {
+    const trials = chain({ result: { data: { id: UUID, status: "active" }, error: null } });
+    mockRequireAuth.mockResolvedValue({ supabase: { from: () => trials }, user: { id: "u1" } });
+    const { PATCH } = await import("../src/app/api/dog-brain/supplements/route");
+    const res = await PATCH(
+      jsonReq(`http://x/api/dog-brain/supplements?id=${UUID}`, "PATCH", { action: "mark_active" }),
+    );
+    expect(res.status).toBe(200);
+    expect(lastEvent().name).toBe(DOG_BRAIN_EVENTS.supplementTrialMarkedActive);
+  });
+
+  it("PATCH outcome emits supplement_trial_outcome_recorded with the bucket", async () => {
+    const trials = chain({ result: { data: { id: UUID, status: "outcome_recorded" }, error: null } });
+    mockRequireAuth.mockResolvedValue({ supabase: { from: () => trials }, user: { id: "u1" } });
+    const { PATCH } = await import("../src/app/api/dog-brain/supplements/route");
+    const res = await PATCH(
+      jsonReq(`http://x/api/dog-brain/supplements?id=${UUID}`, "PATCH", { outcome: "worse" }),
+    );
+    expect(res.status).toBe(200);
+    expect(lastEvent().name).toBe(DOG_BRAIN_EVENTS.supplementTrialOutcomeRecorded);
+    expect(lastEvent().properties?.outcomeBucket).toBe("worse");
+  });
+});

--- a/tests/dog-brain-analytics.test.ts
+++ b/tests/dog-brain-analytics.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Dog Brain analytics — privacy-safe usage events.
+ *
+ * Covers:
+ *   - each builder emits the expected event name + enum/count payload
+ *   - payloads carry ONLY allow-listed enum keys; values are bounded
+ *   - measurements are non-negative integers (counts), defensively normalized
+ *   - raw outcome strings coerce into the bounded bucket vocabulary
+ *   - routing through the shared sink emits the prefixed name with no free text
+ *   - demo mode (no connection string) is a silent no-op
+ */
+
+import {
+  DOG_BRAIN_EVENTS,
+  brainContextLoadedEvent,
+  brainQuestionTraceEmittedEvent,
+  emergencyTraceSuppressedEvent,
+  dogBrainFollowupCreatedEvent,
+  dogBrainFollowupOutcomeRecordedEvent,
+  supplementTrialStartedEvent,
+  supplementTrialMarkedActiveEvent,
+  supplementTrialOutcomeRecordedEvent,
+  recordDogBrainEvent,
+  toOutcomeBucket,
+} from "@/lib/dog-brain/analytics";
+import type {
+  TelemetryEnvelope,
+  TelemetryTransportRequest,
+  TriageTelemetryEvent,
+} from "@/lib/azure/telemetry";
+import type { SecretClientLike } from "@/lib/azure";
+
+const CONFIGURED_ENV = {
+  AZURE_TENANT_ID: "test-tenant-id",
+  AZURE_CLIENT_ID: "test-client-id",
+  AZURE_CLIENT_SECRET: "test-client-secret",
+  AZURE_KEY_VAULT_NAME: "test-vault",
+};
+
+const TEST_CONNECTION_STRING =
+  "InstrumentationKey=test-key-000;IngestionEndpoint=https://test.in.applicationinsights.azure.com/";
+
+function makeConnectedSecretClient(): SecretClientLike {
+  return {
+    getSecret: async (name: string) => ({
+      value:
+        name === "appinsights-connection-string" ? TEST_CONNECTION_STRING : null,
+    }),
+  };
+}
+
+function makeMockTransport() {
+  return jest.fn(async () => undefined);
+}
+
+type EventEnvelope = Extract<
+  TelemetryEnvelope,
+  { data: { baseType: "EventData" } }
+>;
+
+function getEnvelope(transport: jest.Mock): EventEnvelope {
+  const request = transport.mock.calls[0]?.[0] as
+    | TelemetryTransportRequest
+    | undefined;
+  if (!request || request.envelope.data.baseType !== "EventData") {
+    throw new Error("expected an EventData envelope");
+  }
+  return request.envelope as EventEnvelope;
+}
+
+// Only these property keys are ever allowed on a Dog Brain analytics event.
+const ALLOWED_PROPERTY_KEYS = new Set(["questionSource", "outcomeBucket"]);
+
+function assertPrivacySafe(event: TriageTelemetryEvent) {
+  for (const key of Object.keys(event.properties ?? {})) {
+    expect(ALLOWED_PROPERTY_KEYS.has(key)).toBe(true);
+  }
+  for (const value of Object.values(event.measurements ?? {})) {
+    expect(typeof value).toBe("number");
+    expect(Number.isFinite(value as number)).toBe(true);
+    expect(value as number).toBeGreaterThanOrEqual(0);
+  }
+}
+
+describe("Dog Brain analytics builders — enums & counts", () => {
+  it("brain_context_loaded carries the four counts and no properties", () => {
+    const e = brainContextLoadedEvent({
+      signalCount: 3,
+      prioritySymptomCount: 2,
+      followupCount: 1,
+      supplementTrialCount: 1,
+    });
+    expect(e.name).toBe(DOG_BRAIN_EVENTS.contextLoaded);
+    expect(e.measurements).toEqual({
+      signalCount: 3,
+      prioritySymptomCount: 2,
+      followupCount: 1,
+      supplementTrialCount: 1,
+    });
+    expect(e.properties).toBeUndefined();
+    assertPrivacySafe(e);
+  });
+
+  it("normalizes negative / fractional / missing counts to non-negative integers", () => {
+    const e = brainContextLoadedEvent({
+      signalCount: -5,
+      prioritySymptomCount: 2.9,
+      // followupCount missing
+      supplementTrialCount: Number.NaN,
+    });
+    expect(e.measurements).toEqual({
+      signalCount: 0,
+      prioritySymptomCount: 2,
+      followupCount: 0,
+      supplementTrialCount: 0,
+    });
+    assertPrivacySafe(e);
+  });
+
+  it("brain_question_trace_emitted carries source enum + evidence count", () => {
+    const e = brainQuestionTraceEmittedEvent({ source: "brain_memory", evidenceCount: 4 });
+    expect(e.name).toBe(DOG_BRAIN_EVENTS.questionTraceEmitted);
+    expect(e.properties).toEqual({ questionSource: "brain_memory" });
+    expect(e.measurements).toEqual({ evidenceCount: 4 });
+    assertPrivacySafe(e);
+  });
+
+  it("emergency_question_trace_suppressed emits with source=emergency, no counts", () => {
+    const e = emergencyTraceSuppressedEvent();
+    expect(e.name).toBe(DOG_BRAIN_EVENTS.emergencyTraceSuppressed);
+    expect(e.properties).toEqual({ questionSource: "emergency" });
+    assertPrivacySafe(e);
+  });
+
+  it("followup + supplement lifecycle events carry only bounded enums", () => {
+    const events = [
+      dogBrainFollowupCreatedEvent(),
+      dogBrainFollowupOutcomeRecordedEvent({ outcome: "worse" }),
+      supplementTrialStartedEvent(),
+      supplementTrialMarkedActiveEvent(),
+      supplementTrialOutcomeRecordedEvent({ outcome: "side_effect" }),
+    ];
+    expect(events.map((e) => e.name)).toEqual([
+      DOG_BRAIN_EVENTS.followupCreated,
+      DOG_BRAIN_EVENTS.followupOutcomeRecorded,
+      DOG_BRAIN_EVENTS.supplementTrialStarted,
+      DOG_BRAIN_EVENTS.supplementTrialMarkedActive,
+      DOG_BRAIN_EVENTS.supplementTrialOutcomeRecorded,
+    ]);
+    events.forEach(assertPrivacySafe);
+    expect(events[1].properties).toEqual({ outcomeBucket: "worse" });
+    expect(events[4].properties).toEqual({ outcomeBucket: "side_effect" });
+  });
+});
+
+describe("toOutcomeBucket — bounded coercion", () => {
+  it.each([
+    ["improved", "better"],
+    ["BETTER", "better"],
+    ["unchanged", "same"],
+    ["worsening", "worse"],
+    ["side effect", "side_effect"],
+    ["adverse", "side_effect"],
+    ["", "unknown"],
+    ["owner typed a long note here", "unknown"],
+    [null, "unknown"],
+    [undefined, "unknown"],
+  ])("coerces %p → %p", (input, expected) => {
+    expect(toOutcomeBucket(input as string | null | undefined)).toBe(expected);
+  });
+});
+
+describe("recordDogBrainEvent — routing through the shared sink", () => {
+  it("is a silent no-op in demo mode (no connection string)", async () => {
+    const transport = makeMockTransport();
+    await recordDogBrainEvent(brainContextLoadedEvent({ signalCount: 1 }), { transport });
+    expect(transport).not.toHaveBeenCalled();
+  });
+
+  it("emits the 'pawvital.' prefixed event with only safe fields", async () => {
+    const transport = makeMockTransport();
+    await recordDogBrainEvent(
+      brainQuestionTraceEmittedEvent({ source: "brain_memory", evidenceCount: 2 }),
+      {
+        env: CONFIGURED_ENV,
+        secretClientFactory: () => makeConnectedSecretClient(),
+        transport,
+      },
+    );
+    const envelope = getEnvelope(transport);
+    expect(envelope.data.baseData.name).toBe(
+      "pawvital.dogbrain.question_trace.emitted",
+    );
+    expect(envelope.data.baseData.properties).toEqual({ questionSource: "brain_memory" });
+    expect(envelope.data.baseData.measurements).toEqual({ evidenceCount: 2 });
+    // No owner/pet/symptom keys leaked anywhere in the serialized envelope.
+    const serialized = JSON.stringify(envelope).toLowerCase();
+    for (const banned of ["symptom", "ownername", "petname", "notes", "photo"]) {
+      expect(serialized).not.toContain(banned);
+    }
+  });
+});

--- a/tests/dog-brain-memory-ranking.test.ts
+++ b/tests/dog-brain-memory-ranking.test.ts
@@ -1,0 +1,159 @@
+import {
+  rankDetectedSignals,
+  rankDetectedSignalsWithScores,
+  scoreDetectedSignal,
+  type MemoryRankingContext,
+} from "@/lib/dog-brain/memory-ranking";
+import type { DetectedSignal, SignalSeverity, SignalType } from "@/lib/dog-brain/types";
+
+const NOW = new Date("2026-06-23T12:00:00Z");
+
+function sig(
+  signal_type: SignalType,
+  severity: SignalSeverity,
+  dedupe_key = "",
+  extra: Partial<DetectedSignal> = {},
+): DetectedSignal {
+  return {
+    signal_type,
+    severity,
+    owner_message: `${signal_type} owner message`,
+    dedupe_key,
+    ...extra,
+  };
+}
+
+describe("rankDetectedSignals — supportive tiebreak ordering", () => {
+  it("returns empty for empty input (pure, no side effects)", () => {
+    expect(rankDetectedSignals([])).toEqual([]);
+  });
+
+  it("90-day repeated issue can outrank one old isolated note (same severity)", () => {
+    const repeated = sig(
+      "stool_change",
+      "watch",
+      "stool|2026-06-21|2026-06-19|2026-06-17|2026-06-15",
+    );
+    const isolated = sig("vomiting_trend", "watch", "vomit|2026-04-10");
+    const ranked = rankDetectedSignals([isolated, repeated], {}, NOW);
+    expect(ranked[0]).toBe(repeated);
+    expect(ranked[1]).toBe(isolated);
+  });
+
+  it("recent issue outranks an equally-severe old one (recency)", () => {
+    const recent = sig("appetite_drop", "watch", "appetite|2026-06-23");
+    const old = sig("skin_ear_change", "watch", "skin|2026-04-01");
+    const ranked = rankDetectedSignals([old, recent], {}, NOW);
+    expect(ranked[0]).toBe(recent);
+  });
+
+  it("supplement worse/side_effect outcome lifts a GI signal within its tier", () => {
+    const gi = sig("stool_change", "watch", "stool|2026-06-20");
+    const other = sig("mobility_pain_change", "watch", "mobility|2026-06-20");
+
+    // Without context the two are tied on every term → stable input order.
+    expect(rankDetectedSignals([other, gi], {}, NOW)).toEqual([other, gi]);
+
+    // A worsening supplement trial nudges the GI signal ahead.
+    const ctx: MemoryRankingContext = {
+      supplementTrials: [{ outcome: "worse", status: "active" }],
+    };
+    expect(rankDetectedSignals([other, gi], ctx, NOW)).toEqual([gi, other]);
+  });
+
+  it("an unresolved follow-up matching a signal lifts it within its tier", () => {
+    const matched = sig("vomiting_trend", "watch", "vomit|2026-06-20");
+    const unmatched = sig("mobility_pain_change", "watch", "mobility|2026-06-20");
+    const ctx: MemoryRankingContext = {
+      followups: [{ prompt: "Has the vomiting settled since your last check-in?", status: "pending" }],
+    };
+    expect(rankDetectedSignals([unmatched, matched], ctx, NOW)).toEqual([
+      matched,
+      unmatched,
+    ]);
+  });
+
+  it("a symptom-map-backed signal outranks an unmapped med-note signal at the same tier", () => {
+    const mapped = sig("vomiting_trend", "watch");
+    const unmapped = sig("possible_med_side_effect", "watch");
+    // Even with a concerning supplement trial (which the med-note signal is
+    // responsive to), the mapped signal still wins on map relevance.
+    const ctx: MemoryRankingContext = {
+      supplementTrials: [{ outcome: "side_effect", status: "active" }],
+    };
+    expect(rankDetectedSignals([unmapped, mapped], ctx, NOW)[0]).toBe(mapped);
+  });
+});
+
+describe("rankDetectedSignals — urgency safety contract", () => {
+  it("a benign info signal can NEVER outrank a higher-severity alert signal", () => {
+    const alert = sig("vomiting_trend", "alert"); // no dates, no extra credit
+    const benignRich = sig(
+      "stool_change",
+      "info",
+      "stool|2026-06-23|2026-06-22|2026-06-21|2026-06-20|2026-06-19",
+      { confidence: 1 },
+    );
+    const ranked = rankDetectedSignals([benignRich, alert], {}, NOW);
+    expect(ranked[0]).toBe(alert);
+  });
+
+  it("severity tier gap exceeds the max of all other terms combined", () => {
+    // Maximally-boosted watch signal vs a bare alert signal: alert still wins.
+    const bareAlert = sig("vomiting_trend", "alert");
+    const loadedWatch = sig(
+      "stool_change",
+      "watch",
+      "stool|2026-06-23|2026-06-22|2026-06-21|2026-06-20|2026-06-19",
+      { confidence: 1 },
+    );
+    const ctx: MemoryRankingContext = {
+      followups: [{ prompt: "stool update?", status: "pending" }],
+      supplementTrials: [{ outcome: "worse", status: "active" }],
+      vetRecordText: "history of loose stool and diarrhea",
+    };
+    const [a] = rankDetectedSignalsWithScores([loadedWatch, bareAlert], ctx, NOW);
+    expect(a.signal).toBe(bareAlert);
+  });
+
+  it("does not mutate the input signals (severity is preserved verbatim)", () => {
+    const input = [sig("stool_change", "info", "stool|2026-06-23"), sig("vomiting_trend", "alert")];
+    const before = JSON.parse(JSON.stringify(input));
+    rankDetectedSignals(input, {}, NOW);
+    expect(input).toEqual(before);
+  });
+
+  it("score is a finite number, never an urgency/severity string", () => {
+    const { score, signal } = scoreDetectedSignal(sig("stool_change", "watch", "stool|2026-06-23"), {}, NOW);
+    expect(typeof score).toBe("number");
+    expect(Number.isFinite(score)).toBe(true);
+    expect(signal.severity).toBe("watch"); // unchanged
+  });
+});
+
+describe("scoreDetectedSignal — deterministic components", () => {
+  it("ignores future/garbled dates (no recency credit)", () => {
+    const future = scoreDetectedSignal(sig("stool_change", "info", "stool|2099-01-01"), {}, NOW);
+    expect(future.components.recency).toBe(0);
+  });
+
+  it("credits repeated distinct dates but caps the contribution", () => {
+    const many = scoreDetectedSignal(
+      sig(
+        "stool_change",
+        "info",
+        "s|2026-06-23|2026-06-22|2026-06-21|2026-06-20|2026-06-19|2026-06-18|2026-06-17",
+      ),
+      {},
+      NOW,
+    );
+    expect(many.components.repetition).toBe(25); // min(count,5)*5
+  });
+
+  it("is stable for equal scores (input order preserved)", () => {
+    const a = sig("stool_change", "watch", "stool|2026-06-20");
+    const b = sig("vomiting_trend", "watch", "vomit|2026-06-20");
+    expect(rankDetectedSignals([a, b], {}, NOW)).toEqual([a, b]);
+    expect(rankDetectedSignals([b, a], {}, NOW)).toEqual([b, a]);
+  });
+});

--- a/tests/e2e/dog-brain-live-e2e.ts
+++ b/tests/e2e/dog-brain-live-e2e.ts
@@ -1,0 +1,297 @@
+/**
+ * Dog Brain live E2E — investor-demo proof harness (Phase 4).
+ *
+ * Proves the full memory loop against a REAL deployment:
+ *   seed 14/60/90-day logs + follow-up + supplement trial
+ *     → open the symptom checker
+ *     → poll until a memory-driven question appears (brain_question_trace populated)
+ *     → assert the emergency path SUPPRESSES the trace
+ *     → clean up and prove 0 residual rows
+ *     → write screenshots/artifacts
+ *
+ * SAFETY:
+ *   - Env-gated: with required secrets absent it logs SKIP and exits 0 (never
+ *     writes anything). Intended to run only from the manual workflow_dispatch
+ *     CI job, never automatically on every PR.
+ *   - All seeded rows + the sandbox auth user are deleted in `finally`, then a
+ *     residual count is asserted to be 0. A non-zero residual fails the run.
+ *   - It touches whatever project the SUPABASE_SERVICE_ROLE_KEY belongs to —
+ *     point it at a sandbox/staging project, never shared prod data.
+ *
+ * STATUS: authored, NOT yet executed against a live deployment. Selectors for
+ *   the login form are resilient (role/type based) but should be validated on
+ *   the first operator run; the trace assertions hit the API contract directly
+ *   (robust). See docs/dog-brain/INVESTOR_DEMO_HARDENING_STATE.md.
+ *
+ * Run: SUPABASE_SERVICE_ROLE_KEY=… E2E_BASE_URL=… E2E_SANDBOX_EMAIL=… \
+ *      E2E_SANDBOX_PASSWORD=… npx ts-node --esm scripts/e2e/dog-brain-live-e2e.ts
+ */
+
+import { chromium, type APIRequestContext } from "@playwright/test";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+interface SymptomChatResponse {
+  type?: string;
+  message?: string;
+  brain_question_trace?: { evidence_summary?: string } | null;
+}
+
+const ARTIFACT_DIR = join(process.cwd(), "artifacts", "dog-brain-e2e");
+const SANDBOX_PET_NAME = "E2E Bruno (sandbox)";
+const MAX_MEMORY_TURNS = 8;
+
+function requireEnv(): {
+  baseUrl: string;
+  supabaseUrl: string;
+  serviceRoleKey: string;
+  email: string;
+  password: string;
+} | null {
+  const baseUrl = process.env.E2E_BASE_URL?.trim();
+  const supabaseUrl = (
+    process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL
+  )?.trim();
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY?.trim();
+  const email = process.env.E2E_SANDBOX_EMAIL?.trim();
+  const password = process.env.E2E_SANDBOX_PASSWORD?.trim();
+
+  if (!baseUrl || !supabaseUrl || !serviceRoleKey || !email || !password) {
+    return null;
+  }
+  return { baseUrl, supabaseUrl, serviceRoleKey, email, password };
+}
+
+function isoDaysAgo(days: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - days);
+  return d.toISOString().slice(0, 10);
+}
+
+/** 90-day storyline: baseline → soft stool → reduced appetite → vomiting today. */
+function buildLogRows(userId: string, petId: string) {
+  const rows: Record<string, unknown>[] = [];
+  for (let d = 90; d >= 0; d--) {
+    let appetite = "normal";
+    let stool = "normal";
+    let vomiting = 0;
+    if (d <= 30 && d > 10) stool = "soft";
+    if (d <= 10 && d > 3) {
+      stool = "soft";
+      appetite = "reduced";
+    }
+    if (d <= 3) {
+      stool = "diarrhea";
+      appetite = "reduced";
+      vomiting = d === 0 ? 2 : 1;
+    }
+    rows.push({
+      user_id: userId,
+      pet_id: petId,
+      log_date: isoDaysAgo(d),
+      appetite,
+      water: "normal",
+      stool,
+      urination: "normal",
+      vomiting_count: vomiting,
+      energy: d <= 5 ? "low" : "normal",
+      context_signals:
+        stool !== "normal"
+          ? { gi: { change_note: "softer stool than usual" } }
+          : {},
+    });
+  }
+  return rows;
+}
+
+async function seed(admin: SupabaseClient, email: string, password: string) {
+  const { data: created, error: userErr } = await admin.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+  });
+  if (userErr || !created.user) {
+    throw new Error(`seed: createUser failed: ${userErr?.message ?? "no user"}`);
+  }
+  const userId = created.user.id;
+
+  // profiles row may be created by a trigger; upsert defensively (FK target).
+  await admin.from("profiles").upsert({ id: userId }, { onConflict: "id" });
+
+  const { data: pet, error: petErr } = await admin
+    .from("pets")
+    .insert({ user_id: userId, name: SANDBOX_PET_NAME, species: "dog", breed: "Mixed" })
+    .select("id")
+    .single();
+  if (petErr || !pet) {
+    throw new Error(`seed: pet insert failed: ${petErr?.message ?? "no pet"}`);
+  }
+  const petId = pet.id as string;
+
+  const { error: logErr } = await admin
+    .from("daily_health_logs")
+    .insert(buildLogRows(userId, petId));
+  if (logErr) throw new Error(`seed: daily_health_logs insert failed: ${logErr.message}`);
+
+  const { error: fuErr } = await admin.from("dog_brain_followups").insert({
+    user_id: userId,
+    pet_id: petId,
+    signal_key: "stool_change",
+    prompt: "It's been a few days since the stool change — better, same, or worse?",
+    status: "pending",
+    due_at: new Date().toISOString(),
+  });
+  if (fuErr) throw new Error(`seed: followup insert failed: ${fuErr.message}`);
+
+  const { error: stErr } = await admin.from("dog_brain_supplement_trials").insert({
+    user_id: userId,
+    pet_id: petId,
+    supplement_name: "gut-support (ask vet)",
+    reason_signal_key: "stool_change",
+    status: "active",
+    outcome: "worse",
+    started_at: new Date().toISOString(),
+  });
+  if (stErr) throw new Error(`seed: supplement trial insert failed: ${stErr.message}`);
+
+  return { userId, petId };
+}
+
+async function postSymptomChat(
+  request: APIRequestContext,
+  baseUrl: string,
+  petId: string,
+  messages: { role: "user" | "assistant"; content: string }[],
+): Promise<SymptomChatResponse> {
+  const res = await request.post(`${baseUrl}/api/ai/symptom-chat`, {
+    data: {
+      messages,
+      pet: { id: petId, name: SANDBOX_PET_NAME, species: "dog", breed: "Mixed" },
+    },
+  });
+  if (!res.ok()) {
+    throw new Error(`symptom-chat HTTP ${res.status()}: ${await res.text()}`);
+  }
+  return (await res.json()) as SymptomChatResponse;
+}
+
+async function cleanup(admin: SupabaseClient, userId: string, petId: string) {
+  await admin.from("dog_brain_supplement_trials").delete().eq("pet_id", petId);
+  await admin.from("dog_brain_followups").delete().eq("pet_id", petId);
+  await admin.from("daily_health_logs").delete().eq("pet_id", petId);
+  await admin.from("pets").delete().eq("id", petId);
+  await admin.auth.admin.deleteUser(userId);
+
+  // Prove 0 residual.
+  let residual = 0;
+  for (const table of [
+    "dog_brain_supplement_trials",
+    "dog_brain_followups",
+    "daily_health_logs",
+  ]) {
+    const { count } = await admin
+      .from(table)
+      .select("id", { count: "exact", head: true })
+      .eq("pet_id", petId);
+    residual += count ?? 0;
+  }
+  const { count: petCount } = await admin
+    .from("pets")
+    .select("id", { count: "exact", head: true })
+    .eq("id", petId);
+  residual += petCount ?? 0;
+  if (residual !== 0) {
+    throw new Error(`CLEANUP FAILED: ${residual} residual row(s) remain — manual purge required`);
+  }
+  console.log("[e2e] cleanup OK — 0 residual rows");
+}
+
+async function main() {
+  const env = requireEnv();
+  if (!env) {
+    console.log(
+      "[e2e] SKIP — required env missing (E2E_BASE_URL, SUPABASE_URL, " +
+        "SUPABASE_SERVICE_ROLE_KEY, E2E_SANDBOX_EMAIL, E2E_SANDBOX_PASSWORD). No writes performed.",
+    );
+    process.exit(0);
+  }
+  mkdirSync(ARTIFACT_DIR, { recursive: true });
+
+  const admin = createClient(env.supabaseUrl, env.serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  let seeded: { userId: string; petId: string } | null = null;
+  const browser = await chromium.launch();
+  try {
+    seeded = await seed(admin, env.email, env.password);
+    console.log(`[e2e] seeded user=${seeded.userId} pet=${seeded.petId}`);
+
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    // Log in through the real UI to establish the session cookie.
+    await page.goto(`${env.baseUrl}/login`, { waitUntil: "domcontentloaded" });
+    await page.locator('input[type="email"]').first().fill(env.email);
+    await page.locator('input[type="password"]').first().fill(env.password);
+    await page.getByRole("button", { name: /sign in|log in/i }).first().click();
+    await page.waitForLoadState("networkidle");
+
+    // Poll the symptom checker until a memory-driven question surfaces. The
+    // current complaint wins first (Phase 1), so brain memory appears after the
+    // complaint's own questions are exhausted — hence the multi-turn poll.
+    const messages: { role: "user" | "assistant"; content: string }[] = [
+      { role: "user", content: "He vomited twice today and seems a bit off." },
+    ];
+    let memoryTrace: string | null = null;
+    for (let turn = 0; turn < MAX_MEMORY_TURNS; turn++) {
+      const resp = await postSymptomChat(context.request, env.baseUrl, seeded.petId, messages);
+      const trace = resp.brain_question_trace?.evidence_summary;
+      if (typeof trace === "string" && trace.length > 0) {
+        memoryTrace = trace;
+        break;
+      }
+      messages.push({ role: "assistant", content: resp.message ?? "(question)" });
+      messages.push({ role: "user", content: "No, nothing like that." });
+    }
+    if (!memoryTrace) {
+      throw new Error(
+        `ASSERTION FAILED: no brain_question_trace surfaced within ${MAX_MEMORY_TURNS} turns`,
+      );
+    }
+    console.log(`[e2e] memory-driven question proven — trace: "${memoryTrace}"`);
+
+    await page.goto(`${env.baseUrl}/symptom-checker`, { waitUntil: "networkidle" });
+    await page.screenshot({ path: join(ARTIFACT_DIR, "symptom-checker.png"), fullPage: true });
+
+    // Emergency must SUPPRESS the trace.
+    const emergency = await postSymptomChat(context.request, env.baseUrl, seeded.petId, [
+      {
+        role: "user",
+        content: "He collapsed and is having a seizure that won't stop and his gums are pale.",
+      },
+    ]);
+    const emergencyTrace = emergency.brain_question_trace?.evidence_summary;
+    if (typeof emergencyTrace === "string" && emergencyTrace.length > 0) {
+      throw new Error("ASSERTION FAILED: emergency turn did NOT suppress brain_question_trace");
+    }
+    console.log("[e2e] emergency path suppresses the trace — OK");
+
+    writeFileSync(
+      join(ARTIFACT_DIR, "result.json"),
+      JSON.stringify({ memoryTrace, emergencyType: emergency.type, passed: true }, null, 2),
+    );
+    console.log("[e2e] PASS");
+  } finally {
+    if (seeded) {
+      await cleanup(admin, seeded.userId, seeded.petId);
+    }
+    await browser.close();
+  }
+}
+
+main().catch((err) => {
+  console.error("[e2e] FAILED:", err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/tests/symptom-chat.route.test.ts
+++ b/tests/symptom-chat.route.test.ts
@@ -56,6 +56,7 @@ const mockEmit = jest.fn();
 const mockCalibrateDiagnosticConfidence = jest.fn();
 const mockTrackRouteTelemetry = jest.fn();
 const mockTrackException = jest.fn();
+const mockTrackEvent = jest.fn();
 const mockPublishTriageLiveUpdate = jest.fn();
 const mockRequireAuthenticatedApiUser = jest.fn().mockResolvedValue({
   user: { id: "test-user-id" },
@@ -267,6 +268,9 @@ jest.mock("@/lib/events/notification-handler", () => ({}));
 jest.mock("@/lib/azure/telemetry", () => ({
   trackRouteTelemetry: (...args: unknown[]) => mockTrackRouteTelemetry(...args),
   trackException: (...args: unknown[]) => mockTrackException(...args),
+  // The Dog Brain analytics module routes its events through trackEvent; provide
+  // it so the deferred telemetry block (run inline in tests) does not throw.
+  trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
 }));
 
 // The route defers post-response side effects (telemetry) via runAfterSafely,


### PR DESCRIPTION
## Investor-demo hardening — Dog Brain memory loop

Hardens the already-live Dog Brain MVP (PRs #706–#710) into investor-demo-ready
shape. **Additive only** — the deterministic clinical files (`triage-engine.ts`,
`clinical-matrix.ts`, `symptom-memory.ts`) are untouched; `symptom-chat/route.ts`
gains only isolated, deferred telemetry.

### What landed
- **60/90-day memory ranking** (`src/lib/dog-brain/memory-ranking.ts`) — pure module so the symptom-checker tiebreak surfaces the most useful long-memory signals (recent / repeated / follow-up- or supplement-linked) ahead of isolated old notes. **Severity stays dominant → never changes deterministic urgency.** +13 tests.
- **Privacy-safe loop analytics** (`src/lib/dog-brain/analytics.ts`) — 8 `dogbrain.*` events over the existing App Insights sink; counts/enums only (free text structurally impossible). Wired into followups + supplements CRUD routes and the symptom-chat route (`brain_context_loaded`, `brain_question_trace.emitted`). +27 tests.
- **Curated clinical knowledge layer** (`src/lib/clinical/{knowledge-base,clinical-patterns,root-cause-hypotheses,supplement-guardrails}.ts`) — 8 owner-observable domains, non-diagnostic evidence-gated hypotheses, and a hard-fail supplement validator (rejects dosage/brand/price/disease-claim/no-evidence). NON-AUTHORITATIVE urgency floor, separate from triage. +17 tests.
- **Manual live-E2E harness** (`.github/workflows/dog-brain-live-e2e.yml` + `tests/e2e/dog-brain-live-e2e.ts`) — env-gated `workflow_dispatch`: seed → memory-question poll → emergency-suppression assert → cleanup → 0-residual.
- **Supabase migration-ledger runbook** (`docs/runbooks/...`) — verify + repair commands; live verify deferred because the connected MCP project is wrong (not faked).

### Verification
- `npm run typecheck` clean · `npx eslint` 0 errors
- Targeted suite (`clinical|dog-brain|symptom|health-log|followups|vet-record|supplement`): **2382 passing**, incl. symptom-chat route **624 passing**
- `build` deferred to NTFS/Vercel (local `G:` is exFAT)

### Not in this PR (honest gaps)
- `emergency_question_trace_suppressed` emit (would touch multiple emergency early-returns — out of scope for a trace-only change; emergency path already emits no trace).
- Live E2E + Supabase live-verify: require operator secrets / correct project link.
- Knowledge-layer route/UI wiring (modules are tested infra, staged for a follow-up).

Thermo-review verdict: **APPROVE** (no blocking findings; two minor DRY follow-ups noted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
