### PR TITLE
chore(launch-hardening): redact secrets in error logs + guard emergency-grade list

### DIFF
--- a/src/app/api/ai/symptom-chat/route.ts
+++ b/src/app/api/ai/symptom-chat/route.ts
@@ -172,6 +172,7 @@ import {
 } from "@/lib/dog-brain/analytics";
 import { composeWhyAsking } from "@/lib/symptom-chat/why-asking-explanation";
 import { isReportReadinessBlocked } from "@/lib/symptom-chat/report-readiness";
+import { redactSecrets } from "@/lib/redact-secrets";
 import {
   isAsyncWorkerReplay,
   maybeOffloadSymptomChatTurn,
@@ -2569,7 +2570,10 @@ export async function POST(request: Request) {
     });
   } catch (error) {
     errorCode = "symptom_chat_unhandled";
-    console.error("Symptom chat error:", error);
+    // Redact before logging — a thrown error's message can incidentally embed a
+    // session/JWT (observed once on an old deploy). redactSecrets keeps the
+    // stack but masks token-shaped values so they never reach runtime logs.
+    console.error("Symptom chat error:", redactSecrets(error));
     return NextResponse.json(
       {
         type: "error",

--- a/src/lib/redact-secrets.ts
+++ b/src/lib/redact-secrets.ts
@@ -1,0 +1,44 @@
+// =============================================================================
+// Secret redaction for logs.
+//
+// Defensive: error messages can incidentally embed sensitive values (e.g. a
+// thrown TypeError whose message includes a stringified Supabase session /
+// JWT). This redacts token-shaped substrings before anything is logged, so a
+// future error can never leak a session token into runtime logs — independent
+// of whatever bug produced the error.
+// =============================================================================
+
+// A JWT: three base64url segments separated by dots, starting with the standard
+// `eyJ` header. Matches access tokens, refresh-bearing session blobs, etc.
+const JWT_PATTERN = /eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/g;
+// `Bearer <token>` headers.
+const BEARER_PATTERN = /\b[Bb]earer\s+[A-Za-z0-9._-]{12,}/g;
+// Long opaque key/secret values surfaced in `key=value` / `"key":"value"` form.
+const SECRET_KV_PATTERN =
+  /("?(?:access_token|refresh_token|api[_-]?key|authorization|password|secret)"?\s*[:=]\s*"?)([A-Za-z0-9._-]{8,})("?)/gi;
+
+/**
+ * Return a log-safe string for `value`, masking JWTs, bearer tokens, and common
+ * secret key/value pairs. Errors keep their stack/message (redacted) so logs
+ * stay useful. Pure; never throws.
+ */
+export function redactSecrets(value: unknown): string {
+  let text: string;
+  try {
+    if (value instanceof Error) {
+      text = value.stack ?? `${value.name}: ${value.message}`;
+    } else if (typeof value === "string") {
+      text = value;
+    } else {
+      text = JSON.stringify(value);
+    }
+  } catch {
+    text = String(value);
+  }
+  if (typeof text !== "string") return "[unloggable]";
+
+  return text
+    .replace(JWT_PATTERN, "[REDACTED_JWT]")
+    .replace(BEARER_PATTERN, "Bearer [REDACTED]")
+    .replace(SECRET_KV_PATTERN, "$1[REDACTED]$3");
+}

--- a/tests/emergency-grade-critical-questions.test.ts
+++ b/tests/emergency-grade-critical-questions.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Drift guard for the emergency-grade critical question set.
+ *
+ * The report-readiness relaxation (isReportReadinessBlocked) is clinically safe
+ * ONLY because emergency-grade criticals are intercepted upstream by
+ * findReportBlockingCriticalInfo, which keys off EMERGENCY_GRADE_CRITICAL_QUESTIONS.
+ * If an id in that list is renamed, removed, or quietly flipped to non-critical
+ * in FOLLOW_UP_QUESTIONS, that safety floor would break silently. This locks the
+ * list to real, critical follow-up questions so the two can't drift apart.
+ */
+import {
+  EMERGENCY_GRADE_CRITICAL_QUESTIONS,
+  isEmergencyGradeCriticalQuestionId,
+} from "@/lib/clinical/emergency-grade-critical-questions";
+import { FOLLOW_UP_QUESTIONS } from "@/lib/clinical/follow-up-questions";
+
+describe("EMERGENCY_GRADE_CRITICAL_QUESTIONS — drift guard", () => {
+  it("is non-empty and has no duplicates", () => {
+    expect(EMERGENCY_GRADE_CRITICAL_QUESTIONS.length).toBeGreaterThan(0);
+    const unique = new Set<string>(EMERGENCY_GRADE_CRITICAL_QUESTIONS);
+    expect(unique.size).toBe(EMERGENCY_GRADE_CRITICAL_QUESTIONS.length);
+  });
+
+  it("every emergency-grade id is a real follow-up question still tagged critical", () => {
+    const offenders = EMERGENCY_GRADE_CRITICAL_QUESTIONS.filter((id) => {
+      const q = FOLLOW_UP_QUESTIONS[id];
+      // Catches a renamed/removed id OR one silently flipped to critical: false.
+      return !q || q.critical !== true;
+    });
+    expect(offenders).toEqual([]);
+  });
+
+  it("the type guard recognizes members and rejects non-members", () => {
+    for (const id of EMERGENCY_GRADE_CRITICAL_QUESTIONS) {
+      expect(isEmergencyGradeCriticalQuestionId(id)).toBe(true);
+    }
+    expect(isEmergencyGradeCriticalQuestionId("additional_context")).toBe(false);
+    expect(isEmergencyGradeCriticalQuestionId("not_a_real_question")).toBe(false);
+  });
+});

--- a/tests/redact-secrets.test.ts
+++ b/tests/redact-secrets.test.ts
@@ -1,0 +1,43 @@
+/**
+ * redactSecrets — log-safety. A thrown error once leaked a full Supabase session
+ * JWT into runtime logs; this proves token-shaped values are masked before any
+ * log call, while normal diagnostic text is preserved.
+ */
+import { redactSecrets } from "@/lib/redact-secrets";
+
+const FAKE_JWT =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTYiLCJ1c2VyIjoieCJ9.s5dPq3Ab_C9-deadbeefdeadbeef";
+
+describe("redactSecrets", () => {
+  it("masks a JWT embedded in an error message", () => {
+    const err = new TypeError(
+      `Cannot create property 'user' on string '${FAKE_JWT}'`,
+    );
+    const out = redactSecrets(err);
+    expect(out).not.toContain(FAKE_JWT);
+    expect(out).toContain("[REDACTED_JWT]");
+    // Stack/message context is preserved (still useful for debugging).
+    expect(out.toLowerCase()).toContain("cannot create property");
+  });
+
+  it("masks bearer tokens and secret key/value pairs", () => {
+    expect(redactSecrets("Authorization: Bearer abcdef0123456789xyz")).toContain(
+      "Bearer [REDACTED]",
+    );
+    const kv = redactSecrets('{"access_token":"abcdef0123456789","note":"ok"}');
+    expect(kv).not.toContain("abcdef0123456789");
+    expect(kv).toContain("[REDACTED]");
+    expect(kv).toContain("ok"); // non-secret fields survive
+  });
+
+  it("leaves ordinary text untouched", () => {
+    const msg = "Symptom chat error: timeout after 60 seconds";
+    expect(redactSecrets(msg)).toBe(msg);
+  });
+
+  it("never throws on odd inputs", () => {
+    expect(() => redactSecrets(null)).not.toThrow();
+    expect(() => redactSecrets(undefined)).not.toThrow();
+    expect(() => redactSecrets({ a: 1 })).not.toThrow();
+  });
+});


### PR DESCRIPTION
Two safe launch-hardening items.

**#2 Security:** a thrown error once logged a full Supabase session JWT (old deploy). New pure util `redact-secrets.ts` masks JWT/bearer/secret-kv values; the symptom-chat catch now logs `redactSecrets(error)`. Logging-only, keeps the stack, ReDoS-safe regexes.

**#3 Hardening:** new drift-guard test locks `EMERGENCY_GRADE_CRITICAL_QUESTIONS` to real critical follow-ups so the report-readiness safety floor can't silently drift.

Verification: tsc clean; redact-secrets 4/4 + emergency-grade 3/3; symptom-chat 631/631; thermo **APPROVE**.

Note: the async report-path reliability item (mistral-nemotron aborts / 60s timeouts) is deliberately NOT in this PR — it's a larger, separately-verified change (the async result handler renders chat responses, not reports, and prod logs show no 202s, so it needs end-to-end verification before flipping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)