### PR TITLE
fix(symptom-checker): generate_report honors isReadyForDiagnosis (no false 409)

### DIFF
--- a/src/app/api/ai/symptom-chat/route.ts
+++ b/src/app/api/ai/symptom-chat/route.ts
@@ -13,7 +13,6 @@ import {
   getMissingQuestions,
   getQuestionText,
   getExtractionSchema,
-  hasMinimumDiagnosticInfo,
   isReadyForDiagnosis,
   buildDiagnosisContext,
   type TriageSession,
@@ -172,6 +171,7 @@ import {
   shouldEmitEmergencyTraceSuppressed,
 } from "@/lib/dog-brain/analytics";
 import { composeWhyAsking } from "@/lib/symptom-chat/why-asking-explanation";
+import { isReportReadinessBlocked } from "@/lib/symptom-chat/report-readiness";
 import {
   isAsyncWorkerReplay,
   maybeOffloadSymptomChatTurn,
@@ -1047,7 +1047,12 @@ export async function POST(request: Request) {
         });
       }
 
-      if (!hasMinimumDiagnosticInfo(session)) {
+      // 409 ONLY when neither readiness gate is satisfied. Honoring
+      // isReadyForDiagnosis (inside isReportReadinessBlocked) prevents the
+      // contradiction where the chat promised "preparing your report" but the
+      // generate path then refused. Emergency-grade criticals are still blocked
+      // above by findReportBlockingCriticalInfo. See report-readiness.ts.
+      if (isReportReadinessBlocked(session)) {
         statusCode = 409;
         return NextResponse.json(
           {

--- a/src/lib/symptom-chat/report-readiness.ts
+++ b/src/lib/symptom-chat/report-readiness.ts
@@ -1,0 +1,30 @@
+import {
+  hasMinimumDiagnosticInfo,
+  isReadyForDiagnosis,
+  type TriageSession,
+} from "@/lib/triage-engine";
+
+/**
+ * Should `generate_report` reject this session with 409 SESSION_NOT_READY?
+ *
+ * Blocks ONLY when NEITHER readiness gate is satisfied:
+ *  - `hasMinimumDiagnosticInfo` — the permissive "owner asked for a report and we
+ *    have the minimum critical info" gate, and
+ *  - `isReadyForDiagnosis` — the engine's own "I have concluded, here is the
+ *    report" gate (which also fires at the question ceiling).
+ *
+ * Honoring `isReadyForDiagnosis` removes the contradiction that produced the
+ * real-world 409s: the chat would declare "I have enough information — preparing
+ * your report" (isReadyForDiagnosis true, e.g. at the question ceiling with a
+ * critical the owner couldn't resolve), but `generate_report` then refused
+ * because `hasMinimumDiagnosticInfo` was false — so the report never generated.
+ *
+ * Safety: this never releases a dangerously premature report. Emergency-grade
+ * critical questions are blocked UPSTREAM by `findReportBlockingCriticalInfo`
+ * (which returns a terminal cannot-assess report before this gate is reached).
+ * The ceiling case therefore yields, at worst, a "slightly less rich" report —
+ * exactly what `isReadyForDiagnosis` was designed to conclude. Pure; no I/O.
+ */
+export function isReportReadinessBlocked(session: TriageSession): boolean {
+  return !hasMinimumDiagnosticInfo(session) && !isReadyForDiagnosis(session);
+}

--- a/tests/report-readiness.test.ts
+++ b/tests/report-readiness.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Report-readiness gate — regression for the 409 SESSION_NOT_READY contradiction.
+ *
+ * Real-world bug (confirmed via Vercel logs): the chat declared "I have enough
+ * information — preparing your report" (isReadyForDiagnosis true, at the question
+ * ceiling with a critical the owner could not resolve), but generate_report
+ * refused with 409 because hasMinimumDiagnosticInfo was false → the report never
+ * generated. The gate now blocks ONLY when NEITHER readiness signal holds.
+ */
+import {
+  addSymptoms,
+  createSession,
+  hasMinimumDiagnosticInfo,
+  isReadyForDiagnosis,
+  type TriageSession,
+} from "@/lib/triage-engine";
+import { isReportReadinessBlocked } from "@/lib/symptom-chat/report-readiness";
+
+/** A session driven to the question ceiling with the real critical follow-ups
+ *  still unanswered (filler ids stand in for the off-path / repeat-loop turns). */
+function ceilingSession(): TriageSession {
+  let s = createSession();
+  s = addSymptoms(s, ["vomiting"]);
+  return {
+    ...s,
+    red_flags_triggered: [],
+    answered_questions: Array.from({ length: 12 }, (_, i) => `filler_q_${i}`),
+  };
+}
+
+function prematureSession(): TriageSession {
+  let s = createSession();
+  s = addSymptoms(s, ["vomiting"]);
+  return { ...s, red_flags_triggered: [], answered_questions: [] };
+}
+
+describe("isReportReadinessBlocked — honors the chat's readiness promise", () => {
+  it("does NOT block a ceiling-ready session even if hasMinimumDiagnosticInfo is false", () => {
+    const s = ceilingSession();
+    // Precondition: the exact contradiction that produced the production 409s.
+    expect(isReadyForDiagnosis(s)).toBe(true);
+    expect(hasMinimumDiagnosticInfo(s)).toBe(false);
+    // Fixed behavior: the report is allowed to generate (no 409).
+    expect(isReportReadinessBlocked(s)).toBe(false);
+  });
+
+  it("still blocks a genuinely premature session (both gates fail → 409)", () => {
+    const s = prematureSession();
+    expect(isReadyForDiagnosis(s)).toBe(false);
+    expect(hasMinimumDiagnosticInfo(s)).toBe(false);
+    expect(isReportReadinessBlocked(s)).toBe(true);
+  });
+
+  it("does not block when the permissive gate is satisfied (red flags present)", () => {
+    let s = createSession();
+    s = addSymptoms(s, ["vomiting"]);
+    s = { ...s, red_flags_triggered: ["vomit_blood"] };
+    expect(hasMinimumDiagnosticInfo(s)).toBe(true);
+    expect(isReportReadinessBlocked(s)).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes the confirmed prod bug where the veterinary report never generated. Vercel logs showed POST /api/ai/symptom-chat **409 SESSION_NOT_READY** at the exact screenshot timestamps (14:51 UTC = 10:51 EDT): the chat said "preparing your report" (isReadyForDiagnosis true at the question ceiling) but generate_report refused (hasMinimumDiagnosticInfo false, unresolved critical).

**Change:** the 409 gate is now `isReportReadinessBlocked = !hasMinimumDiagnosticInfo && !isReadyForDiagnosis` (a pure, named, tested helper). generate_report 409s only when NEITHER readiness gate holds.

**Safety:** emergency-grade criticals are blocked upstream by `findReportBlockingCriticalInfo` (terminal cannot-assess) before this gate — clinical-reviewer **SAFE**, independently verified. Ceiling case → at worst a slightly-less-rich report, never one missing an emergency answer. No urgency/red-flag/question-selection change.

**Verification:** tsc clean; report-readiness 3/3; symptom-chat 627/627; thermo **APPROVE** + clinical-reviewer **SAFE**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)