### PR TITLE
feat(symptom-checker): contextual Why-I'm-asking banner + report-failure visibility

### DIFF
--- a/src/app/(dashboard)/symptom-checker/page.tsx
+++ b/src/app/(dashboard)/symptom-checker/page.tsx
@@ -980,6 +980,23 @@ export default function SymptomCheckerPage() {
             ? data.persistence.message
             : null
         );
+      } else {
+        // The report did not come back (e.g. 409 not-ready, an upstream error, or
+        // a timeout). Surface it instead of silently doing nothing, and keep the
+        // "Generate Report" affordance visible so the owner can retry.
+        const notReady = res.status === 409 || data?.code === "SESSION_NOT_READY";
+        setMessages((prev) => [
+          ...prev,
+          {
+            role: "assistant",
+            content: notReady
+              ? "I need a moment more to pull this together. Please tap “Generate Report” to try again."
+              : "I couldn't finish generating the report just now. Please tap “Generate Report” to try again.",
+            type: "error",
+            timestamp: new Date(),
+          },
+        ]);
+        setReadyForReport(true);
       }
     } catch {
       setMessages((prev) => [

--- a/src/app/api/ai/symptom-chat/route.ts
+++ b/src/app/api/ai/symptom-chat/route.ts
@@ -171,6 +171,7 @@ import {
   emergencyTraceSuppressedEvent,
   shouldEmitEmergencyTraceSuppressed,
 } from "@/lib/dog-brain/analytics";
+import { composeWhyAsking } from "@/lib/symptom-chat/why-asking-explanation";
 import {
   isAsyncWorkerReplay,
   maybeOffloadSymptomChatTurn,
@@ -2515,6 +2516,14 @@ export async function POST(request: Request) {
         : null;
     // The surfaced question is Brain-memory-driven this turn (telemetry flag only).
     brainTraceWasEmitted = brainQuestionTrace !== null;
+    // Display-only: enrich the "Why I'm asking" banner into a contextual, chained
+    // explanation. Never changes question selection or any clinical control state.
+    const whyAsking = composeWhyAsking({
+      questionId: effectiveQuestionId,
+      baseReason: askingBecause,
+      session,
+      brainEvidenceSummary: brainQuestionTrace?.evidence_summary ?? null,
+    });
     const promptVetRecord = shouldPromptVetRecordUpload(
       session,
       effectiveQuestionId
@@ -2549,7 +2558,7 @@ export async function POST(request: Request) {
       forceDeterministicQuestionFallback: Boolean(textOnlyQuickStartExtraction),
       turnDeadline,
       turnDepth,
-      askingBecause,
+      askingBecause: whyAsking,
       brainQuestionTrace,
       promptVetRecord,
     });

--- a/src/lib/symptom-chat/why-asking-explanation.ts
+++ b/src/lib/symptom-chat/why-asking-explanation.ts
@@ -1,0 +1,125 @@
+import { getQuestionCardById } from "@/lib/clinical-intelligence/question-card-registry";
+import type { TriageSession } from "@/lib/triage-engine";
+
+// =============================================================================
+// "Why I'm asking" — contextual, DISPLAY-ONLY question rationale.
+//
+// Turns the static per-card `shortReason` into a logical, chained explanation
+// the owner can follow: what they reported → why THIS question now → what a
+// concerning answer would mean → how it links to their 1–90 day logged pattern.
+//
+// HARD SAFETY CONTRACT (must never be violated):
+//  - This is EXPLANATION ONLY. It never selects a question, changes urgency,
+//    red flags, or any clinical control state. It only enriches the owner-facing
+//    "Why I'm asking" banner text.
+//  - It composes ONLY from inputs that already exist: the owner's own reported
+//    symptoms, the curated question-card content (shortReason / changesUrgencyIf
+//    / phase), and the owner's own logged Brain evidence. It invents no new
+//    medical claims and never states a diagnosis.
+//  - Pure: no I/O, no model calls. Falls back to the base reason so it is never
+//    worse than today.
+// =============================================================================
+
+export interface WhyAskingInput {
+  /** The question actually being asked this turn. */
+  questionId: string | null;
+  /** The planner's curated short reason (clinical core); may be null. */
+  baseReason: string | null;
+  session: TriageSession;
+  /** The "Why this came up" Brain memory note, when this turn is log-driven. */
+  brainEvidenceSummary?: string | null;
+}
+
+const PHASE_CHAIN: Record<string, string> = {
+  emergency_screen: "as one of the first safety checks",
+  characterize: "to understand what you're seeing",
+  discriminate: "to narrow down the most likely cause",
+  timeline: "to see how this has changed over time",
+  history: "to factor in the background",
+  handoff_detail: "so your vet has the full picture",
+};
+
+const MAX_LEN = 360;
+
+function lowerFirst(s: string): string {
+  return s ? s.charAt(0).toLowerCase() + s.slice(1) : s;
+}
+
+function humanizeSymptom(key: string): string {
+  return key.replace(/[_-]+/g, " ").trim();
+}
+
+/** A short, owner-worded description of what they reported (max 2 symptoms). */
+function describeComplaint(session: TriageSession): string | null {
+  const symptoms = (session.known_symptoms ?? [])
+    .filter((s): s is string => typeof s === "string" && s.trim().length > 0)
+    .map(humanizeSymptom);
+  if (symptoms.length === 0) return null;
+  if (symptoms.length === 1) return symptoms[0];
+  return `${symptoms[0]} and ${symptoms[1]}`;
+}
+
+/** ["a"] → "a"; ["a","b"] → "a and b"; ["a","b","c"] → "a, b and c". */
+function joinAnd(parts: string[]): string {
+  if (parts.length <= 1) return parts[0] ?? "";
+  return `${parts.slice(0, -1).join(", ")} and ${parts[parts.length - 1]}`;
+}
+
+/**
+ * Compose the contextual "Why I'm asking" line. Returns the base reason
+ * unchanged when there is nothing to enrich (never a regression).
+ *
+ * Shape (≤3 tidy sentences): curated clinical purpose → one context sentence
+ * (reasoning chain + reported symptom + log tie-in) → what a concerning answer
+ * would mean. The log tie-in lives in the context sentence, not a trailing
+ * clause, so it is never lost to length trimming.
+ */
+export function composeWhyAsking(input: WhyAskingInput): string | null {
+  const { questionId, baseReason, session, brainEvidenceSummary } = input;
+  const card = questionId ? getQuestionCardById(questionId) : null;
+  const core = (baseReason ?? card?.shortReason ?? "").trim();
+
+  // Nothing curated to anchor on → keep prior behavior exactly.
+  if (!core) return baseReason ?? null;
+
+  const sentences: string[] = [core];
+
+  const complaint = describeComplaint(session);
+  const hasLog = Boolean(brainEvidenceSummary && brainEvidenceSummary.trim());
+  const chain = card ? PHASE_CHAIN[card.phase] : null;
+  const answeredCount = (session.answered_questions ?? []).length;
+
+  if (chain) {
+    // Card-backed: place this question in the reasoning chain + owner context.
+    const context: string[] = [];
+    if (complaint) context.push(`you mentioned ${complaint}`);
+    if (hasLog) context.push("your recent logs show a related pattern");
+    const lead =
+      answeredCount > 0 ? "After your earlier answers, I'm checking this" : "I'm checking this";
+    const tail = context.length > 0 ? ` — ${joinAnd(context)}` : "";
+    sentences.push(`${lead} ${chain}${tail}.`);
+  } else if (complaint || hasLog) {
+    // No card metadata: anchor to the owner's own context only (no fabricated chain).
+    const bits: string[] = [];
+    if (complaint) bits.push(`you told me about ${complaint}`);
+    if (hasLog) bits.push("your recent logs show a related pattern");
+    sentences.push(`I'm checking this because ${joinAnd(bits)}.`);
+  }
+
+  // What a concerning answer would mean — only from curated escalation data.
+  const escalation = card?.changesUrgencyIf?.yes;
+  if (escalation && /escalat|emergency|urgent/i.test(escalation)) {
+    sentences.push(
+      "A concerning answer here would mean urgent care, so it's worth ruling out now.",
+    );
+  }
+
+  let composed = sentences.join(" ").replace(/\s+/g, " ").trim();
+  if (composed.length > MAX_LEN) {
+    // Trim to the last full sentence under the cap so the banner stays tidy.
+    const clipped = composed.slice(0, MAX_LEN);
+    const lastStop = clipped.lastIndexOf(". ");
+    composed = lastStop > 0 ? clipped.slice(0, lastStop + 1) : clipped;
+  }
+  return composed || baseReason || null;
+}

--- a/tests/why-asking-explanation.test.ts
+++ b/tests/why-asking-explanation.test.ts
@@ -1,0 +1,85 @@
+/**
+ * "Why I'm asking" contextual rationale — display-only enrichment.
+ *
+ * Proves the banner becomes a logical, chained explanation (complaint → purpose
+ * → reasoning chain → escalation → log pattern) and that it NEVER regresses:
+ * with nothing curated to anchor on it returns the base reason unchanged.
+ */
+import {
+  addSymptoms,
+  createSession,
+  recordAnswer,
+  type TriageSession,
+} from "@/lib/triage-engine";
+import { composeWhyAsking } from "@/lib/symptom-chat/why-asking-explanation";
+
+const GUM_CARD_REASON =
+  "Changes in gum color can signal poor circulation or oxygenation and may indicate a serious underlying issue.";
+
+function vomitingSession(): TriageSession {
+  let s = createSession();
+  s = addSymptoms(s, ["vomiting"]);
+  // one earlier answer so the "after your earlier answers" chain applies
+  s = recordAnswer(s, "emergency_global_screen", false);
+  return s;
+}
+
+describe("composeWhyAsking — contextual, chained, log-aware", () => {
+  it("links the reported symptom, the clinical purpose, the chain, escalation, and logs", () => {
+    const out = composeWhyAsking({
+      questionId: "gum_color_check",
+      baseReason: GUM_CARD_REASON,
+      session: vomitingSession(),
+      brainEvidenceSummary: "Vomiting was reported 2 times across the latest 3 logged days.",
+    });
+    expect(out).toBeTruthy();
+    const text = (out ?? "").toLowerCase();
+    expect(text).toContain("vomiting"); // the owner's reported complaint
+    expect(text).toContain("gum color"); // the curated clinical purpose (core)
+    expect(text).toContain("after your earlier answers"); // reasoning chain
+    expect(text).toContain("urgent"); // escalation, from curated changesUrgencyIf
+    expect(text).toContain("recent logs"); // 1–90 day pattern tie-in
+  });
+
+  it("omits the log tie-in when there is no Brain evidence", () => {
+    const out = composeWhyAsking({
+      questionId: "gum_color_check",
+      baseReason: GUM_CARD_REASON,
+      session: vomitingSession(),
+      brainEvidenceSummary: null,
+    });
+    expect((out ?? "").toLowerCase()).not.toContain("recent logs");
+    expect(out).toContain("gum color"); // still contextual
+  });
+
+  it("never regresses: no card and no base reason → null (no banner)", () => {
+    expect(
+      composeWhyAsking({
+        questionId: "no_such_card_id",
+        baseReason: null,
+        session: vomitingSession(),
+      }),
+    ).toBeNull();
+  });
+
+  it("falls back to the base reason text when the question has no card", () => {
+    const out = composeWhyAsking({
+      questionId: "no_such_card_id",
+      baseReason: "Some specific clinical reason.",
+      session: vomitingSession(),
+    });
+    expect(out).toContain("Some specific clinical reason.");
+    // no card ⇒ no curated chain/escalation phrasing
+    expect((out ?? "").toLowerCase()).not.toContain("after your earlier answers");
+  });
+
+  it("stays within a tidy banner length", () => {
+    const out = composeWhyAsking({
+      questionId: "gum_color_check",
+      baseReason: GUM_CARD_REASON,
+      session: vomitingSession(),
+      brainEvidenceSummary: "Vomiting was reported 2 times across the latest 3 logged days.",
+    });
+    expect((out ?? "").length).toBeLessThanOrEqual(360);
+  });
+});


### PR DESCRIPTION
Two user-facing symptom-checker improvements.

## 1. Contextual "Why I'm asking" banner (commit 8ece68d)
Replaces the static per-card `shortReason` with a logical, chained explanation: curated clinical purpose → one context sentence (reasoning chain from the card phase + the owner's reported symptom + their 1–90 day logged pattern) → what a concerning answer would mean. New pure module `src/lib/symptom-chat/why-asking-explanation.ts` (`composeWhyAsking`).

**DISPLAY-ONLY**: wired in `symptom-chat/route.ts` by swapping the `askingBecause` value passed to `buildQuestionResponseFlow`. Never changes question selection, urgency, red flags, or control state. Composes only from existing data (no new medical claims). Falls back to the base reason → no regression. Tests 5/5, thermo-review APPROVE.

## 2. Report-generation failure visibility (commit 305da9b)
`generateReport` only surfaced errors in its `catch`; a non-report response (409 SESSION_NOT_READY, upstream error, or timeout) rendered nothing — no report, no error, no retry. Now any failed generation shows a clear retry message and keeps the Generate Report button. Page-only.

Note: the underlying generation failure (suspected Vercel 60s report-LLM timeout) still needs live-log confirmation; this makes it visible/recoverable.

## Verification
tsc clean; why-asking-explanation 5/5; symptom-chat suites green; thermo-review APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)