### PR TITLE
chore(security): clear Dependabot — bump transformers, reconcile stale alerts

### DIFF
--- a/services/async-review-service/requirements.txt
+++ b/services/async-review-service/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.116.1
 uvicorn[standard]==0.35.0
-transformers==4.50.0
+transformers==4.57.0
 torch==2.12.1
 torchvision==0.27.1
 accelerate==1.2.1

--- a/services/multimodal-consult-service/requirements.txt
+++ b/services/multimodal-consult-service/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.116.1
 uvicorn[standard]==0.35.0
-transformers==4.50.0
+transformers==4.57.0
 torch==2.12.1
 torchvision==0.27.1
 accelerate==1.2.1


### PR DESCRIPTION
Bumps `transformers` 4.50.0 → 4.57.0 in the async-review + multimodal-consult sidecars (the only manifests genuinely below a fixed version). All other open alerts are stale — master already pins patched versions (torch 2.12.1, python-multipart 0.0.32, npm lockfile undici 7.28.0 / ws 8.21.0; `npm audit`=0). Python sidecars only; no Vercel redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)