### PR TITLE
perf(symptom-checker): faster report model (deepseek-v3.2 primary, 253B fallback)

### DIFF
--- a/src/lib/model-router.ts
+++ b/src/lib/model-router.ts
@@ -35,9 +35,17 @@ export const MODELS = {
     fallback: "meta/llama-3.3-70b-instruct",
     role: "Question Verification" as const,
   },
+  // Report runs inside Vercel's 60s function cap (extraction THEN diagnosis).
+  // deepseek-v3.2 (fast MoE, ~37B active) is the report PRIMARY: the prior
+  // primary nemotron-ultra-253b is a dense REASONING model — slowest in the
+  // stack and a poor fit for a 60s-capped JSON report (thinking tokens add
+  // latency and risk JSON truncation; cf. the extraction note above). deepseek
+  // was already the proven diagnosis fallback and the diagnosis env priority
+  // already lists NVIDIA_DEEPSEEK_API_KEY first, so model+key are now aligned.
+  // The 253B model is retained as the fallback — no capability loss, reversible.
   diagnosis: {
-    name: "nvidia/llama-3.1-nemotron-ultra-253b-v1",
-    fallback: "deepseek-ai/deepseek-v3.2",
+    name: "deepseek-ai/deepseek-v3.2",
+    fallback: "nvidia/llama-3.1-nemotron-ultra-253b-v1",
     role: "Diagnosis Report" as const,
   },
   safety: {

--- a/src/lib/nvidia-models.ts
+++ b/src/lib/nvidia-models.ts
@@ -293,8 +293,10 @@ export async function reviewQuestionPlanWithNemotron(
 }
 
 /**
- * Generate clinical diagnosis report using Nemotron Ultra 253B.
- * Falls back to DeepSeek V3.2. Deep reasoning for differential diagnosis ranking.
+ * Generate the clinical diagnosis report using DeepSeek V3.2 (fast MoE primary),
+ * falling back to Nemotron Ultra 253B. Writes the owner-facing narrative from the
+ * deterministic matrix ranking — it does NOT decide urgency / red flags /
+ * differential order (those are floored deterministically; see report-pipeline).
  */
 export async function diagnoseWithDeepSeek(prompt: string): Promise<string> {
   return complete({

--- a/src/lib/symptom-chat/report-pipeline.ts
+++ b/src/lib/symptom-chat/report-pipeline.ts
@@ -1347,7 +1347,9 @@ export async function generateReport({
           clinicalCaseContext,
         });
         const rawReport = await diagnoseWithDeepSeek(reportPrompt);
-        console.log("[Engine] Diagnosis: Nemotron Ultra 253B");
+        console.log(
+          "[Engine] Diagnosis: DeepSeek V3.2 (primary) → Nemotron Ultra 253B (fallback)",
+        );
 
         const report = parseReportJSON(rawReport);
         if (

--- a/tests/model-router.test.ts
+++ b/tests/model-router.test.ts
@@ -48,8 +48,8 @@ describe("model-router registry", () => {
       timeoutMs: 45000,
     });
     expect(router.getModelRoute("diagnosis")).toMatchObject({
-      primaryModel: "nvidia/llama-3.1-nemotron-ultra-253b-v1",
-      fallbackModel: "deepseek-ai/deepseek-v3.2",
+      primaryModel: "deepseek-ai/deepseek-v3.2",
+      fallbackModel: "nvidia/llama-3.1-nemotron-ultra-253b-v1",
       timeoutMs: 150000,
     });
     expect(router.getModelRoute("vision_deep")).toMatchObject({


### PR DESCRIPTION
Cuts the >60s report-generation tail. The Diagnosis Report role used a **253B dense reasoning model** (`nvidia/llama-3.1-nemotron-ultra-253b-v1`) — slowest in the stack, poor fit for a 60s-capped JSON report. Swaps the **primary** to `deepseek-ai/deepseek-v3.2` (fast MoE, already the proven diagnosis fallback; diagnosis env priority already lists the deepseek key first). 253B retained as fallback — reversible.

**Safety (clinical-reviewer SAFE):** the report model only writes narrative from the deterministic matrix ranking; urgency/red-flags/differential-order are deterministic and the final-safety-verifier floors the model's urgency (`unsafe_downgrade` rejected). Prose-quality/latency change, not a clinical-decision change. No protected clinical logic touched. Also fixes 2 stale references mislabeling the primary.

**Verification:** tsc clean; model-router + report + symptom-chat 698/698; clinical-reviewer **SAFE**; thermo **APPROVE**. Latency win to be confirmed via post-deploy logs (60s-timeout rate should drop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)