### PR TITLE
feat(dog-brain): stage-proof closeout — calendar memory, crash-safe e2e, accurate telemetry

### DIFF
--- a/src/app/api/ai/symptom-chat/route.ts
+++ b/src/app/api/ai/symptom-chat/route.ts
@@ -809,6 +809,7 @@ export async function POST(request: Request) {
   // Privacy-safe Dog Brain analytics flags — set on the main path, emitted once
   // in the deferred telemetry block below. Never affect the response/payload.
   let brainContextPrioritySymptomCount: number | null = null;
+  let brainEvidenceItemCount = 0;
   let brainTraceWasEmitted = false;
   let liveUpdateTarget: LiveUpdateTarget | null = null;
   let liveUpdateChain: Promise<void> = Promise.resolve();
@@ -1014,8 +1015,11 @@ export async function POST(request: Request) {
         }
         brainPrioritySymptoms = prioritySymptoms;
         brainPrioritySymptomEvidence = prioritySymptomEvidence;
-        // Brain memory was consulted this turn (count only — never the content).
+        // Brain memory was consulted this turn (counts only — never the content).
         brainContextPrioritySymptomCount = prioritySymptoms.length;
+        // Distinct owner-evidence items backing the Brain's question selection —
+        // the real "evidenceCount" for the trace event (was hardcoded 1).
+        brainEvidenceItemCount = Object.keys(prioritySymptomEvidence).length;
       } catch {
         /* best-effort — Brain memory must never block the clinical turn */
       }
@@ -2580,9 +2584,22 @@ export async function POST(request: Request) {
       }
       if (brainTraceWasEmitted) {
         await recordDogBrainEvent(
-          brainQuestionTraceEmittedEvent({ source: "brain_memory", evidenceCount: 1 }),
+          brainQuestionTraceEmittedEvent({
+            source: "brain_memory",
+            evidenceCount: brainEvidenceItemCount,
+          }),
         );
       }
