### PR TITLE
feat(dog-brain): wire curated knowledge layer into vet-handoff report context

### DIFF
--- a/src/lib/health-log/dog-brain-context.ts
+++ b/src/lib/health-log/dog-brain-context.ts
@@ -6,12 +6,17 @@ import {
   type FollowupContextRow,
 } from "./context";
 import { detectDogBrainSignals } from "@/lib/dog-brain/signals";
+import type { DetectedSignal, SignalType } from "@/lib/dog-brain/types";
 import {
   brainPrioritySymptomsFromSignals,
   brainPrioritySymptomEvidence,
   type BrainSymptomEvidence,
 } from "@/lib/dog-brain/question-priority";
 import { rankDetectedSignals } from "@/lib/dog-brain/memory-ranking";
+import {
+  buildRootCauseHypotheses,
+  HYPOTHESIS_SAFETY_BOUNDARY,
+} from "@/lib/clinical/root-cause-hypotheses";
 
 export interface DogBrainContextData {
   /** Supportive narrative for the report prompt; null = skip context. */
@@ -110,6 +115,52 @@ function contextSignalsSummary(signals: ContextSignals): string {
   }
 
   return parts.length > 0 ? parts.join("; ") : "";
+}
+
+/**
+ * Render the curated, NON-DIAGNOSTIC vet-handoff knowledge for the detected Dog
+ * Brain signals as a supportive context block. Pure; no I/O.
+ *
+ * Wires the deterministic clinical knowledge layer (`buildRootCauseHypotheses`)
+ * into the symptom-checker report context. It NEVER touches deterministic triage:
+ * the output is appended to the supportive `context` string only (read by
+ * buildNarrativeReportPrompt, never by triage logic), carries the same
+ * non-override disclaimer as every other section, and deliberately omits the
+ * knowledge layer's owner-facing urgency floor so it can never be mistaken for
+ * the authoritative urgency. Returns "" when there is no evidence-backed pattern
+ * (the aggregator is evidence-gated — no dog-specific evidence ⇒ no output).
+ */
+export function buildDogBrainVetHandoffSection(
+  detectedSignals: DetectedSignal[],
+  disclaimer: string,
+): string {
+  const presentSignalKeys = detectedSignals.map((s) => s.signal_type);
+  const evidenceSummaries: Partial<Record<SignalType, string>> = {};
+  for (const s of detectedSignals) {
+    const text = (s.vet_handoff_text ?? s.owner_message ?? "").trim();
+    if (text && !evidenceSummaries[s.signal_type]) {
+      evidenceSummaries[s.signal_type] = text;
+    }
+  }
+
+  const hypotheses = buildRootCauseHypotheses({
+    presentSignalKeys,
+    evidenceSummaries,
+  }).slice(0, 3);
+  if (hypotheses.length === 0) return "";
+
+  const lines = hypotheses.map((h) => {
+    const missing = h.missing_information.length
+      ? ` Still worth checking: ${h.missing_information.join(", ")}.`
+      : "";
+    return `- ${h.hypothesis_label}: helpful to tell the vet or ask next — ${h.next_best_question}${missing}`;
+  });
+
+  return [
+    `Dog Brain pattern notes — DETERMINISTIC, NON-DIAGNOSTIC. Owner-reported patterns only; never a diagnosis and never an urgency decision (${disclaimer}):`,
+    ...lines,
+    HYPOTHESIS_SAFETY_BOUNDARY,
+  ].join("\n");
 }
 
 export async function loadDogBrainContextWithSignals({
@@ -341,6 +392,14 @@ export async function loadDogBrainContextWithSignals({
     const prioritySymptoms = brainPrioritySymptomsFromSignals(rankedSignals);
     const prioritySymptomEvidence =
       brainPrioritySymptomEvidence(rankedSignals);
+
+    // Curated, non-diagnostic vet-handoff knowledge for the detected signals.
+    // Supportive context only — never feeds deterministic triage/urgency.
+    const vetHandoffSection = buildDogBrainVetHandoffSection(
+      detectedSignals,
+      disclaimer,
+    );
+    if (vetHandoffSection) sections.push(vetHandoffSection);
 
     return {
       context: sections.length === 0 ? null : sections.join("\n\n"),

--- a/tests/dog-brain-context.test.ts
+++ b/tests/dog-brain-context.test.ts
@@ -4,10 +4,13 @@ import { buildVetTimeline } from "@/lib/analytics/vet-timeline";
 import type { SymptomCheckEntry } from "@/components/timeline/types";
 import type { JournalEntry } from "@/types/journal";
 import { detectDogBrainSignals } from "@/lib/dog-brain/signals";
+import type { DetectedSignal } from "@/lib/dog-brain/types";
 import {
   brainPrioritySymptomsFromSignals,
   brainPrioritySymptomEvidence,
 } from "@/lib/dog-brain/question-priority";
+import { buildDogBrainVetHandoffSection } from "@/lib/health-log/dog-brain-context";
+import { HYPOTHESIS_SAFETY_BOUNDARY } from "@/lib/clinical/root-cause-hypotheses";
 
 /** Minimal HealthLog factory */
 function log(overrides: Partial<HealthLog> = {}): HealthLog {
@@ -189,6 +192,74 @@ describe("brainPrioritySymptomEvidence from detected signals", () => {
     ];
     const signals = detectDogBrainSignals(normalLogs).signals;
     expect(brainPrioritySymptomEvidence(signals)).toEqual({});
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Curated vet-handoff knowledge section (wires the deterministic clinical
+// knowledge layer into the supportive report context — never into triage).
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("buildDogBrainVetHandoffSection — non-diagnostic knowledge wiring", () => {
+  const DISCLAIMER =
+    "Owner-reported observations, not clinical measurements; supportive context " +
+    "only — do not override clinical assessment.";
+
+  // Newest 3 logs (detector RECENT_WINDOW) with several digestive signs, so the
+  // detector emits evidence-bearing stool_change + vomiting_trend + appetite_drop.
+  const digestiveLogs = [
+    log({ log_date: "2026-06-18", stool: "diarrhea", vomiting_count: 2, appetite: "reduced" }),
+    log({ log_date: "2026-06-17", stool: "diarrhea", vomiting_count: 1, appetite: "reduced" }),
+    log({ log_date: "2026-06-16", stool: "soft", vomiting_count: 1, appetite: "normal" }),
+  ];
+
+  it("renders an evidence-backed, non-diagnostic pattern note for digestive signs", () => {
+    const signals = detectDogBrainSignals(digestiveLogs).signals;
+    const out = buildDogBrainVetHandoffSection(signals, DISCLAIMER);
+
+    expect(out).toContain("digestive pattern");
+    // Carries the safety boundary and the non-override disclaimer verbatim.
+    expect(out).toContain(HYPOTHESIS_SAFETY_BOUNDARY);
+    expect(out.toLowerCase()).toContain("do not override clinical assessment");
+    expect(out.toLowerCase()).toContain("non-diagnostic");
+  });
+
+  it("never emits diagnosis, dosage, price, brand, or a disease name", () => {
+    const signals = detectDogBrainSignals(digestiveLogs).signals;
+    const out = buildDogBrainVetHandoffSection(signals, DISCLAIMER);
+
+    // Reject diagnostic CLAIMS and disease names — but not the negated safety
+    // phrasing ("non-diagnostic" / "not a diagnosis"), which we require above.
+    expect(out.toLowerCase()).not.toMatch(/likely has|diagnosis is|diagnosis:|most likely it'?s/);
+    expect(out.toLowerCase()).not.toMatch(/gastroenteritis|cancer|parvo|diabetes|pancreatitis|arthritis/);
+    expect(out).not.toMatch(/\b\d+(\.\d+)?\s*(mg|mcg|ml|iu|tsp|tbsp|capsules?|tablets?)\b/i);
+    expect(out).not.toMatch(/\$\s*\d/);
+    expect(out).not.toMatch(/[®™]/);
+  });
+
+  it("omits the knowledge urgency floor so it can't be read as triage urgency", () => {
+    const signals = detectDogBrainSignals(digestiveLogs).signals;
+    const out = buildDogBrainVetHandoffSection(signals, DISCLAIMER);
+    // The raw floor enum tokens must never leak into owner/LLM-facing context.
+    expect(out).not.toMatch(/self_monitor|call_vet|urgency_floor/);
+  });
+
+  it("returns empty string when no signals are present (all-normal logs)", () => {
+    const normalLogs = [
+      log({ log_date: "2026-06-18" }),
+      log({ log_date: "2026-06-17" }),
+      log({ log_date: "2026-06-16" }),
+    ];
+    const signals = detectDogBrainSignals(normalLogs).signals;
+    expect(buildDogBrainVetHandoffSection(signals, DISCLAIMER)).toBe("");
+  });
+
+  it("is evidence-gated — signals without dog-specific evidence yield nothing", () => {
+    const signalsNoEvidence: DetectedSignal[] = [
+      { signal_type: "stool_change", severity: "watch", owner_message: "", dedupe_key: "s1" },
+      { signal_type: "vomiting_trend", severity: "watch", owner_message: "", dedupe_key: "v1" },
+    ];
+    expect(buildDogBrainVetHandoffSection(signalsNoEvidence, DISCLAIMER)).toBe("");
   });
 });
 


### PR DESCRIPTION
## What

Wires the **deterministic clinical knowledge layer** (`buildRootCauseHypotheses`) — built in PR #713 but previously wired into nothing — into the symptom-checker **report context**. This closes one of the two items deliberately deferred at the end of #713.

Adds a pure, exported helper `buildDogBrainVetHandoffSection` that turns the already-detected Dog Brain signals + their owner-reported evidence into a **NON-DIAGNOSTIC** "pattern notes" block: pattern label, the next useful owner/vet question, what's still worth checking, and the safety boundary.

## Why this is the safe slice

- Output is appended to the supportive `context` string **only** (read by `buildNarrativeReportPrompt`, never by deterministic triage logic).
- **Evidence-gated**: no dog-specific evidence ⇒ no output (cannot fabricate a pattern).
- **Deliberately omits the knowledge layer's urgency floor** so it can never be mistaken for the authoritative triage urgency.
- Carries the same non-override disclaimer as every other context section.
- Touches **none** of the protected clinical files (`triage-engine`, `clinical-matrix`, `symptom-chat/route.ts`, `symptom-memory`). Reuses the canonical aggregator instead of duplicating knowledge logic.

## Verification

- `tsc --noEmit`: clean
- `tests/dog-brain-context.test.ts`: 28/28 (5 new cases: evidence-backed render, no-diagnosis/dosage/brand, urgency-floor omitted, all-normal ⇒ "", evidence-gate)
- `dog-brain` + `symptom-chat` suites: 826/826
- thermo-review: **APPROVE** (no structural regression; full clinical-safety compliance)

## Deferred (unchanged from #713)

- `emergency_question_trace_suppressed` emit — confirmed it requires instrumenting clinical emergency early-return paths (`route.ts:1430/1603/1762`), real risk for a zero-user-value internal counter. Stays deferred.
- Live conversational-UI surfacing of the knowledge layer — a larger reviewed feature; this PR delivers the safe report-context slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)