### PR TITLE
feat(dog-brain): emit emergency_question_trace_suppressed telemetry

### DIFF
--- a/src/app/api/ai/symptom-chat/route.ts
+++ b/src/app/api/ai/symptom-chat/route.ts
@@ -168,6 +168,8 @@ import {
   recordDogBrainEvent,
   brainContextLoadedEvent,
   brainQuestionTraceEmittedEvent,
+  emergencyTraceSuppressedEvent,
+  shouldEmitEmergencyTraceSuppressed,
 } from "@/lib/dog-brain/analytics";
 import {
   isAsyncWorkerReplay,
@@ -810,6 +812,10 @@ export async function POST(request: Request) {
   // in the deferred telemetry block below. Never affect the response/payload.
   let brainContextPrioritySymptomCount: number | null = null;
   let brainTraceWasEmitted = false;
+  // Telemetry-only: set true immediately before each emergency-response return so
+  // the deferred block can record that an emergency pre-empted the Brain trace.
+  // Never read by clinical logic; never alters the emergency response.
+  let emergencyResponseReturned = false;
   let liveUpdateTarget: LiveUpdateTarget | null = null;
   let liveUpdateChain: Promise<void> = Promise.resolve();
   const queueTriageLiveUpdate = (
@@ -1427,6 +1433,7 @@ export async function POST(request: Request) {
                 };
               }
 
+              emergencyResponseReturned = true;
               return NextResponse.json(
                 buildVisionGuardrailEmergencyResponse({
                   petName: pet.name,
@@ -1607,6 +1614,7 @@ export async function POST(request: Request) {
         reason: "deterministic_emergency_first_turn",
       });
 
+      emergencyResponseReturned = true;
       return NextResponse.json(
         buildRedFlagEmergencyResponse({
           petName: pet.name,
@@ -2363,6 +2371,7 @@ export async function POST(request: Request) {
         reason: "red_flags_detected",
       });
 
+      emergencyResponseReturned = true;
       return NextResponse.json(
         buildRedFlagEmergencyResponse({
           petName: pet.name,
@@ -2402,6 +2411,7 @@ export async function POST(request: Request) {
         reason: "clinical_escalation",
       });
 
+      emergencyResponseReturned = true;
       return NextResponse.json({
         type: "emergency" as const,
         message: buildDeterministicEmergencyMessage(
@@ -2582,6 +2592,16 @@ export async function POST(request: Request) {
         await recordDogBrainEvent(
           brainQuestionTraceEmittedEvent({ source: "brain_memory", evidenceCount: 1 }),
         );
+      }
+      // An emergency response pre-empted a Brain trace this turn (counts only).
+      if (
+        shouldEmitEmergencyTraceSuppressed({
+          emergencyResponseReturned,
+          brainTraceWasEmitted,
+          brainContextPrioritySymptomCount,
+        })
+      ) {
+        await recordDogBrainEvent(emergencyTraceSuppressedEvent());
       }
     });
     await queueTriageLiveUpdate(

--- a/src/lib/dog-brain/analytics.ts
+++ b/src/lib/dog-brain/analytics.ts
@@ -118,6 +118,27 @@ export function emergencyTraceSuppressedEvent(): TriageTelemetryEvent {
   };
 }
 
+/**
+ * Decide whether a turn should emit the emergency-suppressed trace event. Pure.
+ *
+ * True ONLY when an emergency response was actually returned this turn AND Dog
+ * Brain memory with priority symptoms was loaded — i.e. a Brain question trace
+ * COULD have been surfaced but the emergency pre-empted it — AND no Brain trace
+ * was emitted. The route owns the inputs and calls this in its deferred
+ * telemetry block; this never affects the emergency response itself.
+ */
+export function shouldEmitEmergencyTraceSuppressed(input: {
+  emergencyResponseReturned: boolean;
+  brainTraceWasEmitted: boolean;
+  brainContextPrioritySymptomCount: number | null;
+}): boolean {
+  return (
+    input.emergencyResponseReturned &&
+    !input.brainTraceWasEmitted &&
+    (input.brainContextPrioritySymptomCount ?? 0) > 0
+  );
+}
+
 export function dogBrainFollowupCreatedEvent(): TriageTelemetryEvent {
   return { name: DOG_BRAIN_EVENTS.followupCreated };
 }

--- a/tests/dog-brain-analytics.test.ts
+++ b/tests/dog-brain-analytics.test.ts
@@ -15,6 +15,7 @@ import {
   brainContextLoadedEvent,
   brainQuestionTraceEmittedEvent,
   emergencyTraceSuppressedEvent,
+  shouldEmitEmergencyTraceSuppressed,
   dogBrainFollowupCreatedEvent,
   dogBrainFollowupOutcomeRecordedEvent,
   supplementTrialStartedEvent,
@@ -150,6 +151,39 @@ describe("Dog Brain analytics builders — enums & counts", () => {
     events.forEach(assertPrivacySafe);
     expect(events[1].properties).toEqual({ outcomeBucket: "worse" });
     expect(events[4].properties).toEqual({ outcomeBucket: "side_effect" });
+  });
+});
+
+describe("shouldEmitEmergencyTraceSuppressed — gate for the suppressed event", () => {
+  const base = {
+    emergencyResponseReturned: true,
+    brainTraceWasEmitted: false,
+    brainContextPrioritySymptomCount: 2,
+  };
+
+  it("emits only when an emergency returned with Brain priority memory and no trace", () => {
+    expect(shouldEmitEmergencyTraceSuppressed(base)).toBe(true);
+  });
+
+  it("stays silent when no emergency response was returned this turn", () => {
+    expect(
+      shouldEmitEmergencyTraceSuppressed({ ...base, emergencyResponseReturned: false }),
+    ).toBe(false);
+  });
+
+  it("stays silent when there was no Brain memory to suppress", () => {
+    expect(
+      shouldEmitEmergencyTraceSuppressed({ ...base, brainContextPrioritySymptomCount: null }),
+    ).toBe(false);
+    expect(
+      shouldEmitEmergencyTraceSuppressed({ ...base, brainContextPrioritySymptomCount: 0 }),
+    ).toBe(false);
+  });
+
+  it("stays silent when a Brain trace was actually emitted (not suppressed)", () => {
+    expect(
+      shouldEmitEmergencyTraceSuppressed({ ...base, brainTraceWasEmitted: true }),
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## What

Wires the previously-built-but-unemitted `emergencyTraceSuppressedEvent` — the second of the two items deferred at the end of PR #713. The analytics layer can now count turns where an **emergency response pre-empted a Dog Brain question trace**. Counts/enums only; internal App Insights sink; no-op without a connection string.

## Design — telemetry-only, zero clinical behavior change

- **Decision logic isolated** in a pure predicate `shouldEmitEmergencyTraceSuppressed()` in the canonical `dog-brain/analytics.ts` module, unit-tested via a 4-case truth table.
- **Protected route** (`symptom-chat/route.ts`) gets only a telemetry-only boolean `emergencyResponseReturned`, set immediately before each of the **4 emergency-response returns** (vision guardrail, deterministic first-turn red flag, STEP-3 red-flag override, clinical-escalation `type:"emergency"`), then emitted in the **existing** deferred `runAfterSafely` block beside the sibling brain-trace emit.
- Fires only when an emergency returned **AND** Brain priority memory was loaded **AND** no Brain trace was emitted. Deliberately **excludes** the non-emergency `buildTerminalOutcomeResponse` (cannot-assess) path — avoids mislabeling.

## Safety (clinical override)

No change to any emergency response, determinism, control state, or payload. The flag is a write to a telemetry-only local placed *after* the escalation transition and *immediately before* the existing `return`; it is never read by clinical logic. `answered_questions` / `extracted_answers` / `unresolved_question_ids` / compression untouched. Telemetry stays internal.

## Verification

- `tsc --noEmit`: clean
- `dog-brain-analytics` + `symptom-chat` suites: **651/651** (emergency/red-flag response tests included → behavior preserved)
- +4 new predicate truth-table tests
- thermo-review: **APPROVE**

Closes the last #713 deferred item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)