+      // TODO(dog-brain analytics): emergency_question_trace_suppressed is not
+      // emitted here. Detecting an emergency turn from this deferred block would
+      // require threading a flag through the 3+ emergency EARLY-RETURNS
+      // (deterministic-first-turn, ER_NOW, route-override) — clinical-route churn
+      // we deliberately avoid. The behavior is already correct (the emergency
+      // path returns no brain_question_trace); only the telemetry event is
+      // missing. Narrow future patch: set a single `let emergencyTurn = false`
+      // flag at each emergency-response construction site, then emit
+      // emergencyTraceSuppressedEvent() here when it is true — gated by the
+      // symptom-chat route suite.
     });
     await queueTriageLiveUpdate(
       liveUpdateTarget,

--- a/src/lib/health-log/dog-brain-context.ts
+++ b/src/lib/health-log/dog-brain-context.ts
@@ -51,11 +51,25 @@ const EMPTY_DOG_BRAIN_DATA: DogBrainContextData = {
  * richer output, zero additional Supabase round-trips vs. two separate calls.
  */
 
-// 90-day Dog Brain memory window (supportive report context only — never feeds
-// deterministic triage/urgency). Roughly one log/day → ~90 logs covers 90 days.
-const MAX_LOGS = 90;
+// Dog Brain memory window: a real 90-CALENDAR-DAY lookback (not just the latest
+// 90 rows). MAX_LOG_ROWS is a hard cap so a pet that logs many times per day can
+// never trigger a runaway query. Supportive report context only — never feeds
+// deterministic triage/urgency.
+const MEMORY_WINDOW_DAYS = 90;
+const MAX_LOG_ROWS = 400;
 const MAX_CHECKS = 30;
 const MAX_JOURNAL = 30;
+
+/**
+ * First in-window calendar day (YYYY-MM-DD), `MEMORY_WINDOW_DAYS` before `now`.
+ * A log whose `log_date >=` this string is inside the window; lexicographic
+ * comparison is correct for the YYYY-MM-DD format. Pure; exported for tests.
+ */
+export function memoryWindowStartDate(now: Date = new Date()): string {
+  const start = new Date(now);
+  start.setUTCDate(start.getUTCDate() - MEMORY_WINDOW_DAYS);
+  return start.toISOString().slice(0, 10);
+}
 
 function formatDate(iso: string): string {
   return iso.slice(0, 10);
@@ -166,8 +180,11 @@ export async function loadDogBrainContextWithSignals({
           .select("*")
           .eq("user_id", userId)
           .eq("pet_id", petId)
+          // Real calendar window: the last MEMORY_WINDOW_DAYS days, capped at
+          // MAX_LOG_ROWS rows (so multiple-logs-per-day stays bounded).
+          .gte("log_date", memoryWindowStartDate())
           .order("log_date", { ascending: false })
-          .limit(MAX_LOGS),
+          .limit(MAX_LOG_ROWS),
         supabase
           .from("symptom_checks")
           .select("id, created_at, symptoms, severity")
@@ -216,7 +233,7 @@ export async function loadDogBrainContextWithSignals({
     const logs = (logsResult.data ?? []) as HealthLog[];
     if (logs.length > 0) {
       // Long-window (full 90-day) trend summary — not just the last 14 days.
-      const logSummary = summarizeDailyLogsForContext(logs, petName, MAX_LOGS);
+      const logSummary = summarizeDailyLogsForContext(logs, petName, MAX_LOG_ROWS);
       if (logSummary) sections.push(logSummary);
 
       // Pack signals from the recent window (last ~14 days, newest first) — the

--- a/tests/dog-brain-calendar-window.test.ts
+++ b/tests/dog-brain-calendar-window.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Phase 2 — Dog Brain memory is a real 90-CALENDAR-DAY window, not latest-90-rows.
+ *
+ * `memoryWindowStartDate` is the lower bound the daily-log query filters on
+ * (`log_date >= start`). These tests pin the boundary: a 75-day-old log is in,
+ * a 100-day-old log is out, and the exact 90-day edge is included. Pure + UTC.
+ */
+import { memoryWindowStartDate } from "@/lib/health-log/dog-brain-context";
+
+const NOW = new Date("2026-06-24T12:00:00Z");
+
+function dayBefore(now: Date, days: number): string {
+  const d = new Date(now);
+  d.setUTCDate(d.getUTCDate() - days);
+  return d.toISOString().slice(0, 10);
+}
+
+describe("memoryWindowStartDate — 90 calendar-day lookback", () => {
+  it("is exactly 90 UTC days before now", () => {
+    expect(memoryWindowStartDate(NOW)).toBe("2026-03-26");
+    expect(memoryWindowStartDate(NOW)).toBe(dayBefore(NOW, 90));
+  });
+
+  it("includes a 75-day-old log (inside the window)", () => {
+    expect(dayBefore(NOW, 75) >= memoryWindowStartDate(NOW)).toBe(true);
+  });
+
+  it("excludes a 100-day-old log (outside the window)", () => {
+    expect(dayBefore(NOW, 100) >= memoryWindowStartDate(NOW)).toBe(false);
+  });
+
+  it("includes the exact 90-day boundary day", () => {
+    const start = memoryWindowStartDate(NOW);
+    expect(dayBefore(NOW, 90)).toBe(start);
+    expect(dayBefore(NOW, 90) >= start).toBe(true);
+  });
+
+  it("defaults to the current date when no argument is given (no throw)", () => {
+    expect(memoryWindowStartDate()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});

--- a/tests/dog-brain-e2e-cleanup.test.ts
+++ b/tests/dog-brain-e2e-cleanup.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Phase 1 — live-E2E harness crash-safe cleanup.
+ *
+ * Proves the seed/cleanup contract WITHOUT any network or browser: a seed that
+ * throws after the auth user is created still records the user id in the tracker,
+ * so the finally-block cleanup deletes it (no orphaned auth user). Uses a fake
+ * Supabase admin — the real `main()` is guarded by JEST_WORKER_ID and never runs.
+ */
+import {
+  seed,
+  cleanup,
+  buildLogRows,
+  type SeedTracker,
+} from "./e2e/dog-brain-live-e2e";
+
+type Deleted = { table: string; col: string; val: string };
+
+function makeAdmin(opts: {
+  createUserError?: boolean;
+  petInsertError?: boolean;
+  logInsertError?: boolean;
+  residual?: Record<string, number>;
+} = {}) {
+  const deleted: Deleted[] = [];
+  const deletedUsers: string[] = [];
+
+  const from = (table: string) => ({
+    upsert: async () => ({ error: null }),
+    insert: (_rows: unknown) => {
+      const awaited = {
+        error: opts.logInsertError && table !== "pets" ? { message: "log boom" } : null,
+      };
+      return {
+        select: (_c: string) => ({
+          single: async () => ({
+            data: opts.petInsertError ? null : { id: "pet-1" },
+            error: opts.petInsertError ? { message: "pet boom" } : null,
+          }),
+        }),
+        // makes `await admin.from(t).insert(rows)` resolve for non-pet tables
+        then: (resolve: (v: unknown) => void) => resolve(awaited),
+      };
+    },
+    delete: () => ({
+      eq: async (col: string, val: string) => {
+        deleted.push({ table, col, val });
+        return { error: null };
+      },
+    }),
+    select: (_c: string, _o?: unknown) => ({
+      eq: async () => ({ count: opts.residual?.[table] ?? 0 }),
+    }),
+  });
+
+  const admin = {
+    from,
+    auth: {
+      admin: {
+        createUser: async () => ({
+          data: { user: opts.createUserError ? null : { id: "user-1" } },
+          error: opts.createUserError ? { message: "createUser boom" } : null,
+        }),
+        deleteUser: async (id: string) => {
+          deletedUsers.push(id);
+          return { error: null };
+        },
+      },
+    },
+  };
+  // The harness types admin as SupabaseClient; this fake satisfies the calls used.
+  return { admin: admin as never, deleted, deletedUsers };
+}
+
+describe("live-E2E seed/cleanup — crash safety", () => {
+  it("records the auth user id BEFORE the pet insert, so a mid-seed failure can still clean it up", async () => {
+    const { admin, deleted, deletedUsers } = makeAdmin({ petInsertError: true });
+    const tracker: SeedTracker = {};
+
+    await expect(seed(admin, "sandbox@example.test", "pw", tracker)).rejects.toThrow(
+      /pet insert/,
+    );
+    // The user was created → tracker has it; the pet never was.
+    expect(tracker.userId).toBe("user-1");
+    expect(tracker.petId).toBeUndefined();
+
+    // Cleanup from the partial tracker must delete the orphaned user and NOT
+    // attempt any pet-row deletes (there is no pet).
+    await cleanup(admin, tracker);
+    expect(deletedUsers).toEqual(["user-1"]);
+    expect(deleted).toHaveLength(0);
+  });
+
+  it("a createUser failure leaves the tracker empty and cleanup is a no-op", async () => {
+    const { admin, deleted, deletedUsers } = makeAdmin({ createUserError: true });
+    const tracker: SeedTracker = {};
+    await expect(seed(admin, "s@example.test", "pw", tracker)).rejects.toThrow(
+      /createUser/,
+    );
+    expect(tracker.userId).toBeUndefined();
+    await cleanup(admin, tracker); // safe to call with an empty tracker
+    expect(deletedUsers).toHaveLength(0);
+    expect(deleted).toHaveLength(0);
+  });
+
+  it("a full seed populates both ids and cleanup deletes every table + the user", async () => {
+    const { admin, deleted, deletedUsers } = makeAdmin();
+    const tracker: SeedTracker = {};
+    const res = await seed(admin, "s@example.test", "pw", tracker);
+    expect(res).toEqual({ userId: "user-1", petId: "pet-1" });
+    expect(tracker).toEqual({ userId: "user-1", petId: "pet-1" });
+
+    await cleanup(admin, tracker);
+    expect(deletedUsers).toEqual(["user-1"]);
+    expect(deleted.map((d) => d.table)).toEqual([
+      "dog_brain_supplement_trials",
+      "dog_brain_followups",
+      "daily_health_logs",
+      "pets",
+    ]);
+  });
+
+  it("fails loudly if a residual row remains after cleanup", async () => {
+    const { admin } = makeAdmin({ residual: { daily_health_logs: 2 } });
+    const tracker: SeedTracker = { userId: "user-1", petId: "pet-1" };
+    await expect(cleanup(admin, tracker)).rejects.toThrow(/CLEANUP FAILED/);
+  });
+});
+
+describe("buildLogRows — seed spans a real 90-day window", () => {
+  it("produces one row per day across the full 0..90 day span", () => {
+    const rows = buildLogRows("u", "p");
+    expect(rows).toHaveLength(91); // days 90..0 inclusive
+    const dates = rows.map((r) => r.log_date as string);
+    expect(new Set(dates).size).toBe(91); // all distinct calendar days
+  });
+});

--- a/tests/dog-brain-report-context.integration.test.ts
+++ b/tests/dog-brain-report-context.integration.test.ts
@@ -24,6 +24,7 @@ function tableChain(rows: unknown[]) {
   const chain: Record<string, unknown> = {};
   chain.select = () => chain;
   chain.eq = () => chain;
+  chain.gte = () => chain; // calendar-window filter on daily_health_logs
   chain.order = () => chain;
   chain.limit = async () => ({ data: rows, error: null });
   return chain;

--- a/tests/dog-brain-supplement.test.ts
+++ b/tests/dog-brain-supplement.test.ts
@@ -480,7 +480,7 @@ describe("dog_brain_supplement_trials (minimal backend)", () => {
             return { select: () => ({ eq: () => ({ eq: () => ({ limit: async () => ({ data: [{ id: "p1" }] }) }) }) }) };
           }
           if (table === "daily_health_logs") {
-            return { select: () => ({ eq: () => ({ eq: () => ({ order: () => ({ limit: async () => ({ data: [{ log_date: "2026-01-01", appetite: "normal", water: "normal", stool: "normal", urination: "normal", vomiting_count: 0, energy: "normal", meds_given: false }] }) }) }) }) }) };
+            return { select: () => ({ eq: () => ({ eq: () => ({ gte: () => ({ order: () => ({ limit: async () => ({ data: [{ log_date: "2026-01-01", appetite: "normal", water: "normal", stool: "normal", urination: "normal", vomiting_count: 0, energy: "normal", meds_given: false }] }) }) }) }) }) }) };
           }
           if (table === "symptom_checks") {
             return { select: () => ({ eq: () => ({ order: () => ({ limit: async () => ({ data: [{ id: 'c1', created_at: '2026-01-01', symptoms: 'cough', severity: 'watch' }] }) }) }) }) };

--- a/tests/e2e/dog-brain-live-e2e.ts
+++ b/tests/e2e/dog-brain-live-e2e.ts
@@ -13,10 +13,16 @@
  *   - Env-gated: with required secrets absent it logs SKIP and exits 0 (never
  *     writes anything). Intended to run only from the manual workflow_dispatch
  *     CI job, never automatically on every PR.
- *   - All seeded rows + the sandbox auth user are deleted in `finally`, then a
- *     residual count is asserted to be 0. A non-zero residual fails the run.
+ *   - Crash-safe cleanup: every created resource is recorded in a `SeedTracker`
+ *     the instant it exists (auth user id captured immediately after createUser,
+ *     pet id immediately after insert). The `finally` block cleans up from that
+ *     tracker, so a seed that throws halfway — e.g. the pet insert fails AFTER
+ *     the auth user was created — still deletes the orphaned auth user. A
+ *     residual count is then asserted to be 0; a non-zero residual fails the run.
  *   - It touches whatever project the SUPABASE_SERVICE_ROLE_KEY belongs to —
  *     point it at a sandbox/staging project, never shared prod data.
+ *   - The CLI entry (`main()`) is guarded so importing this module for unit
+ *     tests never performs any writes.
  *
  * STATUS: authored, NOT yet executed against a live deployment. Selectors for
  *   the login form are resilient (role/type based) but should be validated on
@@ -24,13 +30,22 @@
  *   (robust). See docs/dog-brain/INVESTOR_DEMO_HARDENING_STATE.md.
  *
  * Run: SUPABASE_SERVICE_ROLE_KEY=… E2E_BASE_URL=… E2E_SANDBOX_EMAIL=… \
- *      E2E_SANDBOX_PASSWORD=… npx ts-node --esm scripts/e2e/dog-brain-live-e2e.ts
+ *      E2E_SANDBOX_PASSWORD=… npx ts-node --esm tests/e2e/dog-brain-live-e2e.ts
  */
 
 import { chromium, type APIRequestContext } from "@playwright/test";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+
+/**
+ * Records every resource the seed creates, the instant it is created, so the
+ * finally-block cleanup can delete partial state even if seed() throws midway.
+ */
+export interface SeedTracker {
+  userId?: string;
+  petId?: string;
+}
 
 interface SymptomChatResponse {
   type?: string;
@@ -73,7 +88,7 @@ function isoDaysAgo(days: number): string {
 }
 
 /** 90-day storyline: baseline → soft stool → reduced appetite → vomiting today. */
-function buildLogRows(userId: string, petId: string) {
+export function buildLogRows(userId: string, petId: string) {
   const rows: Record<string, unknown>[] = [];
   for (let d = 90; d >= 0; d--) {
     let appetite = "normal";
@@ -108,7 +123,12 @@ function buildLogRows(userId: string, petId: string) {
   return rows;
 }
 
-async function seed(admin: SupabaseClient, email: string, password: string) {
+export async function seed(
+  admin: SupabaseClient,
+  email: string,
+  password: string,
+  tracker: SeedTracker,
+): Promise<{ userId: string; petId: string }> {
   const { data: created, error: userErr } = await admin.auth.admin.createUser({
     email,
     password,
@@ -118,6 +138,9 @@ async function seed(admin: SupabaseClient, email: string, password: string) {
     throw new Error(`seed: createUser failed: ${userErr?.message ?? "no user"}`);
   }
   const userId = created.user.id;
+  // Record the auth user IMMEDIATELY — if any later step throws, cleanup must
+  // still know this id so the user is never orphaned.
+  tracker.userId = userId;
 
   // profiles row may be created by a trigger; upsert defensively (FK target).
   await admin.from("profiles").upsert({ id: userId }, { onConflict: "id" });
@@ -131,6 +154,8 @@ async function seed(admin: SupabaseClient, email: string, password: string) {
     throw new Error(`seed: pet insert failed: ${petErr?.message ?? "no pet"}`);
   }
   const petId = pet.id as string;
+  // Record the pet id immediately, before the dependent inserts below.
+  tracker.petId = petId;
 
   const { error: logErr } = await admin
     .from("daily_health_logs")
@@ -186,35 +211,55 @@ async function postSymptomChat(
   return (await res.json()) as SymptomChatResponse;
 }
 
-async function cleanup(admin: SupabaseClient, userId: string, petId: string) {
-  await admin.from("dog_brain_supplement_trials").delete().eq("pet_id", petId);
-  await admin.from("dog_brain_followups").delete().eq("pet_id", petId);
-  await admin.from("daily_health_logs").delete().eq("pet_id", petId);
-  await admin.from("pets").delete().eq("id", petId);
-  await admin.auth.admin.deleteUser(userId);
+/**
+ * Delete whatever the tracker says was created — tolerant of partial seeds. Safe
+ * to call with only a userId (pet insert never happened), only a petId, or both.
+ * Proves 0 residual for every id that exists. Never throws on a missing id.
+ */
+export async function cleanup(
+  admin: SupabaseClient,
+  tracker: SeedTracker,
+): Promise<void> {
+  const { petId, userId } = tracker;
 
-  // Prove 0 residual.
-  let residual = 0;
-  for (const table of [
-    "dog_brain_supplement_trials",
-    "dog_brain_followups",
-    "daily_health_logs",
-  ]) {
-    const { count } = await admin
-      .from(table)
-      .select("id", { count: "exact", head: true })
-      .eq("pet_id", petId);
-    residual += count ?? 0;
+  if (petId) {
+    await admin.from("dog_brain_supplement_trials").delete().eq("pet_id", petId);
+    await admin.from("dog_brain_followups").delete().eq("pet_id", petId);
+    await admin.from("daily_health_logs").delete().eq("pet_id", petId);
+    await admin.from("pets").delete().eq("id", petId);
   }
-  const { count: petCount } = await admin
-    .from("pets")
-    .select("id", { count: "exact", head: true })
-    .eq("id", petId);
-  residual += petCount ?? 0;
+  // Always delete the auth user last (its rows cascade, but we already removed
+  // them explicitly above for the residual proof).
+  if (userId) {
+    await admin.auth.admin.deleteUser(userId);
+  }
+
+  // Prove 0 residual for the pet's rows (only meaningful once a pet existed).
+  let residual = 0;
+  if (petId) {
+    for (const table of [
+      "dog_brain_supplement_trials",
+      "dog_brain_followups",
+      "daily_health_logs",
+    ]) {
+      const { count } = await admin
+        .from(table)
+        .select("id", { count: "exact", head: true })
+        .eq("pet_id", petId);
+      residual += count ?? 0;
+    }
+    const { count: petCount } = await admin
+      .from("pets")
+      .select("id", { count: "exact", head: true })
+      .eq("id", petId);
+    residual += petCount ?? 0;
+  }
   if (residual !== 0) {
     throw new Error(`CLEANUP FAILED: ${residual} residual row(s) remain — manual purge required`);
   }
-  console.log("[e2e] cleanup OK — 0 residual rows");
+  console.log(
+    `[e2e] cleanup OK — 0 residual rows (user=${userId ? "removed" : "n/a"}, pet=${petId ? "removed" : "n/a"})`,
+  );
 }
 
 async function main() {
@@ -232,10 +277,12 @@ async function main() {
     auth: { autoRefreshToken: false, persistSession: false },
   });
 
-  let seeded: { userId: string; petId: string } | null = null;
+  // The tracker is populated by seed() as each resource is created, so the
+  // finally block can clean up even a half-finished seed (no orphaned user).
+  const tracker: SeedTracker = {};
   const browser = await chromium.launch();
   try {
-    seeded = await seed(admin, env.email, env.password);
+    const seeded = await seed(admin, env.email, env.password, tracker);
     console.log(`[e2e] seeded user=${seeded.userId} pet=${seeded.petId}`);
 
     const context = await browser.newContext();
@@ -328,14 +375,19 @@ async function main() {
     );
     console.log("[e2e] PASS");
   } finally {
-    if (seeded) {
-      await cleanup(admin, seeded.userId, seeded.petId);
+    // Clean up whatever exists — even a partial seed (only a user, only a pet).
+    if (tracker.userId || tracker.petId) {
+      await cleanup(admin, tracker);
     }
     await browser.close();
   }
 }
 
-main().catch((err) => {
-  console.error("[e2e] FAILED:", err instanceof Error ? err.message : err);
-  process.exit(1);
-});
+// CLI entry only — never auto-run when imported by a unit test (which would
+// otherwise try to launch a browser / hit the network with no env configured).
+if (!process.env.JEST_WORKER_ID) {
+  main().catch((err) => {
+    console.error("[e2e] FAILED:", err instanceof Error ? err.message : err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Stage-proof closeout — Dog Brain memory loop

Closes a focused subset of the Codex-review gaps. **Additive / test-only / telemetry-only** — no deterministic clinical file touched (`triage-engine.ts`, `clinical-matrix.ts`, `symptom-memory.ts` untouched); the `symptom-chat/route.ts` change is telemetry-only.

### What landed
- **Phase 1 — crash-safe live-E2E cleanup** (`tests/e2e/dog-brain-live-e2e.ts` + new `tests/dog-brain-e2e-cleanup.test.ts`): a `SeedTracker` records each resource the instant it's created, so a seed that throws *after* the auth user is created (e.g. pet insert fails) still deletes the orphaned user. `cleanup()` tolerates partial state and still proves 0 residual. `main()` is guarded by `JEST_WORKER_ID` (import-safe). 5 unit tests (fake admin, no network).
- **Phase 2 — real 90-calendar-day memory window** (`src/lib/health-log/dog-brain-context.ts` + new `tests/dog-brain-calendar-window.test.ts`): the daily-log query now filters `log_date >= today-90d` (capped at `MAX_LOG_ROWS=400`) instead of "latest 90 rows". Pure exported `memoryWindowStartDate()` helper + boundary tests (75-day in, 100-day out, exact-90 edge in). Ranking unchanged; never feeds triage urgency.
- **Phase 4 — accurate trace telemetry** (`src/app/api/ai/symptom-chat/route.ts`): replaced hardcoded `evidenceCount: 1` with the real count of owner-evidence items backing the Brain's selection (`Object.keys(prioritySymptomEvidence).length`). Documented why `emergency_question_trace_suppressed` is intentionally not wired (would need a flag threaded through 3+ emergency early-returns; behavior already correct, only the event is missing) with a narrow future patch plan.

### What did NOT land (gated / owned elsewhere)
- **Phase 3 symptom-checker hypothesis wiring** — in flight via **PR #720** (`buildRootCauseHypotheses` → report context); not duplicated here.
- **Phase 7 live E2E run** — **STOPPED**: the `dog-brain-e2e` GitHub environment does not exist and no E2E/sandbox secrets are configured. The harness requires a sandbox project; I did not seed test data into prod. Setup instructions in the PR thread / final report.
- **Phase 5 UX polish** — not in this PR (needs a running dev server; demo-mode `loading.tsx` stall is a known blocker). No `.tsx` changes here.
- **Phase 3 supplement evidence-gating** — not attempted (larger change; overlaps the in-flight knowledge-layer work).

### Safety boundaries
No diagnosis / prescription / dosage / brand / price. Emergency urgency unchanged. Memory ranking and the calendar window are supportive context only — they never raise or lower deterministic triage urgency. Emergency path still returns no brain trace.

### Verification (exact results)
- `npm run typecheck` → clean
- `npx eslint .` → **0 errors** (59 pre-existing warnings)
- `npm test -- --testPathPatterns="clinical|dog-brain|symptom|health-log|followups|vet-record|supplement"` → **108 suites / 2392 tests pass**
- `npm test -- --testPathPatterns="symptom-chat"` → **11 suites / 624 pass** (route edit, no regression)
- `npm run build` → **success** (full production build on NTFS worktree, all routes generated)

### Known risks
- Potential merge overlap with PR #720 in `dog-brain-context.ts` (different regions; should auto-merge).
- `memoryWindowStartDate` widens the loaded log set; bounded by `MAX_LOG_ROWS=400`.

### Thermo-review verdict
APPROVE — no blocking findings (harness refactor is a net safety improvement; calendar window is a correctness fix; telemetry placeholder removed).

### Bumblebee
Not run — no package/dependency/lockfile changes in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
